### PR TITLE
Fix for broken build of test on cygwin using gcc - missing fileno/strdup/fdopen

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,13 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
    CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(yaml_test_flags "-Wno-c99-extensions -Wno-variadic-macros -Wno-sign-compare -std=c++11")
+  set(yaml_test_flags "-Wno-c99-extensions -Wno-variadic-macros -Wno-sign-compare")
+
+  if(CMAKE_COMPILER_IS_GNUCXX)
+    set(yaml_test_flags "${yaml_test_flags} -std=gnu++11")
+  else()
+    set(yaml_test_flags "${yaml_test_flags} -std=c++11")
+  endif()
 endif()
 
 file(GLOB test_headers [a-z_]*.h)


### PR DESCRIPTION
Fix for broken build on cygwin using gcc - "error '[fileno, strdup, fdopen]' are not in scope"

https://github.com/jbeder/yaml-cpp/issues/373