### PR TITLE
fix up static, so works as DLL

### DIFF
--- a/include/yaml-cpp/node/detail/node_data.h
+++ b/include/yaml-cpp/node/detail/node_data.h
@@ -81,7 +81,7 @@ class YAML_CPP_API node_data {
                     shared_memory_holder pMemory);
 
  public:
-  static std::string empty_scalar;
+  static std::string& empty_scalar();
 
  private:
   void compute_seq_size() const;

--- a/include/yaml-cpp/node/detail/node_data.h
+++ b/include/yaml-cpp/node/detail/node_data.h
@@ -81,7 +81,7 @@ class YAML_CPP_API node_data {
                     shared_memory_holder pMemory);
 
  public:
-  static std::string& empty_scalar();
+  static const std::string& empty_scalar();
 
  private:
   void compute_seq_size() const;

--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -156,13 +156,13 @@ inline T Node::as(const S& fallback) const {
 inline const std::string& Node::Scalar() const {
   if (!m_isValid)
     throw InvalidNode();
-  return m_pNode ? m_pNode->scalar() : detail::node_data::empty_scalar;
+  return m_pNode ? m_pNode->scalar() : detail::node_data::empty_scalar();
 }
 
 inline const std::string& Node::Tag() const {
   if (!m_isValid)
     throw InvalidNode();
-  return m_pNode ? m_pNode->tag() : detail::node_data::empty_scalar;
+  return m_pNode ? m_pNode->tag() : detail::node_data::empty_scalar();
 }
 
 inline void Node::SetTag(const std::string& tag) {

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -13,7 +13,10 @@
 namespace YAML {
 namespace detail {
 
-std::string node_data::empty_scalar;
+std::string& node_data::empty_scalar(){
+    static std::string _es;
+    return _es ;
+}
 
 node_data::node_data()
     : m_isDefined(false),

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -15,7 +15,7 @@ namespace detail {
 
 const std::string& node_data::empty_scalar() {
     static const std::string svalue;
-    return svalue ;
+    return svalue;
 }
 
 node_data::node_data()

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -13,9 +13,9 @@
 namespace YAML {
 namespace detail {
 
-std::string& node_data::empty_scalar(){
-    static std::string _es;
-    return _es ;
+const std::string& node_data::empty_scalar() {
+    static const std::string svalue;
+    return svalue ;
 }
 
 node_data::node_data()


### PR DESCRIPTION
Windows has problems exporting static data members.
Recommend using a function for statics instead as below

https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/

Handling class static data members 
Eliminate the static data –
   This can be done by making a static getter function with a local static variable
