### PR TITLE
Fix -Wmisleading-indentation warning when using gcc >= 6.

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -88,43 +88,45 @@ struct convert<_Null> {
   }
 };
 
-#define YAML_DEFINE_CONVERT_STREAMABLE(type, negative_op)                \
-  template <>                                                            \
-  struct convert<type> {                                                 \
-    static Node encode(const type& rhs) {                                \
-      std::stringstream stream;                                          \
-      stream.precision(std::numeric_limits<type>::max_digits10);         \
-      stream << rhs;                                                     \
-      return Node(stream.str());                                         \
-    }                                                                    \
-                                                                         \
-    static bool decode(const Node& node, type& rhs) {                    \
-      if (node.Type() != NodeType::Scalar)                               \
-        return false;                                                    \
-      const std::string& input = node.Scalar();                          \
-      std::stringstream stream(input);                                   \
-      stream.unsetf(std::ios::dec);                                      \
-      if ((stream >> std::noskipws >> rhs) && (stream >> std::ws).eof()) \
-        return true;                                                     \
-      if (std::numeric_limits<type>::has_infinity) {                     \
-        if (conversion::IsInfinity(input)) {                             \
-          rhs = std::numeric_limits<type>::infinity();                   \
-          return true;                                                   \
-        } else if (conversion::IsNegativeInfinity(input)) {              \
-          rhs = negative_op std::numeric_limits<type>::infinity();       \
-          return true;                                                   \
-        }                                                                \
-      }                                                                  \
-                                                                         \
-      if (std::numeric_limits<type>::has_quiet_NaN) {                    \
-        if (conversion::IsNaN(input)) {                                  \
-          rhs = std::numeric_limits<type>::quiet_NaN();                  \
-          return true;                                                   \
-        }                                                                \
-      }                                                                  \
-                                                                         \
-      return false;                                                      \
-    }                                                                    \
+#define YAML_DEFINE_CONVERT_STREAMABLE(type, negative_op)                  \
+  template <>                                                              \
+  struct convert<type> {                                                   \
+    static Node encode(const type& rhs) {                                  \
+      std::stringstream stream;                                            \
+      stream.precision(std::numeric_limits<type>::max_digits10);           \
+      stream << rhs;                                                       \
+      return Node(stream.str());                                           \
+    }                                                                      \
+                                                                           \
+    static bool decode(const Node& node, type& rhs) {                      \
+      if (node.Type() != NodeType::Scalar) {                               \
+        return false;                                                      \
+      }                                                                    \
+      const std::string& input = node.Scalar();                            \
+      std::stringstream stream(input);                                     \
+      stream.unsetf(std::ios::dec);                                        \
+      if ((stream >> std::noskipws >> rhs) && (stream >> std::ws).eof()) { \
+        return true;                                                       \
+      }                                                                    \
+      if (std::numeric_limits<type>::has_infinity) {                       \
+        if (conversion::IsInfinity(input)) {                               \
+          rhs = std::numeric_limits<type>::infinity();                     \
+          return true;                                                     \
+        } else if (conversion::IsNegativeInfinity(input)) {                \
+          rhs = negative_op std::numeric_limits<type>::infinity();         \
+          return true;                                                     \
+        }                                                                  \
+      }                                                                    \
+                                                                           \
+      if (std::numeric_limits<type>::has_quiet_NaN) {                      \
+        if (conversion::IsNaN(input)) {                                    \
+          rhs = std::numeric_limits<type>::quiet_NaN();                    \
+          return true;                                                     \
+        }                                                                  \
+      }                                                                    \
+                                                                           \
+      return false;                                                        \
+    }                                                                      \
   }
 
 #define YAML_DEFINE_CONVERT_STREAMABLE_SIGNED(type) \


### PR DESCRIPTION
This happens whenever in a macro you use some "if" block, and don't use curly braces {},
as the macro is expanded on a single line, not on several lines. So just add the missing
curly braces to please gcc.

In file included from /remote/users/mlamesch/CloneFromPlatinum/yamlcpp/osp/Yamlcpp/18-0-0-5/include/yaml-cpp/yaml.h:18,
                 from src/TestYaml.cpp:2:
/remote/users/mlamesch/CloneFromPlatinum/yamlcpp/osp/Yamlcpp/18-0-0-5/include/yaml-cpp/node/convert.h: In static member function static bool YAML::convert<int>::decode(const YAML::Node&, int&):
/remote/users/mlamesch/CloneFromPlatinum/yamlcpp/osp/Yamlcpp/18-0-0-5/include/yaml-cpp/node/convert.h:139:1: error: this if clause does not guard... [-Werror=misleading-indentation]
 YAML_DEFINE_CONVERT_STREAMABLE_SIGNED(int);
 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Note: it doesn't appear clearly in this diff, but most lines are changed just with some empty spaces to align the final backslashes \, so when reviewing ignore all spaces changes (git diff --ignore-all-space) that will be easier for reviewing.