### PR TITLE
changed cmake version from 3.x to 2.8 for centos 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 ### CMake settings
 ###
 # see http://www.cmake.org/Wiki/CMake_Policies
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 2.8)
 
 include(CheckCXXCompilerFlag)
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 2.8)
 
 add_sources(parse.cpp)
 add_executable(parse parse.cpp)


### PR DESCRIPTION
I did not see a good reason to require make 3.x
builds fine on lentos 7 with this change. 