### PR TITLE
Travis CI: Discover Python syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,8 @@ matrix:
   exclude:
   - os: linux
     compiler: clang
+  include:
+  - language: python
+    before_install: pip install flake8
+    before_script: true
+    script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
test/gtest-1.8.0 is not Python 3 compatible https://travis-ci.org/jbeder/yaml-cpp/jobs/552724169#L183