### PR TITLE
add information about cmake's -DBOOST_ROOT parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ cmake [-G generator] [-DBUILD_SHARED_LIBS=ON|OFF] ..
 
   * yaml-cpp defaults to building a static library, but you may build a shared library by specifying `-DBUILD_SHARED_LIBS=ON`.
 
+  * You might also have to specify the path to Boost binaries using the -DBOOST_ROOT argument.
+  
   * For more options on customizing the build, see the [CMakeLists.txt](https://github.com/jbeder/yaml-cpp/blob/master/CMakeLists.txt) file.
 
 4. Build it!


### PR DESCRIPTION
I always have to look for this, so adding it to the readme might save some people some time.