### PR TITLE
Useless forward declaration

### DIFF
--- a/include/yaml-cpp/node/detail/iterator_fwd.h
+++ b/include/yaml-cpp/node/detail/iterator_fwd.h
@@ -13,7 +13,6 @@
 #include <vector>
 
 namespace YAML {
-class node;
 
 namespace detail {
 struct iterator_value;


### PR DESCRIPTION
It should be `YAML::Node` or `YAML::detail::node`. Because nobody noticed it, it should be deleted.