### PR TITLE
Move the YAML_CPP_NOEXCEPT macro to include/yaml-cpp/noexcept.h

### DIFF
--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -8,18 +8,11 @@
 #endif
 
 #include "yaml-cpp/mark.h"
+#include "yaml-cpp/noexcept.h"
 #include "yaml-cpp/traits.h"
 #include <sstream>
 #include <stdexcept>
 #include <string>
-
-// This is here for compatibility with older versions of Visual Studio
-// which don't support noexcept
-#if defined(_MSC_VER) && _MSC_VER < 1900
-    #define YAML_CPP_NOEXCEPT _NOEXCEPT
-#else
-    #define YAML_CPP_NOEXCEPT noexcept
-#endif
 
 namespace YAML {
 // error messages
@@ -293,7 +286,5 @@ class YAML_CPP_API BadFile : public Exception {
   ~BadFile() YAML_CPP_NOEXCEPT override;
 };
 }
-
-#undef YAML_CPP_NOEXCEPT
 
 #endif  // EXCEPTIONS_H_62B23520_7C8E_11DE_8A39_0800200C9A66

--- a/include/yaml-cpp/noexcept.h
+++ b/include/yaml-cpp/noexcept.h
@@ -1,0 +1,18 @@
+#ifndef NOEXCEPT_H_768872DA_476C_11EA_88B8_90B11C0C0FF8
+#define NOEXCEPT_H_768872DA_476C_11EA_88B8_90B11C0C0FF8
+
+#if defined(_MSC_VER) ||                                            \
+    (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
+     (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
+#pragma once
+#endif
+
+// This is here for compatibility with older versions of Visual Studio
+// which don't support noexcept.
+#if defined(_MSC_VER) && _MSC_VER < 1900
+    #define YAML_CPP_NOEXCEPT _NOEXCEPT
+#else
+    #define YAML_CPP_NOEXCEPT noexcept
+#endif
+
+#endif

--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -1,12 +1,5 @@
 #include "yaml-cpp/exceptions.h"
-
-// This is here for compatibility with older versions of Visual Studio
-// which don't support noexcept
-#if defined(_MSC_VER) && _MSC_VER < 1900
-    #define YAML_CPP_NOEXCEPT _NOEXCEPT
-#else
-    #define YAML_CPP_NOEXCEPT noexcept
-#endif
+#include "yaml-cpp/noexcept.h"
 
 namespace YAML {
 
@@ -25,7 +18,3 @@ BadInsert::~BadInsert() YAML_CPP_NOEXCEPT = default;
 EmitterException::~EmitterException() YAML_CPP_NOEXCEPT = default;
 BadFile::~BadFile() YAML_CPP_NOEXCEPT = default;
 }
-
-#undef YAML_CPP_NOEXCEPT
-
-


### PR DESCRIPTION
This is in preparation for other patches that will make use of the
macro. The patch also removes #undef:ing the macro after its been
used to not make the header inclusion order critical. Otherwise,
the new header would always have to be the last of the yaml-cpp
headers to be included.

Signed-off-by: Ted Lyngmo <ted@lyncon.se>