### PR TITLE
Fix using 0 instead of nullptr in required places (clang-tidy warns)

### DIFF
--- a/src/contrib/graphbuilder.cpp
+++ b/src/contrib/graphbuilder.cpp
@@ -11,7 +11,7 @@ void* BuildGraphOfNextDocument(Parser& parser,
   if (parser.HandleNextDocument(eventHandler)) {
     return eventHandler.RootNode();
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 }

--- a/src/contrib/graphbuilderadapter.cpp
+++ b/src/contrib/graphbuilderadapter.cpp
@@ -49,7 +49,7 @@ void GraphBuilderAdapter::OnMapStart(const Mark &mark, const std::string &tag,
                                      EmitterStyle::value /* style */) {
   void *pNode = m_builder.NewMap(mark, tag, GetCurrentParent());
   m_containers.push(ContainerFrame(pNode, m_pKeyNode));
-  m_pKeyNode = NULL;
+  m_pKeyNode = nullptr;
   RegisterAnchor(anchor, pNode);
 }
 
@@ -62,7 +62,7 @@ void GraphBuilderAdapter::OnMapEnd() {
 
 void *GraphBuilderAdapter::GetCurrentParent() const {
   if (m_containers.empty()) {
-    return NULL;
+    return nullptr;
   }
   return m_containers.top().pContainer;
 }
@@ -83,7 +83,7 @@ void GraphBuilderAdapter::DispositionNode(void *pNode) {
   if (m_containers.top().isMap()) {
     if (m_pKeyNode) {
       m_builder.AssignInMap(pContainer, m_pKeyNode, pNode);
-      m_pKeyNode = NULL;
+      m_pKeyNode = nullptr;
     } else {
       m_pKeyNode = pNode;
     }

--- a/src/contrib/graphbuilderadapter.h
+++ b/src/contrib/graphbuilderadapter.h
@@ -26,7 +26,7 @@ namespace YAML {
 class GraphBuilderAdapter : public EventHandler {
  public:
   GraphBuilderAdapter(GraphBuilderInterface& builder)
-      : m_builder(builder), m_pRootNode(NULL), m_pKeyNode(NULL) {}
+      : m_builder(builder), m_pRootNode(nullptr), m_pKeyNode(nullptr) {}
 
   virtual void OnDocumentStart(const Mark& mark) { (void)mark; }
   virtual void OnDocumentEnd() {}

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -197,7 +197,7 @@ void node_data::insert(node& key, node& value, shared_memory_holder pMemory) {
 // indexing
 node* node_data::get(node& key, shared_memory_holder /* pMemory */) const {
   if (m_type != NodeType::Map) {
-    return NULL;
+    return nullptr;
   }
 
   for (node_map::const_iterator it = m_map.begin(); it != m_map.end(); ++it) {
@@ -205,7 +205,7 @@ node* node_data::get(node& key, shared_memory_holder /* pMemory */) const {
       return it->second;
   }
 
-  return NULL;
+  return nullptr;
 }
 
 node& node_data::get(node& key, shared_memory_holder pMemory) {

--- a/src/nodebuilder.cpp
+++ b/src/nodebuilder.cpp
@@ -11,8 +11,8 @@ namespace YAML {
 struct Mark;
 
 NodeBuilder::NodeBuilder()
-    : m_pMemory(new detail::memory_holder), m_pRoot(0), m_mapDepth(0) {
-  m_anchors.push_back(0);  // since the anchors start at 1
+    : m_pMemory(new detail::memory_holder), m_pRoot(nullptr), m_mapDepth(0) {
+  m_anchors.push_back(nullptr);  // since the anchors start at 1
 }
 
 NodeBuilder::~NodeBuilder() {}

--- a/src/ostream_wrapper.cpp
+++ b/src/ostream_wrapper.cpp
@@ -7,7 +7,7 @@
 namespace YAML {
 ostream_wrapper::ostream_wrapper()
     : m_buffer(1, '\0'),
-      m_pStream(0),
+      m_pStream(nullptr),
       m_pos(0),
       m_row(0),
       m_col(0),

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -282,7 +282,7 @@ Scanner::IndentMarker* Scanner::PushIndentTo(int column,
                                              IndentMarker::INDENT_TYPE type) {
   // are we in flow?
   if (InFlowContext()) {
-    return 0;
+    return nullptr;
   }
 
   std::unique_ptr<IndentMarker> pIndent(new IndentMarker(column, type));
@@ -291,12 +291,12 @@ Scanner::IndentMarker* Scanner::PushIndentTo(int column,
 
   // is this actually an indentation?
   if (indent.column < lastIndent.column) {
-    return 0;
+    return nullptr;
   }
   if (indent.column == lastIndent.column &&
       !(indent.type == IndentMarker::SEQ &&
         lastIndent.type == IndentMarker::MAP)) {
-    return 0;
+    return nullptr;
   }
 
   // push a start token

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -49,7 +49,7 @@ class Scanner {
     enum INDENT_TYPE { MAP, SEQ, NONE };
     enum STATUS { VALID, INVALID, UNKNOWN };
     IndentMarker(int column_, INDENT_TYPE type_)
-        : column(column_), type(type_), status(VALID), pStartToken(0) {}
+        : column(column_), type(type_), status(VALID), pStartToken(nullptr) {}
 
     int column;
     INDENT_TYPE type;

--- a/src/simplekey.cpp
+++ b/src/simplekey.cpp
@@ -5,7 +5,7 @@ namespace YAML {
 struct Mark;
 
 Scanner::SimpleKey::SimpleKey(const Mark& mark_, std::size_t flowLevel_)
-    : mark(mark_), flowLevel(flowLevel_), pIndent(0), pMapStart(0), pKey(0) {}
+    : mark(mark_), flowLevel(flowLevel_), pIndent(nullptr), pMapStart(nullptr), pKey(nullptr) {}
 
 void Scanner::SimpleKey::Validate() {
   // Note: pIndent will *not* be garbage here;


### PR DESCRIPTION
This PR fixes nullptr warnings from Clang-Tidy tool