### PR TITLE
Removed boost requirement from memory.h (detail)

### DIFF
--- a/include/yaml-cpp/node/detail/memory.h
+++ b/include/yaml-cpp/node/detail/memory.h
@@ -7,8 +7,6 @@
 #pragma once
 #endif
 
-#include <boost/shared_ptr.hpp>
-#include <boost/smart_ptr/shared_ptr.hpp>
 #include <set>
 
 #include "yaml-cpp/dll.h"
@@ -40,7 +38,7 @@ class YAML_CPP_API memory_holder {
   void merge(memory_holder& rhs);
 
  private:
-  boost::shared_ptr<memory> m_pMemory;
+  shared_memory m_pMemory;
 };
 }
 }


### PR DESCRIPTION
Removed the boost requirement from memory.h using the shared_memory type defined in ptr.h