### PR TITLE
Update node_data::remove to use new equals() method

### DIFF
--- a/include/yaml-cpp/node/detail/impl.h
+++ b/include/yaml-cpp/node/detail/impl.h
@@ -133,7 +133,7 @@ inline bool node_data::remove(const Key& key, shared_memory_holder pMemory) {
     return false;
 
   for (node_map::iterator it = m_map.begin(); it != m_map.end(); ++it) {
-    if (equals(*it->first, key, pMemory)) {
+    if (it->first->equals(key, pMemory)) {
       m_map.erase(it);
       return true;
     }

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -39,6 +39,13 @@ TEST(NodeTest, SimpleAppendSequence) {
   EXPECT_TRUE(node.IsSequence());
 }
 
+TEST(NodeTest, MapElementRemoval) {
+  Node node;
+  node["foo"] = "bar";
+  node.remove("foo");
+  EXPECT_TRUE(!node["foo"]);
+}
+
 TEST(NodeTest, SimpleAssignSequence) {
   Node node;
   node[0] = 10;


### PR DESCRIPTION
- Update the call to equals() in node_data::remove() to match the new implementation
- Add unit test for node::remove() to catch this type of bug in the future