### PR TITLE
Add more std container overloads for YAML::Emitter

### DIFF
--- a/include/yaml-cpp/stlemitter.h
+++ b/include/yaml-cpp/stlemitter.h
@@ -7,45 +7,139 @@
 #pragma once
 #endif
 
-#include <vector>
+#include <array>
+#include <bitset>
+#include <deque>
+#include <forward_list>
 #include <list>
-#include <set>
 #include <map>
+#include <set>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace YAML {
-template <typename Seq>
-inline Emitter& EmitSeq(Emitter& emitter, const Seq& seq) {
-  emitter << BeginSeq;
-  for (typename Seq::const_iterator it = seq.begin(); it != seq.end(); ++it)
-    emitter << *it;
-  emitter << EndSeq;
+
+namespace detail {
+
+template <class SequenceLike>
+Emitter& EmitSeq(Emitter& emit, const SequenceLike& sequence) {
+  emit << BeginSeq;
+  for (const auto& item : sequence)
+    emit << item;
+  emit << EndSeq;
+  return emit;
+}
+
+template <class MapLike>
+Emitter& EmitMap(Emitter& emit, const MapLike& map) {
+  emit << BeginMap;
+  for (const auto& kv : map)
+    emit << Key << kv.first << Value << kv.second;
+  emit << EndMap;
+  return emit;
+}
+
+template <std::size_t Index = 0, typename... Args>
+typename std::enable_if<Index == sizeof...(Args), Emitter&>::type EmitTuple(
+    Emitter& emit, const std::tuple<Args...>& /*tup*/) {
+  return emit;
+}
+
+template <std::size_t Index = 0, typename... Args>
+typename std::enable_if<Index != sizeof...(Args), Emitter&>::type EmitTuple(
+    Emitter& emit, const std::tuple<Args...>& tup) {
+  emit << std::get<Index>(tup);
+  return EmitTuple<Index + 1, Args...>(emit, tup);
+}
+
+}  // namespace detail
+
+// std::vector
+template <class T, class Alloc>
+Emitter& operator<<(Emitter& emit, const std::vector<T, Alloc>& t) {
+  return detail::EmitSeq(emit, t);
+}
+
+// std::list
+template <class T, class Alloc>
+Emitter& operator<<(Emitter& emit, const std::list<T, Alloc>& t) {
+  return detail::EmitSeq(emit, t);
+}
+
+// std::deque
+template <class T, class Alloc>
+Emitter& operator<<(Emitter& emit, const std::deque<T, Alloc>& t) {
+  return detail::EmitSeq(emit, t);
+}
+
+// std::forward_list
+template <class T, class Alloc>
+Emitter& operator<<(Emitter& emit, const std::forward_list<T, Alloc>& t) {
+  return detail::EmitSeq(emit, t);
+}
+
+// std::array
+template <class T, std::size_t N>
+Emitter& operator<<(Emitter& emit, const std::array<T, N>& t) {
+  return detail::EmitSeq(emit, t);
+}
+
+// std::map
+template <class Key, class T, class Compare, class Alloc>
+Emitter& operator<<(Emitter& emit, const std::map<Key, T, Compare, Alloc>& t) {
+  return detail::EmitMap(emit, t);
+}
+
+// std::unordered_map
+template <class Key, class T, class Hash, class KeyEqual, class Alloc>
+Emitter& operator<<(
+    Emitter& emit, const std::unordered_map<Key, T, Hash, KeyEqual, Alloc>& t) {
+  return detail::EmitMap(emit, t);
+}
+
+// std::set
+template <class Key, class Compare, class Alloc>
+Emitter& operator<<(Emitter& emit, const std::set<Key, Compare, Alloc>& t) {
+  return detail::EmitSeq(emit, t);
+}
+
+// std::unordered_set
+template <class Key, class Hash, class KeyEqual, class Alloc>
+Emitter& operator<<(Emitter& emit,
+                    const std::unordered_set<Key, Hash, KeyEqual, Alloc>& t) {
+  return detail::EmitSeq(emit, t);
+}
+
+// std::bitset
+template <std::size_t N>
+Emitter& operator<<(Emitter& emit, const std::bitset<N>& bits) {
+  return emit << bits.to_string();
+}
+
+// std::pair
+template <class First, class Second>
+Emitter& operator<<(Emitter& emit, const std::pair<First, Second>& pair) {
+  emit << BeginSeq << pair.first << pair.second << EndSeq;
+  return emit;
+}
+
+// std::tuple
+template <typename... Args>
+Emitter& operator<<(Emitter& emit, const std::tuple<Args...>& tup) {
+  emit << BeginSeq;
+  detail::EmitTuple(emit, tup);
+  emit << EndSeq;
+  return emit;
+}
+
+// std::tuple -- empty
+inline Emitter& operator<<(Emitter& emitter, const std::tuple<>& /*tup*/) {
+  emitter << Null;
   return emitter;
 }
 
-template <typename T>
-inline Emitter& operator<<(Emitter& emitter, const std::vector<T>& v) {
-  return EmitSeq(emitter, v);
-}
-
-template <typename T>
-inline Emitter& operator<<(Emitter& emitter, const std::list<T>& v) {
-  return EmitSeq(emitter, v);
-}
-
-template <typename T>
-inline Emitter& operator<<(Emitter& emitter, const std::set<T>& v) {
-  return EmitSeq(emitter, v);
-}
-
-template <typename K, typename V>
-inline Emitter& operator<<(Emitter& emitter, const std::map<K, V>& m) {
-  typedef typename std::map<K, V> map;
-  emitter << BeginMap;
-  for (typename map::const_iterator it = m.begin(); it != m.end(); ++it)
-    emitter << Key << it->first << Value << it->second;
-  emitter << EndMap;
-  return emitter;
-}
-}
+}  // namespace YAML
 
 #endif  // STLEMITTER_H_62B23520_7C8E_11DE_8A39_0800200C9A66


### PR DESCRIPTION
yaml sequences:
  - std vector
  - std list
  - std deque
  - std forward_list
  - std array
  - std set
  - std unordered_set
  - std pair
  - std tuple

yaml maps:
  - std map
  - std unordered_map

yaml scalars:
  - std bitset (zeroes and ones)