### PR TITLE
Bazel Support (#722)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 /tags
+/bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,14 @@
+cc_library(
+    name = "yaml-cpp_internal",
+    visibility = ["//:__subpackages__"],
+    strip_include_prefix = "src",
+    hdrs = glob(["src/**/*.h"]),
+)
+
+cc_library(
+    name = "yaml-cpp",
+    visibility = ["//visibility:public"],
+    strip_include_prefix = "include",
+    hdrs = glob(["include/**/*.h"]),
+    srcs = glob(["src/**/*.cpp", "src/**/*.h"]),
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,10 @@
+workspace(name = "com_github_jbeder_yaml_cpp")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "com_google_googletest",
+    strip_prefix = "googletest-release-1.8.1",
+    url = "https://github.com/google/googletest/archive/release-1.8.1.tar.gz",
+    sha256 = "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c",
+)

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,0 +1,14 @@
+cc_test(
+    name = "test",
+    srcs = glob([
+        "*.cpp",
+        "*.h",
+        "integrations/*.cpp",
+        "node/*.cpp",
+    ]),
+    deps = [
+        "//:yaml-cpp",
+        "//:yaml-cpp_internal",
+        "@com_google_googletest//:gtest_main",
+    ],
+)


### PR DESCRIPTION
closes https://github.com/jbeder/yaml-cpp/issues/722

Example of how someone might consume yaml-cpp with bazel

```python
cc_binary(
    name = "example",
    srcs = ["example.cc"],
    deps = ["@com_github_jbeder_yaml_cpp//:yaml-cpp"],
)
```