### PR TITLE
Export only YAML_CPP_API-tagged symbols on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,14 @@ if(WIN32)
 	endif()
 endif()
 
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+	set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+	if (POLICY CMP0063)
+		cmake_policy(SET CMP0063 NEW)
+	endif()
+	add_definitions(-DYAML_CPP_USE_VISIBILITY)
+endif()
+
 # GCC or Clang or Intel Compiler specialities
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
    CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR

--- a/include/yaml-cpp/dll.h
+++ b/include/yaml-cpp/dll.h
@@ -27,7 +27,11 @@
 #define YAML_CPP_API __declspec(dllimport)
 #endif  // yaml_cpp_EXPORTS
 #else   // YAML_CPP_DLL
+#ifdef YAML_CPP_USE_VISIBILITY
+#define YAML_CPP_API __attribute__ ((visibility("default")))
+#else
 #define YAML_CPP_API
+#endif // YAML_CPP_USE_VISIBILITY
 #endif  // YAML_CPP_DLL
 
 #endif  // DLL_H_62B23520_7C8E_11DE_8A39_0800200C9A66


### PR DESCRIPTION
Mark classes tagged with YAML_CPP_API with visibility("default"), to explicitly export them, and then hide everything else via `-fvisibility=hidden`.

This reduces the number of exported symbols by more than 50%, which has a small application start-up time and memory useage benefit. It also makes it more feasible to audit the set of exported symbols in automated ABI compatibility systems.