### PR TITLE
Node hash() and id() for faster is()-type sets

### DIFF
--- a/include/yaml-cpp/node/detail/node.h
+++ b/include/yaml-cpp/node/detail/node.h
@@ -16,22 +16,19 @@
 
 namespace YAML {
 namespace detail {
-class node {
+class node : public node_ref_id {
  public:
-  node() : m_pRef(new node_ref) {}
-  node(const node&) = delete;
-  node& operator=(const node&) = delete;
+  node() : node_ref_id(std::make_shared<node_ref>()) {}
 
   bool is(const node& rhs) const { return m_pRef == rhs.m_pRef; }
-  const node_ref* ref() const { return m_pRef.get(); }
 
-  bool is_defined() const { return m_pRef->is_defined(); }
-  const Mark& mark() const { return m_pRef->mark(); }
-  NodeType::value type() const { return m_pRef->type(); }
+  bool is_defined() const { return nref().is_defined(); }
+  const Mark& mark() const { return nref().mark(); }
+  NodeType::value type() const { return nref().type(); }
 
-  const std::string& scalar() const { return m_pRef->scalar(); }
-  const std::string& tag() const { return m_pRef->tag(); }
-  EmitterStyle::value style() const { return m_pRef->style(); }
+  const std::string& scalar() const { return nref().scalar(); }
+  const std::string& tag() const { return nref().tag(); }
+  EmitterStyle::value style() const { return nref().style(); }
 
   template <typename T>
   bool equals(const T& rhs, shared_memory_holder pMemory);
@@ -41,7 +38,7 @@ class node {
     if (is_defined())
       return;
 
-    m_pRef->mark_defined();
+    nref().mark_defined();
     for (nodes::iterator it = m_dependencies.begin();
          it != m_dependencies.end(); ++it)
       (*it)->mark_defined();
@@ -63,55 +60,55 @@ class node {
   void set_data(const node& rhs) {
     if (rhs.is_defined())
       mark_defined();
-    m_pRef->set_data(*rhs.m_pRef);
+    nref().set_data(rhs.nref());
   }
 
-  void set_mark(const Mark& mark) { m_pRef->set_mark(mark); }
+  void set_mark(const Mark& mark) { nref().set_mark(mark); }
 
   void set_type(NodeType::value type) {
     if (type != NodeType::Undefined)
       mark_defined();
-    m_pRef->set_type(type);
+    nref().set_type(type);
   }
   void set_null() {
     mark_defined();
-    m_pRef->set_null();
+    nref().set_null();
   }
   void set_scalar(const std::string& scalar) {
     mark_defined();
-    m_pRef->set_scalar(scalar);
+    nref().set_scalar(scalar);
   }
   void set_tag(const std::string& tag) {
     mark_defined();
-    m_pRef->set_tag(tag);
+    nref().set_tag(tag);
   }
 
   // style
   void set_style(EmitterStyle::value style) {
     mark_defined();
-    m_pRef->set_style(style);
+    nref().set_style(style);
   }
 
   // size/iterator
-  std::size_t size() const { return m_pRef->size(); }
+  std::size_t size() const { return nref().size(); }
 
   const_node_iterator begin() const {
-    return static_cast<const node_ref&>(*m_pRef).begin();
+    return static_cast<const node_ref&>(nref()).begin();
   }
-  node_iterator begin() { return m_pRef->begin(); }
+  node_iterator begin() { return nref().begin(); }
 
   const_node_iterator end() const {
-    return static_cast<const node_ref&>(*m_pRef).end();
+    return static_cast<const node_ref&>(nref()).end();
   }
-  node_iterator end() { return m_pRef->end(); }
+  node_iterator end() { return nref().end(); }
 
   // sequence
   void push_back(node& input, shared_memory_holder pMemory) {
-    m_pRef->push_back(input, pMemory);
+    nref().push_back(input, pMemory);
     input.add_dependency(*this);
   }
   void insert(node& key, node& value, shared_memory_holder pMemory) {
-    m_pRef->insert(key, value, pMemory);
+    nref().insert(key, value, pMemory);
     key.add_dependency(*this);
     value.add_dependency(*this);
   }
@@ -122,44 +119,43 @@ class node {
     // NOTE: this returns a non-const node so that the top-level Node can wrap
     // it, and returns a pointer so that it can be NULL (if there is no such
     // key).
-    return static_cast<const node_ref&>(*m_pRef).get(key, pMemory);
+    return static_cast<const node_ref&>(nref()).get(key, pMemory);
   }
   template <typename Key>
   node& get(const Key& key, shared_memory_holder pMemory) {
-    node& value = m_pRef->get(key, pMemory);
+    node& value = nref().get(key, pMemory);
     value.add_dependency(*this);
     return value;
   }
   template <typename Key>
   bool remove(const Key& key, shared_memory_holder pMemory) {
-    return m_pRef->remove(key, pMemory);
+    return nref().remove(key, pMemory);
   }
 
   node* get(node& key, shared_memory_holder pMemory) const {
     // NOTE: this returns a non-const node so that the top-level Node can wrap
     // it, and returns a pointer so that it can be NULL (if there is no such
     // key).
-    return static_cast<const node_ref&>(*m_pRef).get(key, pMemory);
+    return static_cast<const node_ref&>(nref()).get(key, pMemory);
   }
   node& get(node& key, shared_memory_holder pMemory) {
-    node& value = m_pRef->get(key, pMemory);
+    node& value = nref().get(key, pMemory);
     key.add_dependency(*this);
     value.add_dependency(*this);
     return value;
   }
   bool remove(node& key, shared_memory_holder pMemory) {
-    return m_pRef->remove(key, pMemory);
+    return nref().remove(key, pMemory);
   }
 
   // map
   template <typename Key, typename Value>
   void force_insert(const Key& key, const Value& value,
                     shared_memory_holder pMemory) {
-    m_pRef->force_insert(key, value, pMemory);
+    nref().force_insert(key, value, pMemory);
   }
 
  private:
-  shared_node_ref m_pRef;
   typedef std::set<node*> nodes;
   nodes m_dependencies;
 };

--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -441,8 +441,6 @@ inline void Node::force_insert(const Key& key, const Value& value) {
                         m_pMemory);
 }
 
-// free functions
-inline bool operator==(const Node& lhs, const Node& rhs) { return lhs.is(rhs); }
 }
 
 #endif  // NODE_IMPL_H_62B23520_7C8E_11DE_8A39_0800200C9A66

--- a/include/yaml-cpp/node/ptr.h
+++ b/include/yaml-cpp/node/ptr.h
@@ -18,6 +18,26 @@ class node_data;
 class memory;
 class memory_holder;
 
+class node_ref_id {
+protected:
+  typedef std::shared_ptr<void> Ptr;
+  Ptr m_pRef;
+  node_ref_id(Ptr && p) : m_pRef((Ptr &&)p) {}
+  node_ref_id(const node_ref_id&) = delete;
+  node_ref_id& operator=(const node_ref_id&) = delete;
+  detail::node_ref& nref() const { return *ref(); }
+public:
+  detail::node_ref* ref() const { return (detail::node_ref*)m_pRef.get(); }
+  const void* id() const {
+    return m_pRef.get();
+  }
+};
+
+inline node_ref_id const* ref_id(node const* node) {
+  // this could be static_cast if we pulled in the full definition of node
+  return reinterpret_cast<node_ref_id const*>(node);
+}
+
 typedef std::shared_ptr<node> shared_node;
 typedef std::shared_ptr<node_ref> shared_node_ref;
 typedef std::shared_ptr<node_data> shared_node_data;


### PR DESCRIPTION
A common use case is to transform each Node once even when *1 &1 DAG
sharing exists in the input. This needs an 'already processed' set,
which, using only is() would be quadratic in this use case. hashable
ids (exposing the underlying pointer used by is) makes it linear time.

For performance, part of node/detail/node.h is effectively exposed - the
fact that it has a shared_ptr<node_ref> as its first member.

Alternatively the implementation of id() could be made non-inline so the
full definition of detail::node could be used.