### PR TITLE
moved move/copyop to cpp for MSVC

### DIFF
--- a/include/yaml-cpp/parser.h
+++ b/include/yaml-cpp/parser.h
@@ -28,10 +28,11 @@ class YAML_CPP_API Parser {
   /** Constructs an empty parser (with no input. */
   Parser();
 
+  /** non copyable but movable */
   Parser(const Parser&) = delete;
-  Parser(Parser&&) = delete;
   Parser& operator=(const Parser&) = delete;
-  Parser& operator=(Parser&&) = delete;
+  Parser(Parser&&); // = default // moved to cpp for MSVC
+  Parser& operator=(Parser&&); // = default // moved to cpp for MSVC
 
   /**
    * Constructs a parser from the given input stream. The input stream must

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -17,6 +17,9 @@ Parser::Parser(std::istream& in) : Parser() { Load(in); }
 
 Parser::~Parser() {}
 
+Parser::Parser(Parser&&) = default;
+Parser& Parser::operator=(Parser&&) = default;
+
 Parser::operator bool() const {
   return m_pScanner.get() && !m_pScanner->empty();
 }


### PR DESCRIPTION
Replacing https://github.com/jbeder/yaml-cpp/pull/690