### PR TITLE
Added template parameter to convert struct to be able to use std::enable_if.

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -23,7 +23,7 @@
 namespace YAML {
 class Binary;
 struct _Null;
-template <typename T>
+template <typename T, typename Enable>
 struct convert;
 }  // namespace YAML
 

--- a/include/yaml-cpp/node/node.h
+++ b/include/yaml-cpp/node/node.h
@@ -138,7 +138,7 @@ YAML_CPP_API bool operator==(const Node& lhs, const Node& rhs);
 
 YAML_CPP_API Node Clone(const Node& node);
 
-template <typename T>
+template <typename T, typename Enable = void>
 struct convert;
 }
 

--- a/test_app/main.cpp
+++ b/test_app/main.cpp
@@ -1,0 +1,86 @@
+// Compile with "g++ main.cpp -lyaml-cpp --std=c++14"
+#include <yaml-cpp/yaml.h>
+
+#include <iostream>
+#include <memory>
+#include <type_traits>
+
+// Base class
+class A
+{
+public:
+	A() : a(-1) {}
+	A(int a) : a(a) {}
+
+	// virtual load/emit methods
+	virtual void load(const YAML::Node &node)
+	{
+		a = node["a"].as<decltype(a)>();
+	}
+	virtual YAML::Node emit() const
+	{
+		YAML::Node node;
+		node["a"] = a;
+		return node;
+	}
+	int a;
+};
+
+// Derived class
+class B : public A
+{
+public:
+	B() : b(-1) {}
+	B(int a, int b) : A(a), b(b) {}
+
+	// override virtual load/emit methods
+	virtual void load(const YAML::Node &node) override
+	{
+		A::load(node);
+		b = node["b"].as<decltype(b)>();
+	}
+	virtual YAML::Node emit() const override
+	{
+		YAML::Node node = A::emit();
+		node["b"] = b;
+		return node;
+	}
+	int b;
+};
+
+// Implementation of convert::{encode,decode} for all classes derived from or being A
+namespace YAML {
+	template<typename T> struct convert<T, typename std::enable_if<std::is_base_of<A, T>::value>::type>
+	{
+		static Node encode(const T &rhs)
+		{
+			Node node = rhs.emit();
+			return node;
+		}
+		static bool decode(const Node &node, T &rhs)
+		{
+			try {
+				rhs.load(node);
+			} catch(...) {
+				return false;
+			}
+			return true;
+		}
+	};
+}
+
+int main(int argc, char **argv)
+{
+	{ // Polymorphic emit
+		std::unique_ptr<A> base_ptr = std::make_unique<B>(1, 2);
+		YAML::Node node;
+		node.push_back(*base_ptr);
+		std::cout << YAML::Dump(node) << std::endl;
+	}
+	{ // load
+		std::unique_ptr<B> derived_ptr = std::make_unique<B>(1, 2);
+		*derived_ptr = YAML::Load("a: 3\nb: 4").as<B>();
+		std::cout << "a: " << derived_ptr->a << " b: " << derived_ptr->b << std::endl;
+	}
+	return 0;
+}


### PR DESCRIPTION
I would like to use std::enable_if and std::is_base_of to write a convert struct that only converts classes derived from one base class.
Therefore I added a template parameter to the convert struct with a default value of void.
This compiles well with gcc (4.8.3 & 4.9.2) and passes all 871 tests.

I added a test application to show the usage of the additional template parameter.
This test is in test_app/main.cpp, because I have not writen tests yet and did not know where to put it in.
Maybe in test/integration/load_node_test.cpp ?
Please let me know if this is the right place and my proposed change is accaptable.
After that I will write a proper test and look at clang-format.

By the way in issue https://github.com/jbeder/yaml-cpp/issues/150 somebody wrote about inheritance in a math library, which would be solved by this change as I understand his problem.

Search for "3) I may have over generalized" in this issue, because I do not know how to link to particular comments in github.
