### PR TITLE
Fixed warining of C4819 under MSVC 14.0

### DIFF
--- a/test/gmock-1.7.0/src/gmock-matchers.cc
+++ b/test/gmock-1.7.0/src/gmock-matchers.cc
@@ -1,4 +1,4 @@
-// Copyright 2007, Google Inc.
+﻿// Copyright 2007, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
```
[ 53%] Building CXX object test/gmock-1.7.0/CMakeFiles/gmock.dir/gtest/src/gtest-all.cc.obj
gtest-all.cc
[ 55%] Building CXX object test/gmock-1.7.0/CMakeFiles/gmock.dir/src/gmock-all.cc.obj
gmock-all.cc
C:\cygwin64\home\karl\ports\jbeder\yaml\yaml\test\gmock-1.7.0\src/gmock-matchers.cc: error C2220: 警告被视为错误 - 没有生成“object”文件
C:\cygwin64\home\karl\ports\jbeder\yaml\yaml\test\gmock-1.7.0\src/gmock-matchers.cc: warning C4819: 该文件包含不能在当前代码页(936)中表示的字符。请将该文件保存为 Unicode 格式以防止数据丢失
NMAKE : fatal error U1077: “C:\PROGRA~2\MICROS~1.0\VC\bin\cl.exe”: 返回代码“0x2”
```
It seems both master and  version 0.5.2 have the problem of C2220 and C4819 under Visual Studio 2015.
And also, it is a boost problem as well. (Boost 1.5.9) (And you used a very strict standard)