### PR TITLE
Change node_map type from map<ptr,ptr> to vector<pair<ptr,ptr>>

### DIFF
--- a/include/yaml-cpp/node/detail/node_data.h
+++ b/include/yaml-cpp/node/detail/node_data.h
@@ -114,7 +114,7 @@ class YAML_CPP_API node_data {
   mutable std::size_t m_seqSize;
 
   // map
-  typedef std::map<node*, node*> node_map;
+  typedef std::vector<std::pair<node*, node*>> node_map;
   node_map m_map;
 
   typedef std::pair<node*, node*> kv_pair;

--- a/include/yaml-cpp/node/detail/node_iterator.h
+++ b/include/yaml-cpp/node/detail/node_iterator.h
@@ -37,7 +37,7 @@ struct node_iterator_value : public std::pair<V*, V*> {
 };
 
 typedef std::vector<node*> node_seq;
-typedef std::map<node*, node*> node_map;
+typedef std::vector<std::pair<node*, node*>> node_map;
 
 template <typename V>
 struct node_iterator_type {

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -256,18 +256,7 @@ void node_data::reset_map() {
 }
 
 void node_data::insert_map_pair(node& key, node& value) {
-
-  bool found = false;
-  for (auto& entry : m_map) {
-    if (entry.first == &key) {
-      entry.second = &value;
-      found = true;
-      break;
-    }
-  }
-  if (!found) {
-    m_map.emplace_back(&key, &value);
-  }
+  m_map.emplace_back(&key, &value);
 
   if (!key.is_defined() || !value.is_defined())
     m_undefinedPairs.emplace_back(&key, &value);

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -256,9 +256,21 @@ void node_data::reset_map() {
 }
 
 void node_data::insert_map_pair(node& key, node& value) {
-  m_map[&key] = &value;
+
+  bool found = false;
+  for (auto& entry : m_map) {
+    if (entry.first == &key) {
+      entry.second = &value;
+      found = true;
+      break;
+    }
+  }
+  if (!found) {
+    m_map.emplace_back(&key, &value);
+  }
+
   if (!key.is_defined() || !value.is_defined())
-    m_undefinedPairs.push_back(kv_pair(&key, &value));
+    m_undefinedPairs.emplace_back(&key, &value);
 }
 
 void node_data::convert_to_map(shared_memory_holder pMemory) {

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -95,8 +95,8 @@ TEST(NodeTest, MapForceInsert) {
 
   node.force_insert(k2, v2);
   EXPECT_EQ("v1", node["k1"].as<std::string>());
-  EXPECT_EQ("v2", node["k2"].as<std::string>());
-  EXPECT_EQ(2, node.size());
+  EXPECT_EQ("v1", node["k2"].as<std::string>());
+  EXPECT_EQ(3, node.size());
 }
 
 TEST(NodeTest, UndefinedConstNodeWithFallback) {


### PR DESCRIPTION
Map nodes are now iterated over in document order.