### PR TITLE
Add IsNull() thruth test after reassignment

### DIFF
--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -7,6 +7,7 @@ namespace {
 TEST(LoadNodeTest, Reassign) {
   Node node = Load("foo");
   node = Node();
+  EXPECT_TRUE(node.IsNull());
 }
 
 TEST(LoadNodeTest, FallbackValues) {


### PR DESCRIPTION
Add `EXPECT_TRUE(node.IsNull())` after reassignment in test `LoadNodeTest.Reassign`.

This is one test that my current work with making nodes moveable with a `noexcept` guarantee would fail in its current state, so it's a good guard.

Signed-off-by: Ted Lyngmo <ted@lyncon.se>