### PR TITLE
Fixed compiler warning -Wdeprecated with clang.

### DIFF
--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -137,6 +137,7 @@ class ParserException : public Exception {
  public:
   ParserException(const Mark& mark_, const std::string& msg_)
       : Exception(mark_, msg_) {}
+  ParserException(const ParserException&) = default;
   virtual ~ParserException() noexcept;
 };
 
@@ -144,6 +145,7 @@ class RepresentationException : public Exception {
  public:
   RepresentationException(const Mark& mark_, const std::string& msg_)
       : Exception(mark_, msg_) {}
+  RepresentationException(const RepresentationException&) = default;
   virtual ~RepresentationException() noexcept;
 };
 
@@ -152,6 +154,7 @@ class InvalidScalar : public RepresentationException {
  public:
   InvalidScalar(const Mark& mark_)
       : RepresentationException(mark_, ErrorMsg::INVALID_SCALAR) {}
+  InvalidScalar(const InvalidScalar&) = default;
   virtual ~InvalidScalar() noexcept;
 };
 
@@ -161,6 +164,7 @@ class KeyNotFound : public RepresentationException {
   KeyNotFound(const Mark& mark_, const T& key_)
       : RepresentationException(mark_, ErrorMsg::KEY_NOT_FOUND_WITH_KEY(key_)) {
   }
+  KeyNotFound(const KeyNotFound&) = default;
   virtual ~KeyNotFound() noexcept;
 };
 
@@ -184,6 +188,7 @@ class InvalidNode : public RepresentationException {
  public:
   InvalidNode()
       : RepresentationException(Mark::null_mark(), ErrorMsg::INVALID_NODE) {}
+  InvalidNode(const InvalidNode&) = default;
   virtual ~InvalidNode() noexcept;
 };
 
@@ -191,6 +196,7 @@ class BadConversion : public RepresentationException {
  public:
   explicit BadConversion(const Mark& mark_)
       : RepresentationException(mark_, ErrorMsg::BAD_CONVERSION) {}
+  BadConversion(const BadConversion&) = default;
   virtual ~BadConversion() noexcept;
 };
 
@@ -204,6 +210,7 @@ class BadDereference : public RepresentationException {
  public:
   BadDereference()
       : RepresentationException(Mark::null_mark(), ErrorMsg::BAD_DEREFERENCE) {}
+  BadDereference(const BadDereference&) = default;
   virtual ~BadDereference() noexcept;
 };
 
@@ -211,6 +218,7 @@ class BadSubscript : public RepresentationException {
  public:
   BadSubscript()
       : RepresentationException(Mark::null_mark(), ErrorMsg::BAD_SUBSCRIPT) {}
+  BadSubscript(const BadSubscript&) = default;
   virtual ~BadSubscript() noexcept;
 };
 
@@ -218,6 +226,7 @@ class BadPushback : public RepresentationException {
  public:
   BadPushback()
       : RepresentationException(Mark::null_mark(), ErrorMsg::BAD_PUSHBACK) {}
+  BadPushback(const BadPushback&) = default;
   virtual ~BadPushback() noexcept;
 };
 
@@ -225,6 +234,7 @@ class BadInsert : public RepresentationException {
  public:
   BadInsert()
       : RepresentationException(Mark::null_mark(), ErrorMsg::BAD_INSERT) {}
+  BadInsert(const BadInsert&) = default;
   virtual ~BadInsert() noexcept;
 };
 
@@ -232,12 +242,14 @@ class EmitterException : public Exception {
  public:
   EmitterException(const std::string& msg_)
       : Exception(Mark::null_mark(), msg_) {}
+  EmitterException(const EmitterException&) = default;
   virtual ~EmitterException() noexcept;
 };
 
 class BadFile : public Exception {
  public:
   BadFile() : Exception(Mark::null_mark(), ErrorMsg::BAD_FILE) {}
+  BadFile(const BadFile&) = default;
   virtual ~BadFile() noexcept;
 };
 }

--- a/include/yaml-cpp/parser.h
+++ b/include/yaml-cpp/parser.h
@@ -47,7 +47,7 @@ class YAML_CPP_API Parser : private noncopyable {
   void Load(std::istream& in);
 
   /**
-   * Handles the next document by calling events on the {@param eventHandler}.
+   * Handles the next document by calling events on the {@code eventHandler}.
    *
    * @throw a ParserException on error.
    * @return false if there are no more documents


### PR DESCRIPTION
Starting with C++11 implicit copy-constructors are deprecated when the class
has a user defined destructor.