### PR TITLE
Improvements to CMake buildsystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,8 @@
 ###
 ### CMake settings
 ###
-## Due to Mac OSX we need to keep compatibility with CMake 2.6
 # see http://www.cmake.org/Wiki/CMake_Policies
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.1)
 # see http://www.cmake.org/cmake/help/cmake-2-8-docs.html#policy:CMP0012
 if(POLICY CMP0012)
 	cmake_policy(SET CMP0012 OLD)
@@ -45,6 +44,10 @@ option(YAML_CPP_BUILD_CONTRIB "Enable contrib stuff in library" ON)
 # see http://www.cmake.org/cmake/help/cmake2.6docs.html#variable:BUILD_SHARED_LIBS
 #     http://www.cmake.org/cmake/help/cmake2.6docs.html#command:add_library
 option(BUILD_SHARED_LIBS "Build Shared Libraries" OFF)
+
+# Set minimum C++ to 2011 standards
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # --> Apple
 option(APPLE_UNIVERSAL_BIN "Apple: Build universal binary" OFF)
@@ -185,7 +188,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
 		set(GCC_EXTRA_OPTIONS "${GCC_EXTRA_OPTIONS} ${FLAG_TESTED}")
 	endif()
 	#
-	set(yaml_cxx_flags "-Wall ${GCC_EXTRA_OPTIONS} -pedantic -Wno-long-long -std=c++11 ${yaml_cxx_flags}")
+	set(yaml_cxx_flags "-Wall ${GCC_EXTRA_OPTIONS} -pedantic -Wno-long-long ${yaml_cxx_flags}")
 
 	### Make specific
 	if(${CMAKE_BUILD_TOOL} MATCHES make OR ${CMAKE_BUILD_TOOL} MATCHES gmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,6 @@ set(YAML_CPP_VERSION_MINOR "6")
 set(YAML_CPP_VERSION_PATCH "0")
 set(YAML_CPP_VERSION "${YAML_CPP_VERSION_MAJOR}.${YAML_CPP_VERSION_MINOR}.${YAML_CPP_VERSION_PATCH}")
 
-enable_testing()
-
 
 ###
 ### Project options
@@ -351,6 +349,7 @@ endif()
 ### Extras
 ###
 if(YAML_CPP_BUILD_TESTS)
+	enable_testing()
 	add_subdirectory(test)
 endif()
 if(YAML_CPP_BUILD_TOOLS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,22 +3,8 @@
 ###
 # see http://www.cmake.org/Wiki/CMake_Policies
 cmake_minimum_required(VERSION 3.1)
-# see http://www.cmake.org/cmake/help/cmake-2-8-docs.html#policy:CMP0012
-if(POLICY CMP0012)
-	cmake_policy(SET CMP0012 OLD)
-endif()
-# see http://www.cmake.org/cmake/help/cmake-2-8-docs.html#policy:CMP0015
-if(POLICY CMP0015)
-	cmake_policy(SET CMP0015 OLD)
-endif()
-# see https://cmake.org/cmake/help/latest/policy/CMP0042.html
-if(POLICY CMP0042)
-	# Enable MACOSX_RPATH by default.
-	cmake_policy(SET CMP0042 NEW)
-endif()
 
 include(CheckCXXCompilerFlag)
-
 
 ###
 ### Project settings

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,26 +1,34 @@
 include(ExternalProject)
 
+if(MSVC)
+    # MS Visual Studio expects lib prefix on static libraries,
+    # but CMake compiles them without prefix
+    # See https://gitlab.kitware.com/cmake/cmake/issues/17338
+    set(CMAKE_STATIC_LIBRARY_PREFIX "")
+endif()
+
 ExternalProject_Add(
 	googletest_project
 	SOURCE_DIR "${CMAKE_SOURCE_DIR}/test/gtest-1.8.0"
 	INSTALL_DIR "${CMAKE_BINARY_DIR}/prefix"
-	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DBUILD_GMOCK=ON
+	CMAKE_ARGS
+		-DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+		-DBUILD_GMOCK=ON
+		-Dgtest_force_shared_crt=ON
 )
 
 add_library(gmock UNKNOWN IMPORTED)
 set_target_properties(gmock PROPERTIES
-	IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/prefix/lib/libgmock.a
+    IMPORTED_LOCATION
+    ${PROJECT_BINARY_DIR}/prefix/lib/${CMAKE_STATIC_LIBRARY_PREFIX}gmock${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
 
 find_package(Threads)
 
 include_directories(SYSTEM "${PROJECT_BINARY_DIR}/prefix/include")
 
-set(gtest_force_shared_crt ${MSVC_SHARED_RT} CACHE BOOL
-  "Use shared (DLL) run-time lib even when Google Test built as a static lib.")
-
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
-   CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	set(yaml_test_flags "-Wno-variadic-macros -Wno-sign-compare")
 
 	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -38,18 +46,18 @@ add_sources(${test_sources} ${test_headers})
 include_directories(${YAML_CPP_SOURCE_DIR}/test)
 
 add_executable(run-tests
-	${test_sources}
-	${test_headers}
+    ${test_sources}
+    ${test_headers}
 )
 
 add_dependencies(run-tests googletest_project)
 
 set_target_properties(run-tests PROPERTIES
-  COMPILE_FLAGS "${yaml_c_flags} ${yaml_cxx_flags} ${yaml_test_flags}"
+    COMPILE_FLAGS "${yaml_c_flags} ${yaml_cxx_flags} ${yaml_test_flags}"
 )
 target_link_libraries(run-tests
-	yaml-cpp
-	gmock
-	${CMAKE_THREAD_LIBS_INIT})
+    yaml-cpp
+    gmock
+    ${CMAKE_THREAD_LIBS_INIT})
 
 add_test(yaml-test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run-tests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,12 +15,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(yaml_test_flags "${yaml_test_flags} -Wno-c99-extensions")
   endif()
-
-  if(CMAKE_COMPILER_IS_GNUCXX)
-    set(yaml_test_flags "${yaml_test_flags} -std=gnu++11")
-  else()
-    set(yaml_test_flags "${yaml_test_flags} -std=c++11")
-  endif()
 endif()
 
 file(GLOB test_headers [a-z_]*.h)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,20 +1,31 @@
+include(ExternalProject)
+
+ExternalProject_Add(
+	googletest_project
+	SOURCE_DIR "${CMAKE_SOURCE_DIR}/test/gtest-1.8.0"
+	INSTALL_DIR "${CMAKE_BINARY_DIR}/prefix"
+	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -DBUILD_GMOCK=ON
+)
+
+add_library(gmock UNKNOWN IMPORTED)
+set_target_properties(gmock PROPERTIES
+	IMPORTED_LOCATION ${PROJECT_BINARY_DIR}/prefix/lib/libgmock.a
+)
+
+find_package(Threads)
+
+include_directories(SYSTEM "${PROJECT_BINARY_DIR}/prefix/include")
+
 set(gtest_force_shared_crt ${MSVC_SHARED_RT} CACHE BOOL
   "Use shared (DLL) run-time lib even when Google Test built as a static lib.")
-add_subdirectory(gtest-1.8.0)
-include_directories(SYSTEM gtest-1.8.0/googlemock/include)
-include_directories(SYSTEM gtest-1.8.0/googletest/include)
-
-if(WIN32 AND BUILD_SHARED_LIBS)
-  add_definitions("-DGTEST_LINKED_AS_SHARED_LIBRARY")
-endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
    CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(yaml_test_flags "-Wno-variadic-macros -Wno-sign-compare")
+	set(yaml_test_flags "-Wno-variadic-macros -Wno-sign-compare")
 
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(yaml_test_flags "${yaml_test_flags} -Wno-c99-extensions")
-  endif()
+	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		set(yaml_test_flags "${yaml_test_flags} -Wno-c99-extensions")
+	endif()
 endif()
 
 file(GLOB test_headers [a-z_]*.h)
@@ -30,9 +41,15 @@ add_executable(run-tests
 	${test_sources}
 	${test_headers}
 )
+
+add_dependencies(run-tests googletest_project)
+
 set_target_properties(run-tests PROPERTIES
   COMPILE_FLAGS "${yaml_c_flags} ${yaml_cxx_flags} ${yaml_test_flags}"
 )
-target_link_libraries(run-tests yaml-cpp gmock)
+target_link_libraries(run-tests
+	yaml-cpp
+	gmock
+	${CMAKE_THREAD_LIBS_INIT})
 
 add_test(yaml-test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run-tests)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,14 +1,12 @@
 add_sources(parse.cpp)
 add_executable(parse parse.cpp)
 target_link_libraries(parse yaml-cpp)
-set_target_properties(parse PROPERTIES COMPILE_FLAGS "-std=c++11")
 
 add_sources(sandbox.cpp)
 add_executable(sandbox sandbox.cpp)
 target_link_libraries(sandbox yaml-cpp)
-set_target_properties(sandbox PROPERTIES COMPILE_FLAGS "-std=c++11")
 
 add_sources(read.cpp)
 add_executable(read read.cpp)
 target_link_libraries(read yaml-cpp)
-set_target_properties(read PROPERTIES COMPILE_FLAGS "-std=c++11")
+


### PR DESCRIPTION
Various improvements to CMake buildsystem:

* Raised minimal CMake version to 3.1 and added in-built c++11 compiler checks (#377). Since yaml-cpp requires decent compilers that supports c++11, cmake 2.6 requirement becomes useless for old systems.
* Remove cmake_policies (#505), those policies are deprecated or already defined to NEW behavior.
* Externalize GTest subproject (#539), now shared libgmock and libgtest are excluded from installation step.