### PR TITLE
noexcept fix for visual studio

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Commit messages should be in the imperative mood, as described in the [Git contr
 
 # Tests
 
-Please verify the tests pass by running the target `tests/run_tests`.
+Please verify the tests pass by running the target `test/run-tests`.
 
 If you are adding functionality, add tests accordingly.
 

--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -8,12 +8,16 @@
 #endif
 
 #ifndef NOEXCEPT
-#ifndef _MSC_VER
-#define NOEXCEPT noexcept
-#else
+#ifdef _MSC_VER
+#ifdef _NOEXCEPT
 #define NOEXCEPT _NOEXCEPT
-#endif
-#endif
+#else
+#define NOEXCEPT
+#endif // ifdef _NOEXCEPT
+#else
+#define NOEXCEPT noexcept
+#endif // ifdef _MSC_VER
+#endif // ifdef NOEXCEPT
 
 #include "yaml-cpp/mark.h"
 #include "yaml-cpp/traits.h"

--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -7,6 +7,14 @@
 #pragma once
 #endif
 
+#ifndef NOEXCEPT
+#ifndef _MSC_VER
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT _NOEXCEPT
+#endif
+#endif
+
 #include "yaml-cpp/mark.h"
 #include "yaml-cpp/traits.h"
 #include <sstream>
@@ -112,7 +120,7 @@ class YAML_CPP_API Exception : public std::runtime_error {
  public:
   Exception(const Mark& mark_, const std::string& msg_)
       : std::runtime_error(build_what(mark_, msg_)), mark(mark_), msg(msg_) {}
-  virtual ~Exception() noexcept;
+  virtual ~Exception() NOEXCEPT;
 
   Exception(const Exception&) = default;
 
@@ -138,7 +146,7 @@ class YAML_CPP_API ParserException : public Exception {
   ParserException(const Mark& mark_, const std::string& msg_)
       : Exception(mark_, msg_) {}
   ParserException(const ParserException&) = default;
-  virtual ~ParserException() noexcept;
+  virtual ~ParserException() NOEXCEPT;
 };
 
 class YAML_CPP_API RepresentationException : public Exception {
@@ -146,7 +154,7 @@ class YAML_CPP_API RepresentationException : public Exception {
   RepresentationException(const Mark& mark_, const std::string& msg_)
       : Exception(mark_, msg_) {}
   RepresentationException(const RepresentationException&) = default;
-  virtual ~RepresentationException() noexcept;
+  virtual ~RepresentationException() NOEXCEPT;
 };
 
 // representation exceptions
@@ -155,7 +163,7 @@ class YAML_CPP_API InvalidScalar : public RepresentationException {
   InvalidScalar(const Mark& mark_)
       : RepresentationException(mark_, ErrorMsg::INVALID_SCALAR) {}
   InvalidScalar(const InvalidScalar&) = default;
-  virtual ~InvalidScalar() noexcept;
+  virtual ~InvalidScalar() NOEXCEPT;
 };
 
 class YAML_CPP_API KeyNotFound : public RepresentationException {
@@ -165,7 +173,7 @@ class YAML_CPP_API KeyNotFound : public RepresentationException {
       : RepresentationException(mark_, ErrorMsg::KEY_NOT_FOUND_WITH_KEY(key_)) {
   }
   KeyNotFound(const KeyNotFound&) = default;
-  virtual ~KeyNotFound() noexcept;
+  virtual ~KeyNotFound() NOEXCEPT;
 };
 
 template <typename T>
@@ -173,7 +181,7 @@ class YAML_CPP_API TypedKeyNotFound : public KeyNotFound {
  public:
   TypedKeyNotFound(const Mark& mark_, const T& key_)
       : KeyNotFound(mark_, key_), key(key_) {}
-  virtual ~TypedKeyNotFound() noexcept {}
+  virtual ~TypedKeyNotFound() NOEXCEPT {}
 
   T key;
 };
@@ -189,7 +197,7 @@ class YAML_CPP_API InvalidNode : public RepresentationException {
   InvalidNode()
       : RepresentationException(Mark::null_mark(), ErrorMsg::INVALID_NODE) {}
   InvalidNode(const InvalidNode&) = default;
-  virtual ~InvalidNode() noexcept;
+  virtual ~InvalidNode() NOEXCEPT;
 };
 
 class YAML_CPP_API BadConversion : public RepresentationException {
@@ -197,7 +205,7 @@ class YAML_CPP_API BadConversion : public RepresentationException {
   explicit BadConversion(const Mark& mark_)
       : RepresentationException(mark_, ErrorMsg::BAD_CONVERSION) {}
   BadConversion(const BadConversion&) = default;
-  virtual ~BadConversion() noexcept;
+  virtual ~BadConversion() NOEXCEPT;
 };
 
 template <typename T>
@@ -211,7 +219,7 @@ class YAML_CPP_API BadDereference : public RepresentationException {
   BadDereference()
       : RepresentationException(Mark::null_mark(), ErrorMsg::BAD_DEREFERENCE) {}
   BadDereference(const BadDereference&) = default;
-  virtual ~BadDereference() noexcept;
+  virtual ~BadDereference() NOEXCEPT;
 };
 
 class YAML_CPP_API BadSubscript : public RepresentationException {
@@ -219,7 +227,7 @@ class YAML_CPP_API BadSubscript : public RepresentationException {
   BadSubscript()
       : RepresentationException(Mark::null_mark(), ErrorMsg::BAD_SUBSCRIPT) {}
   BadSubscript(const BadSubscript&) = default;
-  virtual ~BadSubscript() noexcept;
+  virtual ~BadSubscript() NOEXCEPT;
 };
 
 class YAML_CPP_API BadPushback : public RepresentationException {
@@ -227,7 +235,7 @@ class YAML_CPP_API BadPushback : public RepresentationException {
   BadPushback()
       : RepresentationException(Mark::null_mark(), ErrorMsg::BAD_PUSHBACK) {}
   BadPushback(const BadPushback&) = default;
-  virtual ~BadPushback() noexcept;
+  virtual ~BadPushback() NOEXCEPT;
 };
 
 class YAML_CPP_API BadInsert : public RepresentationException {
@@ -235,7 +243,7 @@ class YAML_CPP_API BadInsert : public RepresentationException {
   BadInsert()
       : RepresentationException(Mark::null_mark(), ErrorMsg::BAD_INSERT) {}
   BadInsert(const BadInsert&) = default;
-  virtual ~BadInsert() noexcept;
+  virtual ~BadInsert() NOEXCEPT;
 };
 
 class YAML_CPP_API EmitterException : public Exception {
@@ -243,14 +251,14 @@ class YAML_CPP_API EmitterException : public Exception {
   EmitterException(const std::string& msg_)
       : Exception(Mark::null_mark(), msg_) {}
   EmitterException(const EmitterException&) = default;
-  virtual ~EmitterException() noexcept;
+  virtual ~EmitterException() NOEXCEPT;
 };
 
 class YAML_CPP_API BadFile : public Exception {
  public:
   BadFile() : Exception(Mark::null_mark(), ErrorMsg::BAD_FILE) {}
   BadFile(const BadFile&) = default;
-  virtual ~BadFile() noexcept;
+  virtual ~BadFile() NOEXCEPT;
 };
 }
 

--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -3,17 +3,17 @@
 namespace YAML {
 
 // These destructors are defined out-of-line so the vtable is only emitted once.
-Exception::~Exception() noexcept {}
-ParserException::~ParserException() noexcept {}
-RepresentationException::~RepresentationException() noexcept {}
-InvalidScalar::~InvalidScalar() noexcept {}
-KeyNotFound::~KeyNotFound() noexcept {}
-InvalidNode::~InvalidNode() noexcept {}
-BadConversion::~BadConversion() noexcept {}
-BadDereference::~BadDereference() noexcept {}
-BadSubscript::~BadSubscript() noexcept {}
-BadPushback::~BadPushback() noexcept {}
-BadInsert::~BadInsert() noexcept {}
-EmitterException::~EmitterException() noexcept {}
-BadFile::~BadFile() noexcept {}
+Exception::~Exception() NOEXCEPT {}
+ParserException::~ParserException() NOEXCEPT {}
+RepresentationException::~RepresentationException() NOEXCEPT {}
+InvalidScalar::~InvalidScalar() NOEXCEPT {}
+KeyNotFound::~KeyNotFound() NOEXCEPT {}
+InvalidNode::~InvalidNode() NOEXCEPT {}
+BadConversion::~BadConversion() NOEXCEPT {}
+BadDereference::~BadDereference() NOEXCEPT {}
+BadSubscript::~BadSubscript() NOEXCEPT {}
+BadPushback::~BadPushback() NOEXCEPT {}
+BadInsert::~BadInsert() NOEXCEPT {}
+EmitterException::~EmitterException() NOEXCEPT {}
+BadFile::~BadFile() NOEXCEPT {}
 }


### PR DESCRIPTION
I ran the test suite, i neither know which tests were disabled nor why.

```
[----------] Global test environment tear-down
[==========] 899 tests from 12 test cases ran. (752 ms total)
[  PASSED  ] 899 tests.

  YOU HAVE 8 DISABLED TESTS
```

This addresses #404 (my other pull request had the wrong user, and also conflicted when defining `NOEXCEPT` with other projects).