### PR TITLE
Handle bad input with a ParseException not an assert()

### DIFF
--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -52,6 +52,7 @@ const char* const INVALID_HEX = "bad character found while scanning hex number";
 const char* const INVALID_UNICODE = "invalid unicode: ";
 const char* const INVALID_ESCAPE = "unknown escape character: ";
 const char* const UNKNOWN_TOKEN = "unknown token";
+const char* const NO_MORE_TOKENS = "no more tokens to be read";
 const char* const DOC_IN_SCALAR = "illegal document indicator in scalar";
 const char* const EOF_IN_SCALAR = "illegal EOF in scalar";
 const char* const CHAR_IN_SCALAR = "illegal character in scalar";

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -34,9 +34,10 @@ void Scanner::pop() {
 
 Token& Scanner::peek() {
   EnsureTokensInQueue();
-  assert(!m_tokens.empty());  // should we be asserting here? I mean, we really
-                              // just be checking
-                              // if it's empty before peeking.
+
+  // If there are no more tokens, we cannon fulfil our post-condition
+  if (m_tokens.empty())
+      throw ParserException(INPUT.mark(), ErrorMsg::NO_MORE_TOKENS);
 
 #if 0
 		static Token *pLast = 0;

--- a/test/parser_test.cpp
+++ b/test/parser_test.cpp
@@ -1,9 +1,11 @@
 #include "yaml-cpp/parser.h"
+#include "yaml-cpp/exceptions.h"
 #include "mock_event_handler.h"
 #include "gtest/gtest.h"
 
 using YAML::Parser;
 using YAML::MockEventHandler;
+using ::testing::NiceMock;
 using ::testing::StrictMock;
 
 TEST(ParserTest, Empty) {
@@ -13,4 +15,12 @@ TEST(ParserTest, Empty) {
 
     StrictMock<MockEventHandler> handler;
     EXPECT_FALSE(parser.HandleNextDocument(handler));
+}
+
+TEST(ParserTest, CVE_2017_11692) {
+    std::istringstream input{"!2"};
+    Parser parser{input};
+
+    NiceMock<MockEventHandler> handler;
+    EXPECT_THROW(parser.HandleNextDocument(handler), YAML::ParserException);
 }


### PR DESCRIPTION
Handle bad input with a ParseException not an assert() (Fixes: #519 aka CVE-2017-11692)

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11692