### PR TITLE
Change node_map type from map<ptr,ptr> to list<pair<ptr,ptr>>.

### DIFF
--- a/include/yaml-cpp/node/detail/node_data.h
+++ b/include/yaml-cpp/node/detail/node_data.h
@@ -114,7 +114,7 @@ class YAML_CPP_API node_data {
   mutable std::size_t m_seqSize;
 
   // map
-  typedef std::map<node*, node*> node_map;
+  typedef std::list<std::pair<node*, node*>> node_map;
   node_map m_map;
 
   typedef std::pair<node*, node*> kv_pair;

--- a/include/yaml-cpp/node/detail/node_iterator.h
+++ b/include/yaml-cpp/node/detail/node_iterator.h
@@ -37,7 +37,7 @@ struct node_iterator_value : public std::pair<V*, V*> {
 };
 
 typedef std::vector<node*> node_seq;
-typedef std::map<node*, node*> node_map;
+typedef std::list<std::pair<node*, node*>> node_map;
 
 template <typename V>
 struct node_iterator_type {

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -256,9 +256,9 @@ void node_data::reset_map() {
 }
 
 void node_data::insert_map_pair(node& key, node& value) {
-  m_map[&key] = &value;
+  m_map.emplace_back(&key, &value);
   if (!key.is_defined() || !value.is_defined())
-    m_undefinedPairs.push_back(kv_pair(&key, &value));
+    m_undefinedPairs.emplace_back(&key, &value);
 }
 
 void node_data::convert_to_map(shared_memory_holder pMemory) {


### PR DESCRIPTION
This will prevent unpredictable reordering of documents after load and save.