### PR TITLE
Fix YAML::detail::iterator_base const comparison operators

### DIFF
--- a/include/yaml-cpp/node/detail/iterator.h
+++ b/include/yaml-cpp/node/detail/iterator.h
@@ -61,12 +61,12 @@ class iterator_base : public std::iterator<std::forward_iterator_tag, V,
   }
 
   template <typename W>
-  bool operator==(const iterator_base<W>& rhs) {
+  bool operator==(const iterator_base<W>& rhs) const {
     return m_iterator == rhs.m_iterator;
   }
 
   template <typename W>
-  bool operator!=(const iterator_base<W>& rhs) {
+  bool operator!=(const iterator_base<W>& rhs) const {
     return m_iterator != rhs.m_iterator;
   }
 


### PR DESCRIPTION
[range-v3](https://github.com/ericniebler/range-v3)'s `view` compares `const` iterators and fails to compile because `operator==` and `operator!=` are not marked as `const` in `YAML::detail::iterator_base`.