### PR TITLE
Fix compiler warnings about truncations

### DIFF
--- a/src/emitterstate.cpp
+++ b/src/emitterstate.cpp
@@ -124,7 +124,7 @@ void EmitterState::StartedScalar() {
 void EmitterState::StartedGroup(GroupType::value type) {
   StartedNode();
 
-  const int lastGroupIndent = (m_groups.empty() ? 0 : m_groups.back()->indent);
+  const std::size_t lastGroupIndent = (m_groups.empty() ? 0 : m_groups.back()->indent);
   m_curIndent += lastGroupIndent;
 
   // TODO: Create move constructors for settings types to simplify transfer
@@ -193,7 +193,7 @@ FlowType::value EmitterState::CurGroupFlowType() const {
   return m_groups.empty() ? FlowType::NoType : m_groups.back()->flowType;
 }
 
-int EmitterState::CurGroupIndent() const {
+std::size_t EmitterState::CurGroupIndent() const {
   return m_groups.empty() ? 0 : m_groups.back()->indent;
 }
 
@@ -205,7 +205,7 @@ bool EmitterState::CurGroupLongKey() const {
   return m_groups.empty() ? false : m_groups.back()->longKey;
 }
 
-int EmitterState::LastIndent() const {
+std::size_t EmitterState::LastIndent() const {
   if (m_groups.size() <= 1) {
     return 0;
   }
@@ -347,14 +347,14 @@ bool EmitterState::SetMapKeyFormat(EMITTER_MANIP value, FmtScope::value scope) {
   }
 }
 
-bool EmitterState::SetFloatPrecision(int value, FmtScope::value scope) {
+bool EmitterState::SetFloatPrecision(std::size_t value, FmtScope::value scope) {
   if (value < 0 || value > std::numeric_limits<float>::digits10 + 1)
     return false;
   _Set(m_floatPrecision, value, scope);
   return true;
 }
 
-bool EmitterState::SetDoublePrecision(int value, FmtScope::value scope) {
+bool EmitterState::SetDoublePrecision(std::size_t value, FmtScope::value scope) {
   if (value < 0 || value > std::numeric_limits<double>::digits10 + 1)
     return false;
   _Set(m_doublePrecision, value, scope);

--- a/src/emitterstate.h
+++ b/src/emitterstate.h
@@ -58,12 +58,12 @@ class EmitterState {
 
   GroupType::value CurGroupType() const;
   FlowType::value CurGroupFlowType() const;
-  int CurGroupIndent() const;
+  std::size_t CurGroupIndent() const;
   std::size_t CurGroupChildCount() const;
   bool CurGroupLongKey() const;
 
-  int LastIndent() const;
-  int CurIndent() const { return m_curIndent; }
+  std::size_t LastIndent() const;
+  std::size_t CurIndent() const { return m_curIndent; }
   bool HasAnchor() const { return m_hasAnchor; }
   bool HasTag() const { return m_hasTag; }
   bool HasBegunNode() const {
@@ -95,12 +95,12 @@ class EmitterState {
   EMITTER_MANIP GetIntFormat() const { return m_intFmt.get(); }
 
   bool SetIndent(std::size_t value, FmtScope::value scope);
-  int GetIndent() const { return m_indent.get(); }
+  std::size_t GetIndent() const { return m_indent.get(); }
 
   bool SetPreCommentIndent(std::size_t value, FmtScope::value scope);
-  int GetPreCommentIndent() const { return m_preCommentIndent.get(); }
+  std::size_t GetPreCommentIndent() const { return m_preCommentIndent.get(); }
   bool SetPostCommentIndent(std::size_t value, FmtScope::value scope);
-  int GetPostCommentIndent() const { return m_postCommentIndent.get(); }
+  std::size_t GetPostCommentIndent() const { return m_postCommentIndent.get(); }
 
   bool SetFlowType(GroupType::value groupType, EMITTER_MANIP value,
                    FmtScope::value scope);
@@ -109,9 +109,9 @@ class EmitterState {
   bool SetMapKeyFormat(EMITTER_MANIP value, FmtScope::value scope);
   EMITTER_MANIP GetMapKeyFormat() const { return m_mapKeyFmt.get(); }
 
-  bool SetFloatPrecision(int value, FmtScope::value scope);
+  bool SetFloatPrecision(std::size_t value, FmtScope::value scope);
   std::size_t GetFloatPrecision() const { return m_floatPrecision.get(); }
-  bool SetDoublePrecision(int value, FmtScope::value scope);
+  bool SetDoublePrecision(std::size_t value, FmtScope::value scope);
   std::size_t GetDoublePrecision() const { return m_doublePrecision.get(); }
 
  private:
@@ -137,8 +137,8 @@ class EmitterState {
   Setting<EMITTER_MANIP> m_seqFmt;
   Setting<EMITTER_MANIP> m_mapFmt;
   Setting<EMITTER_MANIP> m_mapKeyFmt;
-  Setting<int> m_floatPrecision;
-  Setting<int> m_doublePrecision;
+  Setting<std::size_t> m_floatPrecision;
+  Setting<std::size_t> m_doublePrecision;
 
   SettingChanges m_modifiedSettings;
   SettingChanges m_globalModifiedSettings;
@@ -149,7 +149,7 @@ class EmitterState {
 
     GroupType::value type;
     FlowType::value flowType;
-    int indent;
+    std::size_t indent;
     std::size_t childCount;
     bool longKey;
 


### PR DESCRIPTION
Noticed a couple warnings about types being truncated while compiling my project that uses yaml-cpp. This should fix all that MSVC15 complains about.