### PR TITLE
Fix segfault in gmock with GCC-6 when running tests

### DIFF
--- a/test/gmock-1.7.0/include/gmock/gmock-spec-builders.h
+++ b/test/gmock-1.7.0/include/gmock/gmock-spec-builders.h
@@ -1370,6 +1370,8 @@ class ActionResultHolder : public UntypedActionResultHolderBase {
 template <>
 class ActionResultHolder<void> : public UntypedActionResultHolderBase {
  public:
+  explicit ActionResultHolder() {}
+
   void GetValueAndDelete() const { delete this; }
 
   virtual void PrintAsActionResult(::std::ostream* /* os */) const {}
@@ -1381,7 +1383,7 @@ class ActionResultHolder<void> : public UntypedActionResultHolderBase {
       const typename Function<F>::ArgumentTuple& args,
       const string& call_description) {
     func_mocker->PerformDefaultAction(args, call_description);
-    return NULL;
+    return new ActionResultHolder();
   }
 
   // Performs the given action and returns NULL.
@@ -1390,7 +1392,7 @@ class ActionResultHolder<void> : public UntypedActionResultHolderBase {
       const Action<F>& action,
       const typename Function<F>::ArgumentTuple& args) {
     action.Perform(args);
-    return NULL;
+    return new ActionResultHolder();
   }
 };
 


### PR DESCRIPTION
Fixes https://github.com/jbeder/yaml-cpp/issues/301.

See https://github.com/google/googletest/issues/705#issuecomment-235067917 for info on issue and patch.

Tested and working with gcc-6.3.0 and gcc-5.4.0.