### PR TITLE
Allow using a Node as the key in force_insert.

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -43,6 +43,17 @@ inline bool IsNaN(const std::string& input) {
 }
 }
 
+// Node
+template <>
+struct convert<Node> {
+  static Node encode(const Node& rhs) { return rhs; }
+
+  static bool decode(const Node& node, Node& rhs) {
+    rhs.reset(node);
+    return true;
+  }
+};
+
 // std::string
 template <>
 struct convert<std::string> {

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -80,6 +80,25 @@ TEST(NodeTest, MapWithUndefinedValues) {
   EXPECT_EQ(2, node.size());
 }
 
+TEST(NodeTest, MapForceInsert) {
+  Node node;
+  Node k1("k1");
+  Node k2("k2");
+  Node v1("v1");
+  Node v2("v2");
+  node[k1] = v1;
+  node[k2] = v1;
+  EXPECT_TRUE(node.IsMap());
+  EXPECT_EQ("v1", node["k1"].as<std::string>());
+  EXPECT_EQ("v1", node["k2"].as<std::string>());
+  EXPECT_EQ(2, node.size());
+
+  node.force_insert(k2, v2);
+  EXPECT_EQ("v1", node["k1"].as<std::string>());
+  EXPECT_EQ("v2", node["k2"].as<std::string>());
+  EXPECT_EQ(2, node.size());
+}
+
 TEST(NodeTest, UndefinedConstNodeWithFallback) {
   Node node;
   const Node& cn = node;


### PR DESCRIPTION
Node::force_insert() uses convert<> to convert its key to a node.
Add a specialization for convert<Node>.