### PR TITLE
Update the iterator implementation for C++17

### DIFF
--- a/include/yaml-cpp/node/detail/iterator.h
+++ b/include/yaml-cpp/node/detail/iterator.h
@@ -19,8 +19,7 @@ namespace detail {
 struct iterator_value;
 
 template <typename V>
-class iterator_base : public std::iterator<std::forward_iterator_tag, V,
-                                           std::ptrdiff_t, V*, V> {
+class iterator_base {
 
  private:
   template <typename>
@@ -37,8 +36,11 @@ class iterator_base : public std::iterator<std::forward_iterator_tag, V,
   };
 
  public:
-  typedef typename iterator_base::value_type value_type;
-
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = V;
+  using difference_type = std::ptrdiff_t;
+  using pointer = V * ;
+  using reference = V;
  public:
   iterator_base() : m_iterator(), m_pMemory() {}
   explicit iterator_base(base_type rhs, shared_memory_holder pMemory)

--- a/include/yaml-cpp/node/detail/iterator.h
+++ b/include/yaml-cpp/node/detail/iterator.h
@@ -8,11 +8,12 @@
 #endif
 
 #include "yaml-cpp/dll.h"
+#include "yaml-cpp/node/detail/node_iterator.h"
 #include "yaml-cpp/node/node.h"
 #include "yaml-cpp/node/ptr.h"
-#include "yaml-cpp/node/detail/node_iterator.h"
 #include <cstddef>
 #include <iterator>
+
 
 namespace YAML {
 namespace detail {
@@ -39,8 +40,9 @@ class iterator_base {
   using iterator_category = std::forward_iterator_tag;
   using value_type = V;
   using difference_type = std::ptrdiff_t;
-  using pointer = V * ;
+  using pointer = V*;
   using reference = V;
+
  public:
   iterator_base() : m_iterator(), m_pMemory() {}
   explicit iterator_base(base_type rhs, shared_memory_holder pMemory)
@@ -88,7 +90,7 @@ class iterator_base {
   base_type m_iterator;
   shared_memory_holder m_pMemory;
 };
-}
-}
+}  // namespace detail
+}  // namespace YAML
 
 #endif  // VALUE_DETAIL_ITERATOR_H_62B23520_7C8E_11DE_8A39_0800200C9A66


### PR DESCRIPTION
Issue related: #574 

### Problem solved
std does not need user to derive `std::iterator` when they try to implement there own iterator, in C++17, this will cause compiler error unless `_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING` is defined in the code, which supress the warning.

### What I did
I got rid of the base class for `iterator_base`, and declared several type defs, according to the standard requirement.

### compatibality
I only ran the test on my own machine(win10, VS 2017), all passed with several tests skipped(Which I think is configured with intention?). Since this is an platform indepentent issue, I did not test it on other platform and I expect it should be fine on other platform. I will be very glad to fix any problem if one shows up.


Thank you very much :D
