### PR TITLE
Skip newlines in binary decoding (Fix #387)

### DIFF
--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -72,19 +72,21 @@ std::vector<unsigned char> DecodeBase64(const std::string &input) {
   unsigned char *out = &ret[0];
 
   unsigned value = 0;
-  for (std::size_t i = 0; i < input.size(); i++) {
+  for (std::size_t i = 0, cnt = 0; i < input.size(); i++) {
+    if (input[i] == '\n' || input[i] == '\r') continue; // skip newlines
     unsigned char d = decoding[static_cast<unsigned>(input[i])];
     if (d == 255)
       return ret_type();
 
     value = (value << 6) | d;
-    if (i % 4 == 3) {
+    if (cnt % 4 == 3) {
       *out++ = value >> 16;
       if (i > 0 && input[i - 1] != '=')
         *out++ = value >> 8;
       if (input[i] != '=')
         *out++ = value;
     }
+    ++cnt;
   }
 
   ret.resize(out - &ret[0]);

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -75,7 +75,10 @@ std::vector<unsigned char> DecodeBase64(const std::string &input) {
 
   unsigned value = 0;
   for (std::size_t i = 0, cnt = 0; i < input.size(); i++) {
-    if (isspace(input[i])) continue; // skip newlines
+    if (std::isspace(input[i])) {
+      // skip newlines
+      continue;
+    }
     unsigned char d = decoding[static_cast<unsigned>(input[i])];
     if (d == 255)
       return ret_type();

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -1,5 +1,7 @@
 #include "yaml-cpp/binary.h"
 
+#include <ctype.h>
+
 namespace YAML {
 static const char encoding[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -73,7 +75,7 @@ std::vector<unsigned char> DecodeBase64(const std::string &input) {
 
   unsigned value = 0;
   for (std::size_t i = 0, cnt = 0; i < input.size(); i++) {
-    if (input[i] == '\n' || input[i] == '\r') continue; // skip newlines
+    if (isspace(input[i])) continue; // skip newlines
     unsigned char d = decoding[static_cast<unsigned>(input[i])];
     if (d == 255)
       return ret_type();

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -55,6 +55,26 @@ TEST(LoadNodeTest, Binary) {
             node[1].as<Binary>());
 }
 
+TEST(LoadNodeTest, BinaryWithWhitespaces) {
+  Node node = Load(
+      "binaryText: !binary |-\n"
+      "  TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieS\n"
+      "  B0aGlzIHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIG\n"
+      "  x1c3Qgb2YgdGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbi\n"
+      "  B0aGUgY29udGludWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZG\n"
+      "  dlLCBleGNlZWRzIHRoZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS\n"
+      "  4K");
+  EXPECT_EQ(Binary(reinterpret_cast<const unsigned char*>(
+                       "Man is distinguished, not only by his reason, "
+                       "but by this singular passion from other "
+                       "animals, which is a lust of the mind, that by "
+                       "a perseverance of delight in the continued and "
+                       "indefatigable generation of knowledge, exceeds "
+                       "the short vehemence of any carnal pleasure.\n"),
+                   270),
+            node["binaryText"].as<Binary>());
+}
+
 TEST(LoadNodeTest, IterateSequence) {
   Node node = Load("[1, 3, 5, 7]");
   int seq[] = {1, 3, 5, 7};


### PR DESCRIPTION
This fixes #387
