### PR TITLE
Ignored *const* parameter in copy-constructor and -assignment

### DIFF
--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -42,6 +42,16 @@ inline Node::Node(const Node& rhs)
       m_pMemory(rhs.m_pMemory),
       m_pNode(rhs.m_pNode) {}
 
+inline Node::Node(Node&& rhs)
+    : m_isValid(rhs.m_isValid),
+      m_pMemory(rhs.m_pMemory),
+      m_pNode(rhs.m_pNode) {
+
+    rhs.m_pMemory.reset(new detail::memory_holder);
+    rhs.m_pNode = &rhs.m_pMemory->create_node();
+    rhs.m_pNode->set_null();
+}
+
 inline Node::Node(Zombie) : m_isValid(false), m_pNode(NULL) {}
 
 inline Node::Node(detail::node& node, detail::shared_memory_holder pMemory)
@@ -244,6 +254,20 @@ inline Node& Node::operator=(const Node& rhs) {
   if (is(rhs))
     return *this;
   AssignNode(rhs);
+  return *this;
+}
+
+inline Node& Node::operator=(Node&& rhs) {
+  if (!m_isValid || !rhs.m_isValid)
+    throw InvalidNode();
+  if (is(rhs))
+    return *this;
+  AssignNode(rhs);
+
+  rhs.m_pMemory.reset(new detail::memory_holder);
+  rhs.m_pNode = &rhs.m_pMemory->create_node();
+  rhs.m_pNode->set_null();
+
   return *this;
 }
 

--- a/include/yaml-cpp/node/node.h
+++ b/include/yaml-cpp/node/node.h
@@ -47,6 +47,8 @@ class YAML_CPP_API Node {
   explicit Node(const T& rhs);
   explicit Node(const detail::iterator_value& rhs);
   Node(const Node& rhs);
+  Node(Node&& rhs);
+
   ~Node();
 
   YAML::Mark Mark() const;
@@ -81,6 +83,7 @@ class YAML_CPP_API Node {
   template <typename T>
   Node& operator=(const T& rhs);
   Node& operator=(const Node& rhs);
+  Node& operator=(Node&& rhs);
   void reset(const Node& rhs = Node());
 
   // size/iterator

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -494,5 +494,56 @@ TEST_F(NodeEmitterTest, NestFlowMapListNode) {
 
   ExpectOutput("{position: [1.01, 2.01, 3.01]}", mapNode);
 }
+
+TEST(NodeTest, CopyConstructor) {
+  Node node = Node("Hello, World!");
+  Node copy(node);
+
+  node = Node("Bye, World!");
+
+  EXPECT_EQ("Hello, World!", copy.as<std::string>());
+  EXPECT_EQ("Bye, World!", node.as<std::string>());
+}
+
+TEST(NodeTest, CopyAssignment) {
+  Node node = Node("Hello, World!");
+  Node copy = Node("Nice to meet you!");
+
+  copy = node;
+
+  node = Node("Bye, World!");
+
+  EXPECT_EQ("Hello, World!", copy.as<std::string>());
+  EXPECT_EQ("Bye, World!", node.as<std::string>());
+}
+
+TEST(NodeTest, BrokenCopyAssignmentAndConstructorWithVectorInsert) {
+
+  std::vector<YAML::Node> nodes;
+
+  nodes.insert(nodes.begin(), Node("0"));
+  nodes.insert(nodes.begin(), Node("1"));
+  nodes.insert(nodes.begin(), Node("2"));
+  nodes.insert(nodes.begin(), Node("3"));
+
+  EXPECT_EQ("3", nodes[0].Scalar());
+  EXPECT_EQ("2", nodes[1].Scalar());
+  EXPECT_EQ("1", nodes[2].Scalar());
+  EXPECT_EQ("0", nodes[3].Scalar());
+}
+
+TEST(NodeTest, BrokenCopyAssignmentAndConstructorWithVectorInsert2) {
+
+  std::vector<YAML::Node> nodes;
+  nodes.reserve(3);
+  nodes.insert(nodes.begin(), Node("0"));
+  nodes.insert(nodes.begin(), Node("1"));
+  nodes.insert(nodes.begin(), Node("2"));
+
+  EXPECT_EQ("2", nodes[0].Scalar());
+  EXPECT_EQ("1", nodes[1].Scalar());
+  EXPECT_EQ("0", nodes[2].Scalar());
+}
+
 }
 }


### PR DESCRIPTION
I'm not sure if this can be fixed without major changes. Just posting the tests for now and still investigating. Maybe you have a suggestion how this can be resolved.
