### PR TITLE
Fix GCC-types flags appended on Clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ endif()
 
 # GCC or Clang or Intel Compiler specialities
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
-   CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
+   (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT "x${CMAKE_CXX_SIMULATE_ID}" STREQUAL "xMSVC") OR
    CMAKE_CXX_COMPILER_ID MATCHES "Intel")
 
 	### General stuff


### PR DESCRIPTION
Clang-cl actually uses MSVC compile flags, not GCC-style compile flags.

Some GCC compile flags got mixed in clang-cl and makes yaml-cpp not linkable in both Debug and Release mode.

This PR strengthens the check, not appending the GCC flags when we are at CL mode.