### PR TITLE
Only use -Wno-c99-extensions for clang

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,11 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
    CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(yaml_test_flags "-Wno-c99-extensions -Wno-variadic-macros -Wno-sign-compare")
+  set(yaml_test_flags "-Wno-variadic-macros -Wno-sign-compare")
+
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(yaml_test_flags "${yaml_test_flags} -Wno-c99-extensions")
+  endif()
 
   if(CMAKE_COMPILER_IS_GNUCXX)
     set(yaml_test_flags "${yaml_test_flags} -std=gnu++11")


### PR DESCRIPTION
My understanding is that `-Wno-c99-extensions` is a clang-specific flag, so this makes sure the flag is not used when the compiler is not clang.