### PR TITLE
Fixes -Wmaybe-uninitialized warning

### DIFF
--- a/src/regex_yaml.h
+++ b/src/regex_yaml.h
@@ -77,10 +77,11 @@ class YAML_CPP_API RegEx {
 
  private:
   REGEX_OP m_op;
-  char m_a, m_z;
+  char m_a{};
+  char m_z{};
   std::vector<RegEx> m_params;
 };
-}
+}  // namespace YAML
 
 #include "regeximpl.h"
 


### PR DESCRIPTION
Vanilla build reports
```
In file included from /path/to/yaml-cpp/src/regex_yaml.cpp:1:0:
/path/to/yaml-cpp/src/regex_yaml.h: In constructor 'YAML::RegEx::RegEx(const string&, YAML::REGEX_OP)':
/path/to/yaml-cpp/src/regex_yaml.h:31:20: warning: '<anonymous>.YAML::RegEx::m_z' may be used uninitialized in this function [-Wmaybe-uninitialized]
 class YAML_CPP_API RegEx {
                    ^~~~~
```
on GCC 7.3.0. This is fixed by explicitly initialising the member `char`s.