### PR TITLE
Access yaml-cpp version from within a program.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+include/yaml-cpp/version.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,8 @@ include_directories(${YAML_CPP_SOURCE_DIR}/include)
 find_package(Boost REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
+# Create version.h
+configure_file(${header_directory}/version.h.in ${CMAKE_SOURCE_DIR}/${header_directory}/version.h)
 
 ###
 ### General compilation settings

--- a/include/yaml-cpp/version.h.in
+++ b/include/yaml-cpp/version.h.in
@@ -1,0 +1,17 @@
+#ifndef YAML_CPP_VERSION_H
+#define YAML_CPP_VERSION_H
+
+#if defined(_MSC_VER) ||                                            \
+    (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
+     (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
+#pragma once
+#endif
+
+#define YAML_CPP_VERSION_MAJOR ${YAML_CPP_VERSION_MAJOR}
+#define YAML_CPP_VERSION_MINOR ${YAML_CPP_VERSION_MINOR}
+#define YAML_CPP_VERSION_PATCH ${YAML_CPP_VERSION_PATCH}
+
+// String representation of the current version (ie. "0.1.2")
+#define YAML_CPP_VERSION "${YAML_CPP_VERSION}"
+
+#endif  // YAML_CPP_VERSION_H

--- a/test/version_test.cpp
+++ b/test/version_test.cpp
@@ -1,0 +1,27 @@
+#include "yaml-cpp/version.h"
+
+#include "gtest/gtest.h"
+
+namespace YAML {
+namespace {
+TEST(VersionTest, Major)
+{
+  ASSERT_EQ(YAML_CPP_VERSION_MAJOR, 0);
+}
+
+TEST(VersionTest, Minor)
+{
+  ASSERT_EQ(YAML_CPP_VERSION_MINOR, 5);
+}
+
+TEST(VersionTest, Path)
+{
+  ASSERT_EQ(YAML_CPP_VERSION_PATCH, 2);
+}
+
+TEST(VersionTest, String)
+{
+  ASSERT_STREQ(YAML_CPP_VERSION, "0.5.2");
+}
+}
+}


### PR DESCRIPTION
I have added the ability to get the yaml-cpp version via the new yaml-cpp/version.h header so that I can test that I am using the correct one (if travis gets out of sync with a dev computer for example). I have added tests for this.

I was unsure how you generated your include guards so I stuck with a hand-written one. Additionally I was unsure of whether version.h.in really lived inside include/yaml-cpp. I'm inclined to say that it isn't as that means that it will get installed along with the other headers. If you have any other suggestion I'll be happy to move it.

Cheers