### PR TITLE
Revert compiler flag variables in CMake config.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,9 +118,6 @@ include_directories(${YAML_CPP_SOURCE_DIR}/include)
 ###
 ### General compilation settings
 ###
-set(yaml_c_flags ${CMAKE_C_FLAGS})
-set(yaml_cxx_flags ${CMAKE_CXX_FLAGS})
-
 if(BUILD_SHARED_LIBS)
 	set(LABEL_SUFFIX "shared")
 else()
@@ -179,7 +176,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
 		set(GCC_EXTRA_OPTIONS "${GCC_EXTRA_OPTIONS} ${FLAG_TESTED}")
 	endif()
 	#
-	set(yaml_cxx_flags "-Wall ${GCC_EXTRA_OPTIONS} -pedantic -Wno-long-long -std=c++11 ${yaml_cxx_flags}")
+	set(yaml_cxx_flags "-Wall ${GCC_EXTRA_OPTIONS} -pedantic -Wno-long-long -std=c++11")
 
 	### Make specific
 	if(${CMAKE_BUILD_TOOL} MATCHES make OR ${CMAKE_BUILD_TOOL} MATCHES gmake)
@@ -217,7 +214,7 @@ if(MSVC)
 		endif()
 
 		# correct linker options
-		foreach(flag_var  yaml_c_flags  yaml_cxx_flags)
+		foreach(flag_var  CMAKE_C_FLAGS  CMAKE_CXX_FLAGS)
 			foreach(config_name  ""  DEBUG  RELEASE  MINSIZEREL  RELWITHDEBINFO)
 				set(var_name "${flag_var}")
 				if(NOT "${config_name}" STREQUAL "")
@@ -243,7 +240,7 @@ if(MSVC)
 	# /W3 = set warning level; see http://msdn.microsoft.com/en-us/library/thxezb7y.aspx
 	# /wd4127 = disable warning C4127 "conditional expression is constant"; see http://msdn.microsoft.com/en-us/library/6t66728h.aspx
 	# /wd4355 = disable warning C4355 "'this' : used in base member initializer list"; http://msdn.microsoft.com/en-us/library/3c594ae3.aspx
-	set(yaml_cxx_flags "/W3 /wd4127 /wd4355 ${yaml_cxx_flags}")
+	set(CMAKE_CXX_FLAGS "/W3 /wd4127 /wd4355 ${CMAKE_CXX_FLAGS}")
 endif()
 
 
@@ -273,7 +270,7 @@ set(_INSTALL_DESTINATIONS
 ###
 add_library(yaml-cpp ${library_sources})
 set_target_properties(yaml-cpp PROPERTIES
-  COMPILE_FLAGS "${yaml_c_flags} ${yaml_cxx_flags}"
+  COMPILE_FLAGS "${yaml_cxx_flags}"
 )
 
 set_target_properties(yaml-cpp PROPERTIES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,7 +27,7 @@ add_executable(run-tests
 	${test_headers}
 )
 set_target_properties(run-tests PROPERTIES
-  COMPILE_FLAGS "${yaml_c_flags} ${yaml_cxx_flags} ${yaml_test_flags}"
+  COMPILE_FLAGS "${yaml_test_flags}"
 )
 target_link_libraries(run-tests yaml-cpp gmock)
 


### PR DESCRIPTION
This is a partial revert of d59586630e9444f04ee12577e3e5977e93fc9b86, which breaks using CMake (3.2.1) to generate an MSVC project which uses the static runtime. This is due to the introduction of the `yaml_c_flags` and `yaml_cxx_flags` variables.

The main issue is that [this foreach](https://github.com/WrinklyNinja/yaml-cpp/blob/d59586630e9444f04ee12577e3e5977e93fc9b86/CMakeLists.txt#L191-L199) is broken, as `yaml_c_flags` and `yaml_cxx_flags` never contain `/MD`, and their `_RELEASE`, `_DEBUG`, etc. variations are all initialised as empty strings, unlike their `CMAKE_` flags equivalents (which do initially contain `/MD`).

For example, some initial values:

```
CMAKE_CXX_FLAGS = "/DWIN32 /D_WINDOWS /W3 /GR /EHsc"
CMAKE_CXX_FLAGS_RELEASE = "/MD /O2 /Ob2 /D NDEBUG"
yaml_cxx_flags = "/DWIN32 /D_WINDOWS /W3 /GR /EHsc"
yaml_cxx_flags_RELEASE = ""
```

There's a secondary issue in that when you set the [target compile flags](https://github.com/WrinklyNinja/yaml-cpp/blob/d59586630e9444f04ee12577e3e5977e93fc9b86/CMakeLists.txt#L246-L248), you're setting flags that are _in addition_ to the existing flags (which are stored in the `CMAKE_` flag variables). As far as I can tell, that means the switch to the `yaml_` flag variables doesn't do anything other than break the foreach.

As such, I've reverted all the changes relating to the the `yaml_c_flags` and `yaml_cxx_flags` variables. I've tested it on MSVC with static and shared runtimes set, and both work. I haven't tested it on GCC or Clang, but if I've understood everything correctly, there should be no difference in effect.
