### PR TITLE
Attempt to fix the memory leak mentioned in https://github.com/jbeder…

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -10,7 +10,6 @@ void memory_holder::merge(memory_holder& rhs) {
     return;
 
   m_pMemory->merge(*rhs.m_pMemory);
-  rhs.m_pMemory = m_pMemory;
 }
 
 node& memory::create_node() {


### PR DESCRIPTION
…/yaml-cpp/issues/691

It seems that tests pass and the issue described in 691 doesn't reproduce.
The fix simply doesn't assign the argument node's memory to the changed node's memory. I don't see a reason to do it, although I'm not very familiar with the internals of YAML.

It makes sense that the changed node would like to keep the argument node's memory, but not vice-versa.