### PR TITLE
Added dummy function with C linkage so that configure scripts can link against yaml-cpp

### DIFF
--- a/include/yaml-cpp/dummy.h
+++ b/include/yaml-cpp/dummy.h
@@ -1,0 +1,12 @@
+#ifndef DUMMY_H_62B23520_7C8E_11DE_8A39_0800200C9A66
+#define DUMMY_H_62B23520_7C8E_11DE_8A39_0800200C9A66
+
+#if defined(_MSC_VER) ||                                            \
+    (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
+     (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
+#pragma once
+#endif
+
+extern "C" void dummyfunc_for_configure();
+
+#endif  // DUMMY_H_62B23520_7C8E_11DE_8A39_0800200C9A66

--- a/include/yaml-cpp/yaml.h
+++ b/include/yaml-cpp/yaml.h
@@ -20,5 +20,6 @@
 #include "yaml-cpp/node/detail/impl.h"
 #include "yaml-cpp/node/parse.h"
 #include "yaml-cpp/node/emit.h"
+#include "yaml-cpp/dummy.h"
 
 #endif  // YAML_H_62B23520_7C8E_11DE_8A39_0800200C9A66

--- a/src/dummy.cpp
+++ b/src/dummy.cpp
@@ -1,0 +1,6 @@
+#include "yaml-cpp/dummy.h"
+
+void dummyfunc_for_configure()
+{
+  return;
+}


### PR DESCRIPTION
I am sure there is a way to write a configure macro to detect libyaml-cpp but it seems very hard to find the correct macros. 
That is why I am introducing a dummy function that can be linked and checked against.