### PR TITLE
Fix some clang warnings

### DIFF
--- a/include/yaml-cpp/emitter.h
+++ b/include/yaml-cpp/emitter.h
@@ -162,12 +162,12 @@ inline Emitter& Emitter::WriteStreamable(T value) {
 
 template <>
 inline void Emitter::SetStreamablePrecision<float>(std::stringstream& stream) {
-  stream.precision(GetFloatPrecision());
+  stream.precision(static_cast<std::streamsize>(GetFloatPrecision()));
 }
 
 template <>
 inline void Emitter::SetStreamablePrecision<double>(std::stringstream& stream) {
-  stream.precision(GetDoublePrecision());
+  stream.precision(static_cast<std::streamsize>(GetDoublePrecision()));
 }
 
 // overloads of insertion

--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -112,7 +112,7 @@ class Exception : public std::runtime_error {
  public:
   Exception(const Mark& mark_, const std::string& msg_)
       : std::runtime_error(build_what(mark_, msg_)), mark(mark_), msg(msg_) {}
-  virtual ~Exception() throw() {}
+  virtual ~Exception() noexcept {}
 
   Mark mark;
   std::string msg;
@@ -163,7 +163,7 @@ class TypedKeyNotFound : public KeyNotFound {
  public:
   TypedKeyNotFound(const Mark& mark_, const T& key_)
       : KeyNotFound(mark_, key_), key(key_) {}
-  virtual ~TypedKeyNotFound() throw() {}
+  virtual ~TypedKeyNotFound() noexcept {}
 
   T key;
 };

--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -114,6 +114,8 @@ class Exception : public std::runtime_error {
       : std::runtime_error(build_what(mark_, msg_)), mark(mark_), msg(msg_) {}
   virtual ~Exception() noexcept {}
 
+  Exception(const Exception&) = default;
+
   Mark mark;
   std::string msg;
 

--- a/include/yaml-cpp/node/node.h
+++ b/include/yaml-cpp/node/node.h
@@ -58,7 +58,7 @@ class YAML_CPP_API Node {
   bool IsMap() const { return Type() == NodeType::Map; }
 
   // bool conversions
-  YAML_CPP_OPERATOR_BOOL();
+  YAML_CPP_OPERATOR_BOOL()
   bool operator!() const { return !IsDefined(); }
 
   // access


### PR DESCRIPTION
Those warnings appear when compiling a C++14 project that includes yaml-cpp/yaml.h