### PR TITLE
Add support for merge keys.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ os:
 compiler:
   - clang
   - gcc
+env:
+  - YAML_CPP_SUPPORT_MERGE_KEYS=ON
+  - YAML_CPP_SUPPORT_MERGE_KEYS=OFF
 before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
@@ -17,7 +20,7 @@ before_install:
 before_script:
   - mkdir build
   - cd build
-  - cmake ..
+  - cmake .. -DYAML_CPP_SUPPORT_MERGE_KEYS=$YAML_CPP_SUPPORT_MERGE_KEYS
 script:
   - make
   - test/run-tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ enable_testing()
 option(YAML_CPP_BUILD_TESTS "Enable testing" ON)
 option(YAML_CPP_BUILD_TOOLS "Enable parse tools" ON)
 option(YAML_CPP_BUILD_CONTRIB "Enable contrib stuff in library" ON)
+option(YAML_CPP_SUPPORT_MERGE_KEYS "Support YAML merge keys ('<<') in yaml-cpp's executable targets. Use '#define YAML_CPP_SUPPORT_MERGE_KEYS' instead when linking from another project." OFF)
 
 ## Build options
 # --> General
@@ -95,6 +96,10 @@ if(YAML_CPP_BUILD_CONTRIB)
 	file(GLOB contrib_private_headers "src/contrib/[a-zA-Z]*.h")
 else()
 	add_definitions(-DYAML_CPP_NO_CONTRIB)
+endif()
+
+if (YAML_CPP_SUPPORT_MERGE_KEYS)
+    add_definitions(-DYAML_CPP_SUPPORT_MERGE_KEYS)
 endif()
 
 set(library_sources

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -211,6 +211,24 @@ TEST(NodeTest, NestedMergeKeys) {
   ASSERT_FALSE(!node["a"]);
   EXPECT_EQ(1, node["a"].as<int>());
 }
+
+TEST(NodeTest, AnchorAndMergeKey) {
+  Node node = YAML::Load(R"(
+    a_root: &root_anchor
+      key1: value1
+      key2: value2
+    b_child:
+      <<: *root_anchor
+      key2: value2_override
+  )");
+
+  ASSERT_FALSE(!node["a_root"]);
+  ASSERT_FALSE(!node["b_child"]);
+  EXPECT_EQ("value1", node["a_root"]["key1"].as<std::string>());
+  EXPECT_EQ("value2", node["a_root"]["key2"].as<std::string>());
+  EXPECT_EQ("value1", node["b_child"]["key1"].as<std::string>());
+  EXPECT_EQ("value2_override", node["b_child"]["key2"].as<std::string>());
+}
 #else
 TEST(NodeTest, MergeKeySupport) {
   Node node = Load("{<<: {a: 1}}");

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -185,6 +185,39 @@ TEST(LoadNodeTest, DereferenceIteratorError) {
   EXPECT_THROW(node.begin()->begin()->Type(), InvalidNode);
 }
 
+#ifdef YAML_CPP_SUPPORT_MERGE_KEYS
+TEST(NodeTest, MergeKeyScalarSupport) {
+  Node node = Load("{<<: {a: 1}}");
+  ASSERT_FALSE(!node["a"]);
+  EXPECT_EQ(1, node["a"].as<int>());
+}
+
+TEST(NodeTest, MergeKeyExistingKey) {
+  Node node = Load("{a: 1, <<: {a: 2}}");
+  ASSERT_FALSE(!node["a"]);
+  EXPECT_EQ(1, node["a"].as<int>());
+}
+
+TEST(NodeTest, MergeKeySequenceSupport) {
+  Node node = Load("<<: [{a: 1}, {a: 2, b: 3}]");
+  ASSERT_FALSE(!node["a"]);
+  ASSERT_FALSE(!node["b"]);
+  EXPECT_EQ(1, node["a"].as<int>());
+  EXPECT_EQ(3, node["b"].as<int>());
+}
+
+TEST(NodeTest, NestedMergeKeys) {
+  Node node = Load("{<<: {<<: {a: 1}}}");
+  ASSERT_FALSE(!node["a"]);
+  EXPECT_EQ(1, node["a"].as<int>());
+}
+#else
+TEST(NodeTest, MergeKeySupport) {
+  Node node = Load("{<<: {a: 1}}");
+  ASSERT_FALSE(node["a"]);
+}
+#endif
+
 TEST(NodeTest, EmitEmptyNode) {
   Node node;
   Emitter emitter;


### PR DESCRIPTION
This would close issue #41. While the merge key type isn't mentioned in the YAML 1.2 spec, there's a [spec](http://yaml.org/type/merge.html) for YAML 1.1, and I know I'm not alone in finding it a very useful feature.
