### PR TITLE
Array fix

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -68,6 +68,21 @@ struct convert<std::string> {
   }
 };
 
+template <>
+struct convert<unsigned char> {
+  static Node encode(const unsigned char& rhs) { Node n; n = rhs; return n; }
+
+  static bool decode(const Node& node, unsigned char& rhs) {
+    if (node.Type() != NodeType::Scalar) {
+        return false;
+      }
+      int t = stoi(node.Scalar());
+      if(t < 0 || t > 255) return false;
+      rhs = (unsigned char)t;
+      return true;
+  }
+};
+
 // C-strings can only be encoded
 template <>
 struct convert<const char*> {
@@ -146,7 +161,7 @@ YAML_DEFINE_CONVERT_STREAMABLE_UNSIGNED(unsigned long long);
 
 YAML_DEFINE_CONVERT_STREAMABLE_SIGNED(char);
 YAML_DEFINE_CONVERT_STREAMABLE_SIGNED(signed char);
-YAML_DEFINE_CONVERT_STREAMABLE_UNSIGNED(unsigned char);
+//YAML_DEFINE_CONVERT_STREAMABLE_UNSIGNED(unsigned char);
 
 YAML_DEFINE_CONVERT_STREAMABLE_SIGNED(float);
 YAML_DEFINE_CONVERT_STREAMABLE_SIGNED(double);

--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <sstream>
 #include <vector>
+#include <cstring>
 
 #include "yaml-cpp/binary.h"
 #include "yaml-cpp/node/impl.h"
@@ -284,12 +285,15 @@ struct convert<std::array<T, N>> {
       rhs[i] = node[i].as<T>();
 #endif
     }
+    for (auto i = node.size(); i < N; i++) {
+        std::memset(&rhs[i], 0, sizeof(T));
+    }
     return true;
   }
 
  private:
   static bool isNodeValid(const Node& node) {
-    return node.IsSequence() && node.size() == N;
+    return node.IsSequence() && node.size() <= N;
   }
 };
 

--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -116,6 +116,7 @@ struct as_if<std::string, S> {
   }
 };
 
+
 template <typename T>
 struct as_if<T, void> {
   explicit as_if(const Node& node_) : node(node_) {}


### PR DESCRIPTION
For std::array<struct, size> parsing, if yaml parser finds less nodes than expected, decoder will pad remaining structs with 0s