### PR TITLE
Add missing include directive (#536)

### DIFF
--- a/include/yaml-cpp/node/detail/iterator.h
+++ b/include/yaml-cpp/node/detail/iterator.h
@@ -8,6 +8,7 @@
 #endif
 
 #include "yaml-cpp/dll.h"
+#include "yaml-cpp/node/node.h"
 #include "yaml-cpp/node/ptr.h"
 #include "yaml-cpp/node/detail/node_iterator.h"
 #include <cstddef>


### PR DESCRIPTION
Fix #536 

The header `yaml-cpp/node/detail/iterator.h` must include `yaml-cpp/node/node.h`.