### PR TITLE
Replace noexcept with macro compatible with VS

### DIFF
--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -13,6 +13,14 @@
 #include <stdexcept>
 #include <string>
 
+// This is here for compatibility with older versions of Visual Studio
+// which don't support noexcept
+#ifdef _MSC_VER
+    #define YAML_CPP_NOEXCEPT _NOEXCEPT
+#else
+    #define YAML_CPP_NOEXCEPT noexcept
+#endif
+
 namespace YAML {
 // error messages
 namespace ErrorMsg {
@@ -112,7 +120,7 @@ class YAML_CPP_API Exception : public std::runtime_error {
  public:
   Exception(const Mark& mark_, const std::string& msg_)
       : std::runtime_error(build_what(mark_, msg_)), mark(mark_), msg(msg_) {}
-  virtual ~Exception() noexcept;
+  virtual ~Exception() YAML_CPP_NOEXCEPT;
 
   Exception(const Exception&) = default;
 
@@ -138,7 +146,7 @@ class YAML_CPP_API ParserException : public Exception {
   ParserException(const Mark& mark_, const std::string& msg_)
       : Exception(mark_, msg_) {}
   ParserException(const ParserException&) = default;
-  virtual ~ParserException() noexcept;
+  virtual ~ParserException() YAML_CPP_NOEXCEPT;
 };
 
 class YAML_CPP_API RepresentationException : public Exception {
@@ -146,7 +154,7 @@ class YAML_CPP_API RepresentationException : public Exception {
   RepresentationException(const Mark& mark_, const std::string& msg_)
       : Exception(mark_, msg_) {}
   RepresentationException(const RepresentationException&) = default;
-  virtual ~RepresentationException() noexcept;
+  virtual ~RepresentationException() YAML_CPP_NOEXCEPT;
 };
 
 // representation exceptions
@@ -155,7 +163,7 @@ class YAML_CPP_API InvalidScalar : public RepresentationException {
   InvalidScalar(const Mark& mark_)
       : RepresentationException(mark_, ErrorMsg::INVALID_SCALAR) {}
   InvalidScalar(const InvalidScalar&) = default;
-  virtual ~InvalidScalar() noexcept;
+  virtual ~InvalidScalar() YAML_CPP_NOEXCEPT;
 };
 
 class YAML_CPP_API KeyNotFound : public RepresentationException {
@@ -165,7 +173,7 @@ class YAML_CPP_API KeyNotFound : public RepresentationException {
       : RepresentationException(mark_, ErrorMsg::KEY_NOT_FOUND_WITH_KEY(key_)) {
   }
   KeyNotFound(const KeyNotFound&) = default;
-  virtual ~KeyNotFound() noexcept;
+  virtual ~KeyNotFound() YAML_CPP_NOEXCEPT;
 };
 
 template <typename T>
@@ -173,7 +181,7 @@ class YAML_CPP_API TypedKeyNotFound : public KeyNotFound {
  public:
   TypedKeyNotFound(const Mark& mark_, const T& key_)
       : KeyNotFound(mark_, key_), key(key_) {}
-  virtual ~TypedKeyNotFound() noexcept {}
+  virtual ~TypedKeyNotFound() YAML_CPP_NOEXCEPT {}
 
   T key;
 };
@@ -189,7 +197,7 @@ class YAML_CPP_API InvalidNode : public RepresentationException {
   InvalidNode()
       : RepresentationException(Mark::null_mark(), ErrorMsg::INVALID_NODE) {}
   InvalidNode(const InvalidNode&) = default;
-  virtual ~InvalidNode() noexcept;
+  virtual ~InvalidNode() YAML_CPP_NOEXCEPT;
 };
 
 class YAML_CPP_API BadConversion : public RepresentationException {
@@ -197,7 +205,7 @@ class YAML_CPP_API BadConversion : public RepresentationException {
   explicit BadConversion(const Mark& mark_)
       : RepresentationException(mark_, ErrorMsg::BAD_CONVERSION) {}
   BadConversion(const BadConversion&) = default;
-  virtual ~BadConversion() noexcept;
+  virtual ~BadConversion() YAML_CPP_NOEXCEPT;
 };
 
 template <typename T>
@@ -211,7 +219,7 @@ class YAML_CPP_API BadDereference : public RepresentationException {
   BadDereference()
       : RepresentationException(Mark::null_mark(), ErrorMsg::BAD_DEREFERENCE) {}
   BadDereference(const BadDereference&) = default;
-  virtual ~BadDereference() noexcept;
+  virtual ~BadDereference() YAML_CPP_NOEXCEPT;
 };
 
 class YAML_CPP_API BadSubscript : public RepresentationException {
@@ -219,7 +227,7 @@ class YAML_CPP_API BadSubscript : public RepresentationException {
   BadSubscript()
       : RepresentationException(Mark::null_mark(), ErrorMsg::BAD_SUBSCRIPT) {}
   BadSubscript(const BadSubscript&) = default;
-  virtual ~BadSubscript() noexcept;
+  virtual ~BadSubscript() YAML_CPP_NOEXCEPT;
 };
 
 class YAML_CPP_API BadPushback : public RepresentationException {
@@ -227,7 +235,7 @@ class YAML_CPP_API BadPushback : public RepresentationException {
   BadPushback()
       : RepresentationException(Mark::null_mark(), ErrorMsg::BAD_PUSHBACK) {}
   BadPushback(const BadPushback&) = default;
-  virtual ~BadPushback() noexcept;
+  virtual ~BadPushback() YAML_CPP_NOEXCEPT;
 };
 
 class YAML_CPP_API BadInsert : public RepresentationException {
@@ -235,7 +243,7 @@ class YAML_CPP_API BadInsert : public RepresentationException {
   BadInsert()
       : RepresentationException(Mark::null_mark(), ErrorMsg::BAD_INSERT) {}
   BadInsert(const BadInsert&) = default;
-  virtual ~BadInsert() noexcept;
+  virtual ~BadInsert() YAML_CPP_NOEXCEPT;
 };
 
 class YAML_CPP_API EmitterException : public Exception {
@@ -243,15 +251,17 @@ class YAML_CPP_API EmitterException : public Exception {
   EmitterException(const std::string& msg_)
       : Exception(Mark::null_mark(), msg_) {}
   EmitterException(const EmitterException&) = default;
-  virtual ~EmitterException() noexcept;
+  virtual ~EmitterException() YAML_CPP_NOEXCEPT;
 };
 
 class YAML_CPP_API BadFile : public Exception {
  public:
   BadFile() : Exception(Mark::null_mark(), ErrorMsg::BAD_FILE) {}
   BadFile(const BadFile&) = default;
-  virtual ~BadFile() noexcept;
+  virtual ~BadFile() YAML_CPP_NOEXCEPT;
 };
 }
+
+#undef YAML_CPP_NOEXCEPT
 
 #endif  // EXCEPTIONS_H_62B23520_7C8E_11DE_8A39_0800200C9A66

--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -1,19 +1,31 @@
 #include "yaml-cpp/exceptions.h"
 
+// This is here for compatibility with older versions of Visual Studio
+// which don't support noexcept
+#ifdef _MSC_VER
+    #define YAML_CPP_NOEXCEPT _NOEXCEPT
+#else
+    #define YAML_CPP_NOEXCEPT noexcept
+#endif
+
 namespace YAML {
 
 // These destructors are defined out-of-line so the vtable is only emitted once.
-Exception::~Exception() noexcept {}
-ParserException::~ParserException() noexcept {}
-RepresentationException::~RepresentationException() noexcept {}
-InvalidScalar::~InvalidScalar() noexcept {}
-KeyNotFound::~KeyNotFound() noexcept {}
-InvalidNode::~InvalidNode() noexcept {}
-BadConversion::~BadConversion() noexcept {}
-BadDereference::~BadDereference() noexcept {}
-BadSubscript::~BadSubscript() noexcept {}
-BadPushback::~BadPushback() noexcept {}
-BadInsert::~BadInsert() noexcept {}
-EmitterException::~EmitterException() noexcept {}
-BadFile::~BadFile() noexcept {}
+Exception::~Exception() YAML_CPP_NOEXCEPT {}
+ParserException::~ParserException() YAML_CPP_NOEXCEPT {}
+RepresentationException::~RepresentationException() YAML_CPP_NOEXCEPT {}
+InvalidScalar::~InvalidScalar() YAML_CPP_NOEXCEPT {}
+KeyNotFound::~KeyNotFound() YAML_CPP_NOEXCEPT {}
+InvalidNode::~InvalidNode() YAML_CPP_NOEXCEPT {}
+BadConversion::~BadConversion() YAML_CPP_NOEXCEPT {}
+BadDereference::~BadDereference() YAML_CPP_NOEXCEPT {}
+BadSubscript::~BadSubscript() YAML_CPP_NOEXCEPT {}
+BadPushback::~BadPushback() YAML_CPP_NOEXCEPT {}
+BadInsert::~BadInsert() YAML_CPP_NOEXCEPT {}
+EmitterException::~EmitterException() YAML_CPP_NOEXCEPT {}
+BadFile::~BadFile() YAML_CPP_NOEXCEPT {}
 }
+
+#undef YAML_CPP_NOEXCEPT
+
+


### PR DESCRIPTION
This way it's possible to build using older MSVC (<13) that don't
support this yet. Macro is undefined in each file where it is used so it
should stack well with other libs and sources.