### PR TITLE
WIP: fix stack overflow in HandleNode() (CVE-2017-5950)

### DIFF
--- a/src/singledocparser.cpp
+++ b/src/singledocparser.cpp
@@ -46,6 +46,8 @@ void SingleDocParser::HandleDocument(EventHandler& eventHandler) {
 }
 
 void SingleDocParser::HandleNode(EventHandler& eventHandler) {
+  assert(depth < depth_limit);
+  depth++;
   // an empty node *is* a possibility
   if (m_scanner.empty()) {
     eventHandler.OnNull(m_scanner.mark(), NullAnchor);

--- a/src/singledocparser.h
+++ b/src/singledocparser.h
@@ -51,6 +51,8 @@ class SingleDocParser : private noncopyable {
   anchor_t LookupAnchor(const Mark& mark, const std::string& name) const;
 
  private:
+  int depth = 0;
+  int depth_limit = 2000;
   Scanner& m_scanner;
   const Directives& m_directives;
   std::unique_ptr<CollectionStack> m_pCollectionStack;


### PR DESCRIPTION
simply set a hardcoded recursion limit to 2000 (inspired by Python's)
to avoid infinitely recursing into arbitrary data structures

assert() the depth. unsure if this is the right approach, but given
that HandleNode() is "void", I am not sure how else to return an
error. the problem with this approach of course is that it will still
crash the caller, unless they have proper exception handling in place.

Closes: #459