### PR TITLE
add_library & and_executable omitted sources added back

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,9 @@ set(msvc-rt-mt-dll $<STREQUAL:${msvc-rt},MultiThreadedDLL>)
 
 set(backport-msvc-runtime $<VERSION_LESS:${CMAKE_VERSION},3.15>)
 
-add_library(yaml-cpp ${yaml-cpp-type})
+add_library(yaml-cpp ${yaml-cpp-type}
+    $<$<BOOL:${YAML_CPP_BUILD_CONTRIB}>:${yaml-cpp-contrib-sources}>
+    ${yaml-cpp-sources})
 add_library(yaml::yaml ALIAS yaml-cpp)
 
 set_property(TARGET yaml-cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,7 +20,9 @@ endif()
 file(GLOB test-new-api-sources ${test-new-api-pattern})
 file(GLOB test-sources ${test-source-pattern})
 
-add_executable(yaml-cpp-tests)
+add_executable(yaml-cpp-tests
+    ${test-new-api-sources}
+    ${test-sources})
 target_sources(yaml-cpp-tests
   PRIVATE
     ${test-new-api-sources}


### PR DESCRIPTION
 for cmake 3.10.x and below compatibility. related to issue #757 (by me) and #759 (by another user)