### PR TITLE
Separate tests and tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ enable_testing()
 ### Project options
 ###
 ## Project stuff
-option(YAML_CPP_BUILD_TOOLS "Enable testing and parse tools" ON)
+option(YAML_CPP_BUILD_TESTS "Enable testing" ON)
+option(YAML_CPP_BUILD_TOOLS "Enable parse tools" ON)
 option(YAML_CPP_BUILD_CONTRIB "Enable contrib stuff in library" ON)
 
 ## Build options
@@ -355,8 +356,10 @@ endif()
 ###
 ### Extras
 ###
-if(YAML_CPP_BUILD_TOOLS)
+if(YAML_CPP_BUILD_TESTS)
 	add_subdirectory(test)
+endif()
+if(YAML_CPP_BUILD_TOOLS)
 	add_subdirectory(util)
 endif()
 


### PR DESCRIPTION
Don't build tests if the confusingly named `YAML_CPP_BUILD_TOOLS` is `ON`. Instead, add a new option that controls only if the tests are built.