### PR TITLE
Fix for setenv in Mingw32.

### DIFF
--- a/test/gmock-1.7.0/gtest/test/gtest_unittest.cc
+++ b/test/gmock-1.7.0/gtest/test/gtest_unittest.cc
@@ -447,7 +447,7 @@ class FormatEpochTimeInMillisAsIso8601Test : public Test {
     // tzset() distinguishes between the TZ variable being present and empty
     // and not being present, so we have to consider the case of time_zone
     // being NULL.
-#if _MSC_VER
+#if _MSC_VER || _WIN32
     // ...Unless it's MSVC, whose standard library's _putenv doesn't
     // distinguish between an empty and a missing variable.
     const std::string env_var =


### PR DESCRIPTION
# if _MSC_VER doesn't catch Mingw32 Builds.  added || _WIN32.
