### PR TITLE
Fix some problems related to virtual methods

### DIFF
--- a/include/yaml-cpp/contrib/graphbuilder.h
+++ b/include/yaml-cpp/contrib/graphbuilder.h
@@ -19,6 +19,8 @@ class Parser;
 //   functions.
 class GraphBuilderInterface {
  public:
+  virtual ~GraphBuilderInterface() = 0;
+
   // Create and return a new node with a null value.
   virtual void *NewNull(const Mark &mark, void *pParentNode) = 0;
 

--- a/util/parse.cpp
+++ b/util/parse.cpp
@@ -20,21 +20,21 @@ Params ParseArgs(int argc, char** argv) {
 
 class NullEventHandler : public YAML::EventHandler {
  public:
-  virtual void OnDocumentStart(const YAML::Mark&) {}
-  virtual void OnDocumentEnd() {}
+  void OnDocumentStart(const YAML::Mark&) override {}
+  void OnDocumentEnd() override {}
 
-  virtual void OnNull(const YAML::Mark&, YAML::anchor_t) {}
-  virtual void OnAlias(const YAML::Mark&, YAML::anchor_t) {}
-  virtual void OnScalar(const YAML::Mark&, const std::string&, YAML::anchor_t,
-                        const std::string&) {}
+  void OnNull(const YAML::Mark&, YAML::anchor_t) override {}
+  void OnAlias(const YAML::Mark&, YAML::anchor_t) override {}
+  void OnScalar(const YAML::Mark&, const std::string&, YAML::anchor_t,
+                const std::string&) override {}
 
-  virtual void OnSequenceStart(const YAML::Mark&, const std::string&,
-                               YAML::anchor_t) {}
-  virtual void OnSequenceEnd() {}
+  void OnSequenceStart(const YAML::Mark&, const std::string&, YAML::anchor_t,
+                       YAML::EmitterStyle::value) override {}
+  void OnSequenceEnd() override {}
 
-  virtual void OnMapStart(const YAML::Mark&, const std::string&,
-                          YAML::anchor_t) {}
-  virtual void OnMapEnd() {}
+  void OnMapStart(const YAML::Mark&, const std::string&, YAML::anchor_t,
+                  YAML::EmitterStyle::value) override {}
+  void OnMapEnd() override {}
 };
 
 void parse(std::istream& input) {


### PR DESCRIPTION
Fix two issues related to virtual methods:

- `GraphBuilderInterface` had a non-virtual destructor, which tripped a `-Wnon-virtual-dtor` warning, and is potentially dangerous as deleting an instance (necessarily a derived type, as `GraphBuilderInterface` is abstract) via a pointer to the base type would invoke the wrong destructor. Add an explicit (abstract) virtual destructor to fix this.
- A pair of methods  in `NullEventHandler` were shadowing base methods, tripping a `-Woverloaded-virtual` warning. It appears that these were intended to overload the base methods instead (especially as said methods are pure virtual), but did not, due to a mismatch of parameters. Correct the mismatch, and also add `override` keywords to prevent these going out of sync in the future.