### PR TITLE
Suppress warning C4127

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -116,10 +116,11 @@ struct convert<_Null> {
         }                                                                \
       }                                                                  \
                                                                          \
-      if (std::numeric_limits<type>::has_quiet_NaN &&                    \
-          conversion::IsNaN(input)) {                                    \
-        rhs = std::numeric_limits<type>::quiet_NaN();                    \
-        return true;                                                     \
+      if (std::numeric_limits<type>::has_quiet_NaN) {                    \
+        if (conversion::IsNaN(input)) {                                  \
+          rhs = std::numeric_limits<type>::quiet_NaN();                  \
+          return true;                                                   \
+        }                                                                \
       }                                                                  \
                                                                          \
       return false;                                                      \


### PR DESCRIPTION
Closes #670

Splitting the condition of the if statement containing `constant expression` eliminates warnings in Visual Studio with /W4.