### PR TITLE
additional unittest for aliases

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,4 +41,5 @@ set_target_properties(run-tests PROPERTIES
 )
 target_link_libraries(run-tests yaml-cpp gmock)
 
-add_test(yaml-test ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/run-tests)
+add_test(NAME yaml-test COMMAND run-tests
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -78,6 +78,36 @@ TEST(LoadNodeTest, IterateMap) {
   EXPECT_EQ(3, i);
 }
 
+TEST(LoadNodeTest, AliasAccess) {
+  const Node doc = Load("{A: &DEFAULT {str: string, int: 42, float: 3.1415}, B: *DEFAULT}");
+  const Node& A = doc["A"];
+  const Node& B = doc["B"];
+
+  // A and B have the same content
+  ASSERT_TRUE(A);
+  ASSERT_TRUE(A.IsMap());
+  ASSERT_TRUE(B);
+  ASSERT_TRUE(B.IsMap());
+
+  // A and B have the same content
+  std::map<std::string, std::string> values = {{"str", "string"}, {"float", "3.1415"}, {"int", "42"}};
+  for (YAML::const_iterator it = A.begin(); it != A.end(); ++it) {
+    const std::string& key = it->first.as<std::string>();
+    SCOPED_TRACE("key " + key);
+    const Node& a = A[key];
+    const Node& b = B[key];
+    EXPECT_TRUE(a);
+    EXPECT_TRUE(b);
+    EXPECT_TRUE(a.IsScalar());
+    EXPECT_TRUE(b.IsScalar());
+
+    // a and b should be identical
+    EXPECT_EQ(a.as<std::string>(), b.as<std::string>());
+    // ... and have the values given in the map
+    EXPECT_EQ(a.as<std::string>(), values[key]);
+  }
+}
+
 #ifdef BOOST_FOREACH
 TEST(LoadNodeTest, ForEach) {
   Node node = Load("[1, 3, 5, 7]");


### PR DESCRIPTION
I'm having trouble with accessing values in a yaml file like this:
```yaml
A: &DEFAULT
  str: string
  float: 3.1415
  int: 42
B: *DEFAULT
```
For some reason, in my application, accessing values `B[key]` fails, while `A[key]` succeeds. For this reason, I thought there might be an issue in yaml-cpp and implemented appropriate unittests with a minimal example. However, the unittests work as expected. Now idea, how to proceed now...
Nevertheless, the unittests might be interesting to you anyway. If haven't found particular tests for aliases/references.