### PR TITLE
Fix clang error: a space is required between '>>'

### DIFF
--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -97,7 +97,7 @@ const char* const BAD_FILE = "bad file";
 
 template <typename T>
 inline const std::string KEY_NOT_FOUND_WITH_KEY(
-    const T&, typename disable_if<is_numeric<T>>::type* = 0) {
+    const T&, typename disable_if<is_numeric<T> >::type* = 0) {
   return KEY_NOT_FOUND;
 }
 
@@ -109,7 +109,7 @@ inline const std::string KEY_NOT_FOUND_WITH_KEY(const std::string& key) {
 
 template <typename T>
 inline const std::string KEY_NOT_FOUND_WITH_KEY(
-    const T& key, typename enable_if<is_numeric<T>>::type* = 0) {
+    const T& key, typename enable_if<is_numeric<T> >::type* = 0) {
   std::stringstream stream;
   stream << KEY_NOT_FOUND << ": " << key;
   return stream.str();

--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -163,7 +163,7 @@ struct convert<bool> {
 
 // std::map
 template <typename K, typename V>
-struct convert<std::map<K, V>> {
+struct convert<std::map<K, V> > {
   static Node encode(const std::map<K, V>& rhs) {
     Node node(NodeType::Map);
     for (typename std::map<K, V>::const_iterator it = rhs.begin();
@@ -190,7 +190,7 @@ struct convert<std::map<K, V>> {
 
 // std::vector
 template <typename T>
-struct convert<std::vector<T>> {
+struct convert<std::vector<T> > {
   static Node encode(const std::vector<T>& rhs) {
     Node node(NodeType::Sequence);
     for (typename std::vector<T>::const_iterator it = rhs.begin();
@@ -217,7 +217,7 @@ struct convert<std::vector<T>> {
 
 // std::list
 template <typename T>
-struct convert<std::list<T>> {
+struct convert<std::list<T> > {
   static Node encode(const std::list<T>& rhs) {
     Node node(NodeType::Sequence);
     for (typename std::list<T>::const_iterator it = rhs.begin();
@@ -244,7 +244,7 @@ struct convert<std::list<T>> {
 
 // std::array
 template <typename T, std::size_t N>
-struct convert<std::array<T, N>> {
+struct convert<std::array<T, N> > {
   static Node encode(const std::array<T, N>& rhs) {
     Node node(NodeType::Sequence);
     for (const auto& element : rhs) {
@@ -277,7 +277,7 @@ struct convert<std::array<T, N>> {
 
 // std::pair
 template <typename T, typename U>
-struct convert<std::pair<T, U>> {
+struct convert<std::pair<T, U> > {
   static Node encode(const std::pair<T, U>& rhs) {
     Node node(NodeType::Sequence);
     node.push_back(rhs.first);

--- a/include/yaml-cpp/node/detail/node_data.h
+++ b/include/yaml-cpp/node/detail/node_data.h
@@ -114,7 +114,7 @@ class YAML_CPP_API node_data {
   mutable std::size_t m_seqSize;
 
   // map
-  typedef std::vector<std::pair<node*, node*>> node_map;
+  typedef std::vector<std::pair<node*, node*> > node_map;
   node_map m_map;
 
   typedef std::pair<node*, node*> kv_pair;

--- a/include/yaml-cpp/node/detail/node_iterator.h
+++ b/include/yaml-cpp/node/detail/node_iterator.h
@@ -37,7 +37,7 @@ struct node_iterator_value : public std::pair<V*, V*> {
 };
 
 typedef std::vector<node*> node_seq;
-typedef std::vector<std::pair<node*, node*>> node_map;
+typedef std::vector<std::pair<node*, node*> > node_map;
 
 template <typename V>
 struct node_iterator_type {
@@ -55,7 +55,7 @@ template <typename V>
 class node_iterator_base
     : public std::iterator<std::forward_iterator_tag, node_iterator_value<V>,
                            std::ptrdiff_t, node_iterator_value<V>*,
-                           node_iterator_value<V>> {
+                           node_iterator_value<V> > {
  private:
   struct enabler {};
 


### PR DESCRIPTION
Full error: a space is required between consecutive right angle brackets (use '> >')