### PR TITLE
Add support for emitting null and strings that are JSON-compatible

### DIFF
--- a/include/yaml-cpp/emittermanip.h
+++ b/include/yaml-cpp/emittermanip.h
@@ -19,6 +19,7 @@ enum EMITTER_MANIP {
   // output character set
   EmitNonAscii,
   EscapeNonAscii,
+  EscapeAsJson,
 
   // string manipulators
   // Auto, // duplicate

--- a/src/emitterstate.cpp
+++ b/src/emitterstate.cpp
@@ -231,6 +231,7 @@ bool EmitterState::SetOutputCharset(EMITTER_MANIP value,
   switch (value) {
     case EmitNonAscii:
     case EscapeNonAscii:
+    case EscapeAsJson:
       _Set(m_charset, value, scope);
       return true;
     default:

--- a/src/emitterutils.h
+++ b/src/emitterutils.h
@@ -24,6 +24,10 @@ struct StringFormat {
   enum value { Plain, SingleQuoted, DoubleQuoted, Literal };
 };
 
+struct StringEscaping {
+  enum value { None, NonAscii, JSON };
+};
+
 namespace Utils {
 StringFormat::value ComputeStringFormat(const std::string& str,
                                         EMITTER_MANIP strFormat,
@@ -32,10 +36,11 @@ StringFormat::value ComputeStringFormat(const std::string& str,
 
 bool WriteSingleQuotedString(ostream_wrapper& out, const std::string& str);
 bool WriteDoubleQuotedString(ostream_wrapper& out, const std::string& str,
-                             bool escapeNonAscii);
+                             StringEscaping::value stringEscaping);
 bool WriteLiteralString(ostream_wrapper& out, const std::string& str,
                         std::size_t indent);
-bool WriteChar(ostream_wrapper& out, char ch);
+bool WriteChar(ostream_wrapper& out, char ch,
+               StringEscaping::value stringEscapingStyle);
 bool WriteComment(ostream_wrapper& out, const std::string& str,
                   std::size_t postCommentIndent);
 bool WriteAlias(ostream_wrapper& out, const std::string& str);

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -813,7 +813,43 @@ TEST_F(EmitterTest, Unicode) {
 
 TEST_F(EmitterTest, DoubleQuotedUnicode) {
   out << DoubleQuoted << "\x24 \xC2\xA2 \xE2\x82\xAC \xF0\xA4\xAD\xA2";
-  ExpectEmit("\"\x24 \xC2\xA2 \xE2\x82\xAC \xF0\xA4\xAD\xA2\"");
+  ExpectEmit("\"\x24 \xC2\xA2 \xE2\x82\xAC \xF0\xA4\xAD\xA2\""); 
+}
+
+TEST_F(EmitterTest, EscapedJsonString) {
+  out.SetStringFormat(DoubleQuoted);
+  out.SetOutputCharset(EscapeAsJson);
+  out << "\" \\ "
+    "\x01 \x02 \x03 \x04 \x05 \x06 \x07 \x08 \x09 \x0A \x0B \x0C \x0D \x0E \x0F "
+    "\x10 \x11 \x12 \x13 \x14 \x15 \x16 \x17 \x18 \x19 \x1A \x1B \x1C \x1D \x1E \x1F "
+    "\x24 \xC2\xA2 \xE2\x82\xAC \xF0\xA4\xAD\xA2";
+
+  ExpectEmit(R"("\" \\ \u0001 \u0002 \u0003 \u0004 \u0005 \u0006 \u0007 \b \t )"
+             R"(\n \u000b \f \r \u000e \u000f \u0010 \u0011 \u0012 \u0013 )"
+             R"(\u0014 \u0015 \u0016 \u0017 \u0018 \u0019 \u001a \u001b )"
+             R"(\u001c \u001d \u001e \u001f )"
+             "$ \xC2\xA2 \xE2\x82\xAC \xF0\xA4\xAD\xA2\"");
+}
+
+TEST_F(EmitterTest, EscapedCharacters) {
+  out << BeginSeq 
+    << '\x00'
+    << '\x0C'
+    << '\x0D'
+    << EndSeq;
+
+  ExpectEmit("- \"\\x00\"\n- \"\\f\"\n- \"\\r\"");
+}
+
+TEST_F(EmitterTest, CharactersEscapedAsJson) {
+  out.SetOutputCharset(EscapeAsJson);
+  out << BeginSeq
+    << '\x00'
+    << '\x0C'
+    << '\x0D'
+    << EndSeq;
+
+  ExpectEmit("- \"\\u0000\"\n- \"\\f\"\n- \"\\r\"");
 }
 
 TEST_F(EmitterTest, DoubleQuotedString) {


### PR DESCRIPTION
yaml-cpp currently only supports emitting null values as `~`, when they can also be (and JSON requires them to be) `null`. Also, JSON strings don't allow `\x` style escapes, and use UTF-16 surrogate pair escapes instead of `\U` escapes.

This PR adds emitter manipulators to support JSON-style null values and strings. When outputting JSON-style strings, yaml-cpp will escape only the code points it is required to by the YAML and JSON specs, and use two-character escape codes for the code points that have them.

(As an aside, I noticed that the existing code point escapes don't cover all the code points required by the YAML 1.2 spec section 5.1, but I didn't fix that as it's out of scope for this PR as JSON is fine with those that are currently unescaped.)