### PR TITLE
Add missing include for minimalists

### DIFF
--- a/include/yaml-cpp/node/detail/node_iterator.h
+++ b/include/yaml-cpp/node/detail/node_iterator.h
@@ -9,6 +9,7 @@
 
 #include "yaml-cpp/dll.h"
 #include "yaml-cpp/node/ptr.h"
+#include "yaml-cpp/node/detail/node.h"
 #include <cstddef>
 #include <iterator>
 #include <memory>


### PR DESCRIPTION
This is one case:
```
#include <yaml-cpp/node/node.h>
#include <yaml-cpp/node/iterator.h>
for(const YAML::Node &b : a) {...}
```