### PR TITLE
Added a parameter to add more control of comment offset

### DIFF
--- a/include/yaml-cpp/emittermanip.h
+++ b/include/yaml-cpp/emittermanip.h
@@ -113,11 +113,13 @@ inline _Tag SecondaryTag(const std::string content) {
 }
 
 struct _Comment {
-  _Comment(const std::string& content_) : content(content_) {}
+  _Comment(const std::string& content_, int col = -1) : content(content_), indent_col(col), indent_to(col > 0) {}
   std::string content;
+  size_t indent_col;
+  bool indent_to;
 };
 
-inline _Comment Comment(const std::string content) { return _Comment(content); }
+inline _Comment Comment(const std::string content, int col = -1) { return _Comment(content, col); }
 
 struct _Precision {
   _Precision(int floatPrecision_, int doublePrecision_)

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -874,7 +874,12 @@ Emitter& Emitter::Write(const _Comment& comment) {
   PrepareNode(EmitterNodeType::NoType);
 
   if (m_stream.col() > 0)
-    m_stream << Indentation(m_pState->GetPreCommentIndent());
+  {
+    if(comment.indent_to && comment.indent_col > m_stream.col())
+      m_stream << IndentTo(comment.indent_col);
+    else  
+      m_stream << Indentation(m_pState->GetPreCommentIndent());
+  }
   Utils::WriteComment(m_stream, comment.content,
                       m_pState->GetPostCommentIndent());
 


### PR DESCRIPTION
I wanted this for generating config files that users would interact with on a regular basis. This makes it a little easier to look at as a user. The existing tests still work.