### PR TITLE
Android dynamic library cross compile support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,21 @@ find_program(YAML_CPP_CLANG_FORMAT_EXE NAMES clang-format)
 option(YAML_CPP_BUILD_CONTRIB "Enable yaml-cpp contrib in library" ON)
 option(YAML_CPP_BUILD_TOOLS "Enable parse tools" ON)
 
+option(BUILD_SHARED_LIBS "Build shared library" OFF)
+option(BUILD_ANDROID_LIBS "Build Android dynamic library" OFF)
+
+if (BUILD_ANDROID_LIBS)
+  set(BUILD_SHARED_LIBS ON)
+
+  if("${ANDROID_STL}" STREQUAL "c++_shared")
+      message(STATUS "Configuring STL libc++_shared.so for ${ANDROID_ABI}")
+      configure_file(
+          "${ANDROID_NDK}/sources/cxx-stl/llvm-libc++/libs/${ANDROID_ABI}/libc++_shared.so"
+          "${CMAKE_BINARY_DIR}/libc++_shared.so"
+          COPYONLY)
+  endif()
+endif()
+
 cmake_dependent_option(YAML_CPP_BUILD_TESTS
   "Enable yaml-cpp tests" ON
   "BUILD_TESTING;CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
@@ -20,7 +35,7 @@ cmake_dependent_option(YAML_CPP_INSTALL
   "Enable generation of yaml-cpp install targets" ON
   "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 cmake_dependent_option(YAML_BUILD_SHARED_LIBS
-  "Build yaml-cpp shared library" OFF
+  "Build yaml-cpp shared library" ON
   "BUILD_SHARED_LIBS" OFF)
 
 cmake_dependent_option(YAML_MSVC_SHARED_RT

--- a/README.md
+++ b/README.md
@@ -26,21 +26,41 @@ cd build
 3. Run CMake. The basic syntax is:
 
 ```
-cmake [-G generator] [-DYAML_BUILD_SHARED_LIBS=ON|OFF] ..
+cmake [-G generator] [-DBUILD_SHARED_LIBS=ON|OFF] ..
 ```
 
   * The `generator` is whatever type of build system you'd like to use. To see a full list of generators on your platform, just run `cmake` (with no arguments). For example:
     * On Windows, you might use "Visual Studio 12 2013" to generate a Visual Studio 2013 solution or "Visual Studio 14 2015 Win64" to generate a 64-bit Visual Studio 2015 solution.
     * On OS X, you might use "Xcode" to generate an Xcode project
     * On a UNIX-y system, simply omit the option to generate a makefile
-
   * yaml-cpp defaults to building a static library, but you may build a shared library by specifying `-DYAML_BUILD_SHARED_LIBS=ON`.
-
   * For more options on customizing the build, see the [CMakeLists.txt](https://github.com/jbeder/yaml-cpp/blob/master/CMakeLists.txt) file.
 
 4. Build it!
 
 5. To clean up, just remove the `build` directory.
+
+### Cross Compile Dynamic Library for Android
+
+* The 3rd step above can do like this:
+
+  ```
+  cmake -DCMAKE_TOOLCHAIN_FILE=${NDKROOT}/build/cmake/android.toolchain.cmake -DANDROID_STL=c++_shared -DANDROID_PLATFORM=android-26 -DANDROID_ABI=x86_64 -DBUILD_ANDROID_LIBS=ON ..
+  ```
+
+  - To do cross-compiling, `ndk-bundle`OR `android-sdk` is needed. Also `NDKROOT` should be exported in your `bash` config file, just like:
+
+    ```
+    export NDKROOT=~/Library/Android/sdk/ndk-bundle
+    ```
+
+  - The arguments `ANDROID_ABI` can be set to `arm64-v8a`, `armeabi-v7a`, `armeabi`, `x86`, `x86_64`， etc. If NOT set, the default value is `armeabi-v7a`.
+  
+- The arguments `ANDROID_PLATFORM` can be set to `android-xx` OR `latest`, `xx` can be replaced to the android api number, the default value will be the minimum supported version of your `ndk-bundle`, while the value `latest` will using the maximum supported version.
+  
+  -  `BUILD_ANDROID_LIBS=ON` will default set `BUILD_SHARED_LIBS=ON`, and copy the `libc++_shared.so` to `build` directory from `ndk-bundle`, which maybe needed by `libyaml-cpp.so`.
+  
+   
 
 # Recent Release #
 


### PR DESCRIPTION
CMake: Add Android dynamic library cross compile support.
CMake: Fix shared library compile configure error.


I tried `cmake -DYAML_BUILD_SHARED_LIBS=ON ..` and `make`,  but failed to generate `libyaml-cpp.so`, still got "libyaml-cpp.a".

I found
```
cmake_dependent_option(YAML_BUILD_SHARED_LIBS
    "Build yaml-cpp shared library" OFF
    "BUILD_SHARED_LIBS" OFF)
```
and change the first `OFF` to `ON`, and add `option(BUILD_SHARED_LIBS "Build shared library" OFF)` above, then try `cmake -D_BUILD_SHARED_LIBS=ON ..`, it works.