### PR TITLE
only add -std=c++11 for clang and gcc

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,14 +1,18 @@
 add_sources(parse.cpp)
 add_executable(parse parse.cpp)
 target_link_libraries(parse yaml-cpp)
-set_target_properties(parse PROPERTIES COMPILE_FLAGS "-std=c++11")
 
 add_sources(sandbox.cpp)
 add_executable(sandbox sandbox.cpp)
 target_link_libraries(sandbox yaml-cpp)
-set_target_properties(sandbox PROPERTIES COMPILE_FLAGS "-std=c++11")
 
 add_sources(read.cpp)
 add_executable(read read.cpp)
 target_link_libraries(read yaml-cpp)
-set_target_properties(read PROPERTIES COMPILE_FLAGS "-std=c++11")
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
+    CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set_target_properties(parse PROPERTIES COMPILE_FLAGS "-std=c++11")
+  set_target_properties(sandbox PROPERTIES COMPILE_FLAGS "-std=c++11")
+  set_target_properties(read PROPERTIES COMPILE_FLAGS "-std=c++11")
+endif()


### PR DESCRIPTION
Not sure if  I should have used yaml_cxx_flags instead, but the current code will add -std=c++11 to the MS compiler which does not know that flag.
