### PR TITLE
Removed quoted variables to avoid CMP0054 policy warnings on CMake 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,8 +148,8 @@ if(WIN32)
 endif()
 
 # GCC or Clang specialities
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-   "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
+   CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	### General stuff
 	if(WIN32)
 		set(CMAKE_SHARED_LIBRARY_PREFIX "")	# DLLs do not have a "lib" prefix

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,8 +8,8 @@ if(WIN32 AND BUILD_SHARED_LIBS)
   add_definitions("-DGTEST_LINKED_AS_SHARED_LIBRARY")
 endif()
 
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR
-   "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
+   CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(yaml_test_flags "-Wno-c99-extensions -Wno-variadic-macros -Wno-sign-compare -std=c++11")
 endif()
 


### PR DESCRIPTION
This is just a small change to silence warnings regarding cmake policy 54 on cmake 3.3.0.
I have verified that the change does not affect the build process when running cmake  2.8.12.2 as shipped with Ubuntu Linux LTS 14.04 and does what the conditional is expected to do.