### PR TITLE
CMake: Avoid setting options that infect parent project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,10 +32,6 @@ option(YAML_CPP_INSTALL "Enable generation of install target" ON)
 #     http://www.cmake.org/cmake/help/cmake2.6docs.html#command:add_library
 option(BUILD_SHARED_LIBS "Build Shared Libraries" OFF)
 
-# Set minimum C++ to 2011 standards
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # --> Apple
 option(APPLE_UNIVERSAL_BIN "Apple: Build universal binary" OFF)
 
@@ -266,6 +262,11 @@ if (NOT CMAKE_VERSION VERSION_LESS 2.8.12)
                $<INSTALL_INTERFACE:${INCLUDE_INSTALL_ROOT_DIR}>
         PRIVATE $<BUILD_INTERFACE:${YAML_CPP_SOURCE_DIR}/src>)
 endif()
+
+set_target_properties(yaml-cpp PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+)
 
 set_target_properties(yaml-cpp PROPERTIES
   COMPILE_FLAGS "${yaml_c_flags} ${yaml_cxx_flags}"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,11 @@ add_executable(run-tests
     ${test_headers}
 )
 
+set_target_properties(run-tests PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+)
+
 add_dependencies(run-tests googletest_project)
 
 set_target_properties(run-tests PROPERTIES

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -2,13 +2,25 @@ cmake_minimum_required(VERSION 3.5)
 
 add_sources(parse.cpp)
 add_executable(parse parse.cpp)
+set_target_properties(parse PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+)
 target_link_libraries(parse yaml-cpp)
 
 add_sources(sandbox.cpp)
 add_executable(sandbox sandbox.cpp)
+set_target_properties(sandbox PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+)
 target_link_libraries(sandbox yaml-cpp)
 
 add_sources(read.cpp)
 add_executable(read read.cpp)
+set_target_properties(read PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+)
 target_link_libraries(read yaml-cpp)
 


### PR DESCRIPTION
Setting CMAKE_CXX_STANDARD and CMAKE_CXX_STANDARD_REQUIRED directly is problematic when including yaml-cpp as a subproject.

The proper way is to set these per-target.