### PR TITLE
Don't throw exception in iterator or .as(fallback) on missing node

### DIFF
--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -282,26 +282,26 @@ inline std::size_t Node::size() const {
 
 inline const_iterator Node::begin() const {
   if (!m_isValid)
-    throw InvalidNode();
+    return const_iterator();
   return m_pNode ? const_iterator(m_pNode->begin(), m_pMemory)
                  : const_iterator();
 }
 
 inline iterator Node::begin() {
   if (!m_isValid)
-    throw InvalidNode();
+    return iterator();
   return m_pNode ? iterator(m_pNode->begin(), m_pMemory) : iterator();
 }
 
 inline const_iterator Node::end() const {
   if (!m_isValid)
-    throw InvalidNode();
+    return const_iterator();
   return m_pNode ? const_iterator(m_pNode->end(), m_pMemory) : const_iterator();
 }
 
 inline iterator Node::end() {
   if (!m_isValid)
-    throw InvalidNode();
+    return iterator();
   return m_pNode ? iterator(m_pNode->end(), m_pMemory) : iterator();
 }
 

--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -149,7 +149,7 @@ inline const T Node::as() const {
 template <typename T, typename S>
 inline const T Node::as(const S& fallback) const {
   if (!m_isValid)
-    throw InvalidNode();
+    return fallback;
   return as_if<T, S>(*this)(fallback);
 }
 


### PR DESCRIPTION
This appears to be a behaviour change caused by 1025f76df1b32b6ec3571ca928d7797a768a3341 - where a missing node is no longer considered 'valid'.
This is referenced in issue #305 - but also affects a number of other paths causing changes in behaviour.

I noticed this running OpenXcom (http://github.com/SupSuper/OpenXcom) which regularly uses .as(fallback) on optional nodes, expecting the fallback if it's missing (not an exception), and iterates over optional nodes (which it expects .begin() == .end() on such missing nodes).

There are likely other behaviour changes causing by this on missing nodes (I noticed that .size() would have returned 0 instead of throwing an exception, for example) but this change request does not fix that at this time.

I have been unable to find any documentation of what is expected in these cases, but these were working in 0.5.1 and broke in 0.5.2.