### PR TITLE
Bugfix - include file

### DIFF
--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -1,6 +1,6 @@
 #include "yaml-cpp/binary.h"
 
-#include <ctype.h>
+#include <cctype>
 
 namespace YAML {
 static const char encoding[] =


### PR DESCRIPTION
https://github.com/jbeder/yaml-cpp/commit/45d9035a331c947e492caa70487d3b838327ec35 introduced a compile error on Visual Studio 2015. The C header file *ctype.h* does not put functions (isspace) in namespace std.

This corrects the include and fixes the error.