### PR TITLE
Fix paths in pkg-config file

### DIFF
--- a/yaml-cpp.pc.cmake
+++ b/yaml-cpp.pc.cmake
@@ -1,5 +1,7 @@
-libdir=@LIB_INSTALL_DIR@
-includedir=@INCLUDE_INSTALL_ROOT_DIR@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/@INCLUDE_INSTALL_ROOT_DIR@
+libdir=${exec_prefix}/@LIB_INSTALL_DIR@
 
 Name: Yaml-cpp
 Description: A YAML parser and emitter for C++


### PR DESCRIPTION
`pkg-config` should be giving absolute paths rather than relative paths.

Broken by https://github.com/jbeder/yaml-cpp/commit/dc9c750efd0114e5ebf736f5639aaf3df15c4bab and in 0.6.0. If it would be possible to cut a 0.6.1 release with this fix in it, it would be very much appreciated.

Before:

```
$ cat yaml-cpp.pc
libdir=lib
includedir=include

Name: Yaml-cpp
Description: A YAML parser and emitter for C++
Version: 0.6.0
Requires:
Libs: -L${libdir} -lyaml-cpp
Cflags: -I${includedir}
$ pkg-config --cflags yaml-cpp 
-Iinclude
$pkg-config --libs yaml-cpp 
-Llib -lyaml-cpp
```

After (for example with install prefix `/usr/local`):
```
$ cat yaml-cpp.pc 
prefix=/usr/local
exec_prefix=${prefix}
includedir=${prefix}/include
libdir=${exec_prefix}/lib

Name: Yaml-cpp
Description: A YAML parser and emitter for C++
Version: 0.6.0
Requires:
Libs: -L${libdir} -lyaml-cpp
Cflags: -I${includedir}
$ pkg-config --cflags yaml-cpp 
-I/usr/local/include
$ pkg-config --libs yaml-cpp 
-L/usr/local/lib -lyaml-cpp
```

PTAL @jbeder.