### PR TITLE
Adds CMake conditional to disable pthreads on MinGW builds of gtest.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,10 @@
 set(gtest_force_shared_crt ${MSVC_SHARED_RT} CACHE BOOL
   "Use shared (DLL) run-time lib even when Google Test built as a static lib.")
+
+if(MINGW)
+  set(gtest_disable_pthreads ON)
+endif()
+  
 add_subdirectory(gmock-1.7.0)
 include_directories(SYSTEM gmock-1.7.0/gtest/include)
 include_directories(SYSTEM gmock-1.7.0/include)


### PR DESCRIPTION
Disables gtest's use of pthreads on MinGW builds allowing `run-tests` to execute without fatal crashes.