### PR TITLE
Make sure output of NaN, Infinity and -Infinity is identical on all platforms

### DIFF
--- a/include/yaml-cpp/emitter.h
+++ b/include/yaml-cpp/emitter.h
@@ -161,7 +161,7 @@ inline Emitter& Emitter::WriteStreamable(T value) {
   if (std::is_floating_point_v<T>) {
     if ((std::numeric_limits<T>::has_quiet_NaN ||
          std::numeric_limits<T>::has_signaling_NaN) &&
-        value != value) {
+        std::isnan(value)) {
       special = true;
       stream << ".nan";
     } else if (std::numeric_limits<T>::has_infinity) {

--- a/include/yaml-cpp/emitter.h
+++ b/include/yaml-cpp/emitter.h
@@ -158,7 +158,7 @@ inline Emitter& Emitter::WriteStreamable(T value) {
   SetStreamablePrecision<T>(stream);
 
   bool special = false;
-  if (std::is_floating_point_v<T>) {
+  if (std::is_floating_point<T>::value) {
     if ((std::numeric_limits<T>::has_quiet_NaN ||
          std::numeric_limits<T>::has_signaling_NaN) &&
         std::isnan(value)) {

--- a/include/yaml-cpp/emitter.h
+++ b/include/yaml-cpp/emitter.h
@@ -7,6 +7,7 @@
 #pragma once
 #endif
 
+#include <cmath>
 #include <cstddef>
 #include <limits>
 #include <memory>
@@ -158,10 +159,9 @@ inline Emitter& Emitter::WriteStreamable(T value) {
 
   bool special = false;
   if (std::is_floating_point_v<T>) {
-    if ((std::numeric_limits<T>::has_quiet_NaN &&
-         value == std::numeric_limits<T>::quiet_NaN()) ||
-        (std::numeric_limits<T>::has_signaling_NaN &&
-         value == std::numeric_limits<T>::signaling_NaN())) {
+    if ((std::numeric_limits<T>::has_quiet_NaN ||
+         std::numeric_limits<T>::has_signaling_NaN) &&
+        value != value) {
       special = true;
       stream << ".nan";
     } else if (std::numeric_limits<T>::has_infinity) {

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -253,8 +253,9 @@ TEST_F(EmitterTest, ScalarFormat) {
   out << DoubleQuoted << "explicit double-quoted scalar";
   out << "auto-detected\ndouble-quoted scalar";
   out << "a non-\"auto-detected\" double-quoted scalar";
-  out << Literal << "literal scalar\nthat may span\nmany, many\nlines "
-                    "and have \"whatever\" crazy\tsymbols that we like";
+  out << Literal
+      << "literal scalar\nthat may span\nmany, many\nlines "
+         "and have \"whatever\" crazy\tsymbols that we like";
   out << EndSeq;
 
   ExpectEmit(
@@ -526,9 +527,10 @@ TEST_F(EmitterTest, SimpleComment) {
 
 TEST_F(EmitterTest, MultiLineComment) {
   out << BeginSeq;
-  out << "item 1" << Comment(
-                         "really really long\ncomment that couldn't "
-                         "possibly\nfit on one line");
+  out << "item 1"
+      << Comment(
+             "really really long\ncomment that couldn't "
+             "possibly\nfit on one line");
   out << "item 2";
   out << EndSeq;
 
@@ -984,6 +986,33 @@ TEST_F(EmitterTest, ValueOfBackslash) {
   ExpectEmit("foo: \"\\\\\"");
 }
 
+TEST_F(EmitterTest, Infinity) {
+  out << YAML::BeginMap;
+  out << YAML::Key << "foo" << YAML::Value
+      << std::numeric_limits<float>::infinity();
+  out << YAML::EndMap;
+
+  ExpectEmit("foo: .inf");
+}
+
+TEST_F(EmitterTest, NegInfinity) {
+  out << YAML::BeginMap;
+  out << YAML::Key << "foo" << YAML::Value
+      << -std::numeric_limits<float>::infinity();
+  out << YAML::EndMap;
+
+  ExpectEmit("foo: -.inf");
+}
+
+TEST_F(EmitterTest, NaN) {
+  out << YAML::BeginMap;
+  out << YAML::Key << "foo" << YAML::Value
+      << -std::numeric_limits<float>::quiet_NaN();
+  out << YAML::EndMap;
+
+  ExpectEmit("foo: .nan");
+}
+
 class EmitterErrorTest : public ::testing::Test {
  protected:
   void ExpectEmitError(const std::string& expectedError) {
@@ -1034,5 +1063,5 @@ TEST_F(EmitterErrorTest, InvalidAlias) {
 
   ExpectEmitError(ErrorMsg::INVALID_ALIAS);
 }
-}
-}
+}  // namespace
+}  // namespace YAML

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -990,27 +990,39 @@ TEST_F(EmitterTest, Infinity) {
   out << YAML::BeginMap;
   out << YAML::Key << "foo" << YAML::Value
       << std::numeric_limits<float>::infinity();
+  out << YAML::Key << "bar" << YAML::Value
+      << std::numeric_limits<double>::infinity();
   out << YAML::EndMap;
 
-  ExpectEmit("foo: .inf");
+  ExpectEmit(
+	  "foo: .inf\n"
+	  "bar: .inf");
 }
 
 TEST_F(EmitterTest, NegInfinity) {
   out << YAML::BeginMap;
   out << YAML::Key << "foo" << YAML::Value
       << -std::numeric_limits<float>::infinity();
+  out << YAML::Key << "bar" << YAML::Value
+      << -std::numeric_limits<double>::infinity();
   out << YAML::EndMap;
 
-  ExpectEmit("foo: -.inf");
+  ExpectEmit(
+	  "foo: -.inf\n"
+	  "bar: -.inf");
 }
 
 TEST_F(EmitterTest, NaN) {
   out << YAML::BeginMap;
   out << YAML::Key << "foo" << YAML::Value
-      << -std::numeric_limits<float>::quiet_NaN();
+      << std::numeric_limits<float>::quiet_NaN();
+  out << YAML::Key << "bar" << YAML::Value
+      << std::numeric_limits<double>::quiet_NaN();
   out << YAML::EndMap;
 
-  ExpectEmit("foo: .nan");
+  ExpectEmit(
+	  "foo: .nan\n"
+	  "bar: .nan");
 }
 
 class EmitterErrorTest : public ::testing::Test {


### PR DESCRIPTION
Since the stream output of these special floating point values are implementation defined, .nan, .inf and -.inf were emitted without dots on some platforms.