### PR TITLE
Fix _NOEXCEPT not available in VS2017 15.8. Use noexcept for VS2015+

### DIFF
--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -15,7 +15,7 @@
 
 // This is here for compatibility with older versions of Visual Studio
 // which don't support noexcept
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1900
     #define YAML_CPP_NOEXCEPT _NOEXCEPT
 #else
     #define YAML_CPP_NOEXCEPT noexcept

--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -2,7 +2,7 @@
 
 // This is here for compatibility with older versions of Visual Studio
 // which don't support noexcept
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1900
     #define YAML_CPP_NOEXCEPT _NOEXCEPT
 #else
     #define YAML_CPP_NOEXCEPT noexcept


### PR DESCRIPTION
Visual Studio 2017 15.8 no longer defines _NOEXCEPT, leading to several of these:
`error C3646: '_NOEXCEPT': unknown override specifier`

`noexcept` is defined in VS2015+ (reference: [link](https://msdn.microsoft.com/en-us/library/wfa0edys.aspx))
This PR changes the YAML_CPP_NOEXCEPT to be defined as `noexcept` for VS2015+.

We used the same patch in vcpkg to resolve the issue: [link](https://github.com/Microsoft/vcpkg/commit/239b35330152a4813e1b5575bd8b1b01c9bba9d5)


edit: `_MSC_VER` values: [link](https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering)
