### PR TITLE
0.5.2 regressions

### DIFF
--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -149,7 +149,7 @@ inline const T Node::as() const {
 template <typename T, typename S>
 inline const T Node::as(const S& fallback) const {
   if (!m_isValid)
-    throw InvalidNode();
+    return fallback;
   return as_if<T, S>(*this)(fallback);
 }
 
@@ -282,26 +282,26 @@ inline std::size_t Node::size() const {
 
 inline const_iterator Node::begin() const {
   if (!m_isValid)
-    throw InvalidNode();
+    return const_iterator();
   return m_pNode ? const_iterator(m_pNode->begin(), m_pMemory)
                  : const_iterator();
 }
 
 inline iterator Node::begin() {
   if (!m_isValid)
-    throw InvalidNode();
+    return iterator();
   return m_pNode ? iterator(m_pNode->begin(), m_pMemory) : iterator();
 }
 
 inline const_iterator Node::end() const {
   if (!m_isValid)
-    throw InvalidNode();
+    return const_iterator();
   return m_pNode ? const_iterator(m_pNode->end(), m_pMemory) : const_iterator();
 }
 
 inline iterator Node::end() {
   if (!m_isValid)
-    throw InvalidNode();
+    return iterator();
   return m_pNode ? iterator(m_pNode->end(), m_pMemory) : iterator();
 }
 

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -80,6 +80,12 @@ TEST(NodeTest, MapWithUndefinedValues) {
   EXPECT_EQ(2, node.size());
 }
 
+TEST(NodeTest, UndefinedConstNodeWithFallback) {
+  Node node;
+  const Node& cn = node;
+  EXPECT_EQ(cn["undefined"].as<int>(3), 3);
+}
+
 TEST(NodeTest, MapIteratorWithUndefinedValues) {
   Node node;
   node["key"] = "value";
@@ -89,6 +95,32 @@ TEST(NodeTest, MapIteratorWithUndefinedValues) {
   for (const_iterator it = node.begin(); it != node.end(); ++it)
     count++;
   EXPECT_EQ(1, count);
+}
+
+TEST(NodeTest, ConstIteratorOnConstUndefinedNode) {
+  Node node;
+  const Node& cn = node;
+  const Node& undefinedCn = cn["undefined"];
+
+  std::size_t count = 0;
+  for (const_iterator it = undefinedCn.begin(); it != undefinedCn.end(); ++it) {
+    count++;
+ }
+  EXPECT_EQ(0, count);
+}
+
+TEST(NodeTest, IteratorOnConstUndefinedNode) {
+  Node node;
+  const Node& cn = node;
+  const Node& undefinedCn = cn["undefined"];
+
+  Node& nonConstUndefinedNode = const_cast<Node&>(undefinedCn);
+
+  std::size_t count = 0;
+  for (iterator it = nonConstUndefinedNode.begin(); it != nonConstUndefinedNode.end(); ++it) {
+    count++;
+  }
+  EXPECT_EQ(0, count);
 }
 
 TEST(NodeTest, SimpleSubkeys) {


### PR DESCRIPTION
Fixes at least three regressions from 0.5.1 -> 0.5.2 with tests - all introduced in 1025f76df1b32b6ec3571ca928d7797a768a3341 and relating to 'undefined' const Node& objects returned from a operator[] with no matching node.

- .as(fallback) returns the fallback value, 0.5.2 throws an exception (issue #305)
- const_iterator .begin()/.end() returned const_iterator() in 0.5.1 but throws an exception in 0.5.2
- iterator .begin()/.end() returned const_iterator() in 0.5.1 but throws an exception in 0.5.2

This should replace by previous pull request #315 