### PR TITLE
Fix ninja build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,11 +175,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
 
 	### Make specific
 	if(${CMAKE_BUILD_TOOL} MATCHES make OR ${CMAKE_BUILD_TOOL} MATCHES gmake)
-		add_custom_target(debuggable $(MAKE) clean
+		add_custom_target(debuggable ${CMAKE_MAKE_PROGRAM} clean
 			COMMAND ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=Debug ${CMAKE_SOURCE_DIR}
 			COMMENT "Adjusting settings for debug compilation"
 			VERBATIM)
-		add_custom_target(releasable $(MAKE) clean
+		add_custom_target(releasable ${CMAKE_MAKE_PROGRAM} clean
 			COMMAND ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=Release ${CMAKE_SOURCE_DIR}
 			COMMENT "Adjusting settings for release compilation"
 			VERBATIM)


### PR DESCRIPTION
NDK now uses ninja for building but yaml-cpp would emit the `ninja: error: build.ninja:326: bad $-escape (literal $ must be written as $$)` error due to syntax error in the generated build.ninja file. Related issue: https://github.com/jbeder/yaml-cpp/issues/630