### PR TITLE
Remove redundant checks and add more unit tests

### DIFF
--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -172,8 +172,6 @@ inline const std::string& Node::Tag() const {
 }
 
 inline void Node::SetTag(const std::string& tag) {
-  if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   m_pNode->set_tag(tag);
 }
@@ -185,8 +183,6 @@ inline EmitterStyle::value Node::Style() const {
 }
 
 inline void Node::SetStyle(EmitterStyle::value style) {
-  if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   m_pNode->set_style(style);
 }
@@ -202,15 +198,11 @@ inline bool Node::is(const Node& rhs) const {
 
 template <typename T>
 inline Node& Node::operator=(const T& rhs) {
-  if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
   Assign(rhs);
   return *this;
 }
 
 inline Node& Node::operator=(const Node& rhs) {
-  if (!m_isValid || !rhs.m_isValid)
-    throw InvalidNode(m_invalidKey);
   if (is(rhs))
     return *this;
   AssignNode(rhs);
@@ -233,29 +225,21 @@ inline void Node::Assign(const T& rhs) {
 
 template <>
 inline void Node::Assign(const std::string& rhs) {
-  if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   m_pNode->set_scalar(rhs);
 }
 
 inline void Node::Assign(const char* rhs) {
-  if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   m_pNode->set_scalar(rhs);
 }
 
 inline void Node::Assign(char* rhs) {
-  if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   m_pNode->set_scalar(rhs);
 }
 
 inline void Node::AssignData(const Node& rhs) {
-  if (!m_isValid || !rhs.m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   rhs.EnsureNodeExists();
 
@@ -264,7 +248,7 @@ inline void Node::AssignData(const Node& rhs) {
 }
 
 inline void Node::AssignNode(const Node& rhs) {
-  if (!m_isValid || !rhs.m_isValid)
+  if (!m_isValid)
     throw InvalidNode(m_invalidKey);
   rhs.EnsureNodeExists();
 
@@ -320,8 +304,6 @@ inline void Node::push_back(const T& rhs) {
 }
 
 inline void Node::push_back(const Node& rhs) {
-  if (!m_isValid || !rhs.m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   rhs.EnsureNodeExists();
 
@@ -382,8 +364,6 @@ std::string key_to_string(const Key& key) {
 // indexing
 template <typename Key>
 inline const Node Node::operator[](const Key& key) const {
-  if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   detail::node* value = static_cast<const detail::node&>(*m_pNode).get(
       detail::to_value(key), m_pMemory);
@@ -395,8 +375,6 @@ inline const Node Node::operator[](const Key& key) const {
 
 template <typename Key>
 inline Node Node::operator[](const Key& key) {
-  if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   detail::node& value = m_pNode->get(detail::to_value(key), m_pMemory);
   return Node(value, m_pMemory);
@@ -404,15 +382,11 @@ inline Node Node::operator[](const Key& key) {
 
 template <typename Key>
 inline bool Node::remove(const Key& key) {
-  if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   return m_pNode->remove(detail::to_value(key), m_pMemory);
 }
 
 inline const Node Node::operator[](const Node& key) const {
-  if (!m_isValid || !key.m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   key.EnsureNodeExists();
   m_pMemory->merge(*key.m_pMemory);
@@ -425,8 +399,6 @@ inline const Node Node::operator[](const Node& key) const {
 }
 
 inline Node Node::operator[](const Node& key) {
-  if (!m_isValid || !key.m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   key.EnsureNodeExists();
   m_pMemory->merge(*key.m_pMemory);
@@ -435,8 +407,6 @@ inline Node Node::operator[](const Node& key) {
 }
 
 inline bool Node::remove(const Node& key) {
-  if (!m_isValid || !key.m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   key.EnsureNodeExists();
   return m_pNode->remove(*key.m_pNode, m_pMemory);
@@ -445,8 +415,6 @@ inline bool Node::remove(const Node& key) {
 // map
 template <typename Key, typename Value>
 inline void Node::force_insert(const Key& key, const Value& value) {
-  if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
   EnsureNodeExists();
   m_pNode->force_insert(detail::to_value(key), detail::to_value(value),
                         m_pMemory);

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -59,6 +59,18 @@ TEST(NodeTest, SequenceElementRemoval) {
   EXPECT_EQ("c", node[1].as<std::string>());
 }
 
+TEST(NodeTest, SequenceFirstElementRemoval) {
+  Node node;
+  node[0] = "a";
+  node[1] = "b";
+  node[2] = "c";
+  node.remove(0);
+  EXPECT_TRUE(node.IsSequence());
+  EXPECT_EQ(2, node.size());
+  EXPECT_EQ("b", node[0].as<std::string>());
+  EXPECT_EQ("c", node[1].as<std::string>());
+}
+
 TEST(NodeTest, SequenceLastElementRemoval) {
   Node node;
   node[0] = "a";
@@ -69,6 +81,19 @@ TEST(NodeTest, SequenceLastElementRemoval) {
   EXPECT_EQ(2, node.size());
   EXPECT_EQ("a", node[0].as<std::string>());
   EXPECT_EQ("b", node[1].as<std::string>());
+}
+
+TEST(NodeTest, NodeAssignment) {
+  Node node1;
+  Node node2;
+  node1[1] = 1;
+  node1[2] = 2;
+  node1[3] = 3;
+  node2 = node1;
+  EXPECT_EQ(node1, node2);
+  EXPECT_EQ(node1[1], node2[1]);
+  EXPECT_EQ(node1[2], node2[2]);
+  EXPECT_EQ(node1[3], node2[3]);
 }
 
 TEST(NodeTest, MapElementRemoval) {


### PR DESCRIPTION
I have found a lot of redundant checks (that Node is valid) in methods of `Node` class. There are a lot of cases when there is check and after that there is `EnsureNodeExists` method call (or call a method that call `EnsureNodeExists`) with the same check. Also I have added more unit tests for `Node` class.