### PR TITLE
Fix plenty of clang warnings `declaration shadows a variable`: using class enum instead of enum

### DIFF
--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -677,7 +677,7 @@ Emitter& Emitter::Write(const std::string& str) {
     return *this;
 
   const bool escapeNonAscii = m_pState->GetOutputCharset() == EscapeNonAscii;
-  const StringFormat::value strFormat =
+  const StringFormat strFormat =
       Utils::ComputeStringFormat(str, m_pState->GetStringFormat(),
                                  m_pState->CurGroupFlowType(), escapeNonAscii);
 

--- a/src/emitterstate.cpp
+++ b/src/emitterstate.cpp
@@ -90,7 +90,7 @@ void EmitterState::StartedNode() {
 }
 
 EmitterNodeType::value EmitterState::NextGroupType(
-    GroupType::value type) const {
+    GroupType type) const {
   if (type == GroupType::Seq) {
     if (GetFlowType(type) == Block)
       return EmitterNodeType::BlockSeq;
@@ -125,7 +125,7 @@ void EmitterState::StartedScalar() {
   ClearModifiedSettings();
 }
 
-void EmitterState::StartedGroup(GroupType::value type) {
+void EmitterState::StartedGroup(GroupType type) {
   StartedNode();
 
   const std::size_t lastGroupIndent =
@@ -152,7 +152,7 @@ void EmitterState::StartedGroup(GroupType::value type) {
   m_groups.push_back(std::move(pGroup));
 }
 
-void EmitterState::EndedGroup(GroupType::value type) {
+void EmitterState::EndedGroup(GroupType type) {
   if (m_groups.empty()) {
     if (type == GroupType::Seq) {
       return SetError(ErrorMsg::UNEXPECTED_END_SEQ);
@@ -190,11 +190,11 @@ EmitterNodeType::value EmitterState::CurGroupNodeType() const {
   return m_groups.back()->NodeType();
 }
 
-GroupType::value EmitterState::CurGroupType() const {
+GroupType EmitterState::CurGroupType() const {
   return m_groups.empty() ? GroupType::NoType : m_groups.back()->type;
 }
 
-FlowType::value EmitterState::CurGroupFlowType() const {
+FlowType EmitterState::CurGroupFlowType() const {
   return m_groups.empty() ? FlowType::NoType : m_groups.back()->flowType;
 }
 
@@ -221,7 +221,7 @@ std::size_t EmitterState::LastIndent() const {
 void EmitterState::ClearModifiedSettings() { m_modifiedSettings.clear(); }
 
 bool EmitterState::SetOutputCharset(EMITTER_MANIP value,
-                                    FmtScope::value scope) {
+                                    FmtScope scope) {
   switch (value) {
     case EmitNonAscii:
     case EscapeNonAscii:
@@ -232,7 +232,7 @@ bool EmitterState::SetOutputCharset(EMITTER_MANIP value,
   }
 }
 
-bool EmitterState::SetStringFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetStringFormat(EMITTER_MANIP value, FmtScope scope) {
   switch (value) {
     case Auto:
     case SingleQuoted:
@@ -245,7 +245,7 @@ bool EmitterState::SetStringFormat(EMITTER_MANIP value, FmtScope::value scope) {
   }
 }
 
-bool EmitterState::SetBoolFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetBoolFormat(EMITTER_MANIP value, FmtScope scope) {
   switch (value) {
     case OnOffBool:
     case TrueFalseBool:
@@ -258,7 +258,7 @@ bool EmitterState::SetBoolFormat(EMITTER_MANIP value, FmtScope::value scope) {
 }
 
 bool EmitterState::SetBoolLengthFormat(EMITTER_MANIP value,
-                                       FmtScope::value scope) {
+                                       FmtScope scope) {
   switch (value) {
     case LongBool:
     case ShortBool:
@@ -270,7 +270,7 @@ bool EmitterState::SetBoolLengthFormat(EMITTER_MANIP value,
 }
 
 bool EmitterState::SetBoolCaseFormat(EMITTER_MANIP value,
-                                     FmtScope::value scope) {
+                                     FmtScope scope) {
   switch (value) {
     case UpperCase:
     case LowerCase:
@@ -282,7 +282,7 @@ bool EmitterState::SetBoolCaseFormat(EMITTER_MANIP value,
   }
 }
 
-bool EmitterState::SetIntFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetIntFormat(EMITTER_MANIP value, FmtScope scope) {
   switch (value) {
     case Dec:
     case Hex:
@@ -294,7 +294,7 @@ bool EmitterState::SetIntFormat(EMITTER_MANIP value, FmtScope::value scope) {
   }
 }
 
-bool EmitterState::SetIndent(std::size_t value, FmtScope::value scope) {
+bool EmitterState::SetIndent(std::size_t value, FmtScope scope) {
   if (value <= 1)
     return false;
 
@@ -303,7 +303,7 @@ bool EmitterState::SetIndent(std::size_t value, FmtScope::value scope) {
 }
 
 bool EmitterState::SetPreCommentIndent(std::size_t value,
-                                       FmtScope::value scope) {
+                                       FmtScope scope) {
   if (value == 0)
     return false;
 
@@ -312,7 +312,7 @@ bool EmitterState::SetPreCommentIndent(std::size_t value,
 }
 
 bool EmitterState::SetPostCommentIndent(std::size_t value,
-                                        FmtScope::value scope) {
+                                        FmtScope scope) {
   if (value == 0)
     return false;
 
@@ -320,8 +320,8 @@ bool EmitterState::SetPostCommentIndent(std::size_t value,
   return true;
 }
 
-bool EmitterState::SetFlowType(GroupType::value groupType, EMITTER_MANIP value,
-                               FmtScope::value scope) {
+bool EmitterState::SetFlowType(GroupType groupType, EMITTER_MANIP value,
+                               FmtScope scope) {
   switch (value) {
     case Block:
     case Flow:
@@ -332,7 +332,7 @@ bool EmitterState::SetFlowType(GroupType::value groupType, EMITTER_MANIP value,
   }
 }
 
-EMITTER_MANIP EmitterState::GetFlowType(GroupType::value groupType) const {
+EMITTER_MANIP EmitterState::GetFlowType(GroupType groupType) const {
   // force flow style if we're currently in a flow
   if (CurGroupFlowType() == FlowType::Flow)
     return Flow;
@@ -341,7 +341,7 @@ EMITTER_MANIP EmitterState::GetFlowType(GroupType::value groupType) const {
   return (groupType == GroupType::Seq ? m_seqFmt.get() : m_mapFmt.get());
 }
 
-bool EmitterState::SetMapKeyFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetMapKeyFormat(EMITTER_MANIP value, FmtScope scope) {
   switch (value) {
     case Auto:
     case LongKey:
@@ -352,7 +352,7 @@ bool EmitterState::SetMapKeyFormat(EMITTER_MANIP value, FmtScope::value scope) {
   }
 }
 
-bool EmitterState::SetFloatPrecision(std::size_t value, FmtScope::value scope) {
+bool EmitterState::SetFloatPrecision(std::size_t value, FmtScope scope) {
   if (value > std::numeric_limits<float>::max_digits10)
     return false;
   _Set(m_floatPrecision, value, scope);
@@ -360,7 +360,7 @@ bool EmitterState::SetFloatPrecision(std::size_t value, FmtScope::value scope) {
 }
 
 bool EmitterState::SetDoublePrecision(std::size_t value,
-                                      FmtScope::value scope) {
+                                      FmtScope scope) {
   if (value > std::numeric_limits<double>::max_digits10)
     return false;
   _Set(m_doublePrecision, value, scope);

--- a/src/emitterstate.cpp
+++ b/src/emitterstate.cpp
@@ -89,8 +89,7 @@ void EmitterState::StartedNode() {
   m_hasNonContent = false;
 }
 
-EmitterNodeType::value EmitterState::NextGroupType(
-    GroupType type) const {
+EmitterNodeType::value EmitterState::NextGroupType(GroupType type) const {
   if (type == GroupType::Seq) {
     if (GetFlowType(type) == Block)
       return EmitterNodeType::BlockSeq;
@@ -220,8 +219,7 @@ std::size_t EmitterState::LastIndent() const {
 
 void EmitterState::ClearModifiedSettings() { m_modifiedSettings.clear(); }
 
-bool EmitterState::SetOutputCharset(EMITTER_MANIP value,
-                                    FmtScope scope) {
+bool EmitterState::SetOutputCharset(EMITTER_MANIP value, FmtScope scope) {
   switch (value) {
     case EmitNonAscii:
     case EscapeNonAscii:
@@ -257,8 +255,7 @@ bool EmitterState::SetBoolFormat(EMITTER_MANIP value, FmtScope scope) {
   }
 }
 
-bool EmitterState::SetBoolLengthFormat(EMITTER_MANIP value,
-                                       FmtScope scope) {
+bool EmitterState::SetBoolLengthFormat(EMITTER_MANIP value, FmtScope scope) {
   switch (value) {
     case LongBool:
     case ShortBool:
@@ -269,8 +266,7 @@ bool EmitterState::SetBoolLengthFormat(EMITTER_MANIP value,
   }
 }
 
-bool EmitterState::SetBoolCaseFormat(EMITTER_MANIP value,
-                                     FmtScope scope) {
+bool EmitterState::SetBoolCaseFormat(EMITTER_MANIP value, FmtScope scope) {
   switch (value) {
     case UpperCase:
     case LowerCase:
@@ -302,8 +298,7 @@ bool EmitterState::SetIndent(std::size_t value, FmtScope scope) {
   return true;
 }
 
-bool EmitterState::SetPreCommentIndent(std::size_t value,
-                                       FmtScope scope) {
+bool EmitterState::SetPreCommentIndent(std::size_t value, FmtScope scope) {
   if (value == 0)
     return false;
 
@@ -311,8 +306,7 @@ bool EmitterState::SetPreCommentIndent(std::size_t value,
   return true;
 }
 
-bool EmitterState::SetPostCommentIndent(std::size_t value,
-                                        FmtScope scope) {
+bool EmitterState::SetPostCommentIndent(std::size_t value, FmtScope scope) {
   if (value == 0)
     return false;
 
@@ -359,8 +353,7 @@ bool EmitterState::SetFloatPrecision(std::size_t value, FmtScope scope) {
   return true;
 }
 
-bool EmitterState::SetDoublePrecision(std::size_t value,
-                                      FmtScope scope) {
+bool EmitterState::SetDoublePrecision(std::size_t value, FmtScope scope) {
   if (value > std::numeric_limits<double>::max_digits10)
     return false;
   _Set(m_doublePrecision, value, scope);

--- a/src/emitterstate.h
+++ b/src/emitterstate.h
@@ -18,14 +18,21 @@
 #include <vector>
 
 namespace YAML {
-struct FmtScope {
-  enum value { Local, Global };
+enum class FmtScope {
+  Local,
+  Global
 };
-struct GroupType {
-  enum value { NoType, Seq, Map };
+
+enum class GroupType {
+  NoType,
+  Seq,
+  Map
 };
-struct FlowType {
-  enum value { NoType, Flow, Block };
+
+enum class FlowType {
+  NoType,
+  Flow,
+  Block
 };
 
 class EmitterState {
@@ -50,14 +57,14 @@ class EmitterState {
   void StartedDoc();
   void EndedDoc();
   void StartedScalar();
-  void StartedGroup(GroupType::value type);
-  void EndedGroup(GroupType::value type);
+  void StartedGroup(GroupType type);
+  void EndedGroup(GroupType type);
 
-  EmitterNodeType::value NextGroupType(GroupType::value type) const;
+  EmitterNodeType::value NextGroupType(GroupType type) const;
   EmitterNodeType::value CurGroupNodeType() const;
 
-  GroupType::value CurGroupType() const;
-  FlowType::value CurGroupFlowType() const;
+  GroupType CurGroupType() const;
+  FlowType CurGroupFlowType() const;
   std::size_t CurGroupIndent() const;
   std::size_t CurGroupChildCount() const;
   bool CurGroupLongKey() const;
@@ -76,47 +83,47 @@ class EmitterState {
   // formatters
   void SetLocalValue(EMITTER_MANIP value);
 
-  bool SetOutputCharset(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetOutputCharset(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetOutputCharset() const { return m_charset.get(); }
 
-  bool SetStringFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetStringFormat(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetStringFormat() const { return m_strFmt.get(); }
 
-  bool SetBoolFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetBoolFormat(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetBoolFormat() const { return m_boolFmt.get(); }
 
-  bool SetBoolLengthFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetBoolLengthFormat(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetBoolLengthFormat() const { return m_boolLengthFmt.get(); }
 
-  bool SetBoolCaseFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetBoolCaseFormat(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetBoolCaseFormat() const { return m_boolCaseFmt.get(); }
 
-  bool SetIntFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetIntFormat(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetIntFormat() const { return m_intFmt.get(); }
 
-  bool SetIndent(std::size_t value, FmtScope::value scope);
+  bool SetIndent(std::size_t value, FmtScope scope);
   std::size_t GetIndent() const { return m_indent.get(); }
 
-  bool SetPreCommentIndent(std::size_t value, FmtScope::value scope);
+  bool SetPreCommentIndent(std::size_t value, FmtScope scope);
   std::size_t GetPreCommentIndent() const { return m_preCommentIndent.get(); }
-  bool SetPostCommentIndent(std::size_t value, FmtScope::value scope);
+  bool SetPostCommentIndent(std::size_t value, FmtScope scope);
   std::size_t GetPostCommentIndent() const { return m_postCommentIndent.get(); }
 
-  bool SetFlowType(GroupType::value groupType, EMITTER_MANIP value,
-                   FmtScope::value scope);
-  EMITTER_MANIP GetFlowType(GroupType::value groupType) const;
+  bool SetFlowType(GroupType groupType, EMITTER_MANIP value,
+                   FmtScope scope);
+  EMITTER_MANIP GetFlowType(GroupType groupType) const;
 
-  bool SetMapKeyFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetMapKeyFormat(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetMapKeyFormat() const { return m_mapKeyFmt.get(); }
 
-  bool SetFloatPrecision(std::size_t value, FmtScope::value scope);
+  bool SetFloatPrecision(std::size_t value, FmtScope scope);
   std::size_t GetFloatPrecision() const { return m_floatPrecision.get(); }
-  bool SetDoublePrecision(std::size_t value, FmtScope::value scope);
+  bool SetDoublePrecision(std::size_t value, FmtScope scope);
   std::size_t GetDoublePrecision() const { return m_doublePrecision.get(); }
 
  private:
   template <typename T>
-  void _Set(Setting<T>& fmt, T value, FmtScope::value scope);
+  void _Set(Setting<T>& fmt, T value, FmtScope scope);
 
   void StartedNode();
 
@@ -144,7 +151,7 @@ class EmitterState {
   SettingChanges m_globalModifiedSettings;
 
   struct Group {
-    explicit Group(GroupType::value type_)
+    explicit Group(GroupType type_)
         : type(type_),
           flowType{},
           indent(0),
@@ -152,8 +159,8 @@ class EmitterState {
           longKey(false),
           modifiedSettings{} {}
 
-    GroupType::value type;
-    FlowType::value flowType;
+    GroupType type;
+    FlowType flowType;
     std::size_t indent;
     std::size_t childCount;
     bool longKey;
@@ -188,7 +195,7 @@ class EmitterState {
 };
 
 template <typename T>
-void EmitterState::_Set(Setting<T>& fmt, T value, FmtScope::value scope) {
+void EmitterState::_Set(Setting<T>& fmt, T value, FmtScope scope) {
   switch (scope) {
     case FmtScope::Local:
       m_modifiedSettings.push(fmt.set(value));

--- a/src/emitterstate.h
+++ b/src/emitterstate.h
@@ -18,22 +18,11 @@
 #include <vector>
 
 namespace YAML {
-enum class FmtScope {
-  Local,
-  Global
-};
+enum class FmtScope { Local, Global };
 
-enum class GroupType {
-  NoType,
-  Seq,
-  Map
-};
+enum class GroupType { NoType, Seq, Map };
 
-enum class FlowType {
-  NoType,
-  Flow,
-  Block
-};
+enum class FlowType { NoType, Flow, Block };
 
 class EmitterState {
  public:
@@ -109,8 +98,7 @@ class EmitterState {
   bool SetPostCommentIndent(std::size_t value, FmtScope scope);
   std::size_t GetPostCommentIndent() const { return m_postCommentIndent.get(); }
 
-  bool SetFlowType(GroupType groupType, EMITTER_MANIP value,
-                   FmtScope scope);
+  bool SetFlowType(GroupType groupType, EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetFlowType(GroupType groupType) const;
 
   bool SetMapKeyFormat(EMITTER_MANIP value, FmtScope scope);

--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -261,9 +261,8 @@ bool WriteAliasName(ostream_wrapper& out, const std::string& str) {
 }  // namespace
 
 StringFormat ComputeStringFormat(const std::string& str,
-                                        EMITTER_MANIP strFormat,
-                                        FlowType flowType,
-                                        bool escapeNonAscii) {
+                                 EMITTER_MANIP strFormat, FlowType flowType,
+                                 bool escapeNonAscii) {
   switch (strFormat) {
     case Auto:
       if (IsValidPlainScalar(str, flowType, escapeNonAscii)) {

--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -260,7 +260,7 @@ bool WriteAliasName(ostream_wrapper& out, const std::string& str) {
 }
 }  // namespace
 
-StringFormat::value ComputeStringFormat(const std::string& str,
+StringFormat ComputeStringFormat(const std::string& str,
                                         EMITTER_MANIP strFormat,
                                         FlowType flowType,
                                         bool escapeNonAscii) {

--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -151,7 +151,7 @@ void WriteCodePoint(ostream_wrapper& out, int codePoint) {
   }
 }
 
-bool IsValidPlainScalar(const std::string& str, FlowType::value flowType,
+bool IsValidPlainScalar(const std::string& str, FlowType flowType,
                         bool allowOnlyAscii) {
   // check against null
   if (IsNullString(str)) {
@@ -210,7 +210,7 @@ bool IsValidSingleQuotedScalar(const std::string& str, bool escapeNonAscii) {
   return true;
 }
 
-bool IsValidLiteralScalar(const std::string& str, FlowType::value flowType,
+bool IsValidLiteralScalar(const std::string& str, FlowType flowType,
                           bool escapeNonAscii) {
   if (flowType == FlowType::Flow) {
     return false;
@@ -262,7 +262,7 @@ bool WriteAliasName(ostream_wrapper& out, const std::string& str) {
 
 StringFormat::value ComputeStringFormat(const std::string& str,
                                         EMITTER_MANIP strFormat,
-                                        FlowType::value flowType,
+                                        FlowType flowType,
                                         bool escapeNonAscii) {
   switch (strFormat) {
     case Auto:

--- a/src/emitterutils.h
+++ b/src/emitterutils.h
@@ -27,7 +27,7 @@ struct StringFormat {
 namespace Utils {
 StringFormat::value ComputeStringFormat(const std::string& str,
                                         EMITTER_MANIP strFormat,
-                                        FlowType::value flowType,
+                                        FlowType flowType,
                                         bool escapeNonAscii);
 
 bool WriteSingleQuotedString(ostream_wrapper& out, const std::string& str);

--- a/src/emitterutils.h
+++ b/src/emitterutils.h
@@ -20,18 +20,12 @@ class ostream_wrapper;
 namespace YAML {
 class Binary;
 
-enum class StringFormat {
-  Plain,
-  SingleQuoted,
-  DoubleQuoted,
-  Literal
-};
+enum class StringFormat { Plain, SingleQuoted, DoubleQuoted, Literal };
 
 namespace Utils {
 StringFormat ComputeStringFormat(const std::string& str,
-                                        EMITTER_MANIP strFormat,
-                                        FlowType flowType,
-                                        bool escapeNonAscii);
+                                 EMITTER_MANIP strFormat, FlowType flowType,
+                                 bool escapeNonAscii);
 
 bool WriteSingleQuotedString(ostream_wrapper& out, const std::string& str);
 bool WriteDoubleQuotedString(ostream_wrapper& out, const std::string& str,
@@ -47,7 +41,7 @@ bool WriteTag(ostream_wrapper& out, const std::string& str, bool verbatim);
 bool WriteTagWithPrefix(ostream_wrapper& out, const std::string& prefix,
                         const std::string& tag);
 bool WriteBinary(ostream_wrapper& out, const Binary& binary);
-}
-}
+}  // namespace Utils
+}  // namespace YAML
 
 #endif  // EMITTERUTILS_H_62B23520_7C8E_11DE_8A39_0800200C9A66

--- a/src/emitterutils.h
+++ b/src/emitterutils.h
@@ -20,12 +20,15 @@ class ostream_wrapper;
 namespace YAML {
 class Binary;
 
-struct StringFormat {
-  enum value { Plain, SingleQuoted, DoubleQuoted, Literal };
+enum class StringFormat {
+  Plain,
+  SingleQuoted,
+  DoubleQuoted,
+  Literal
 };
 
 namespace Utils {
-StringFormat::value ComputeStringFormat(const std::string& str,
+StringFormat ComputeStringFormat(const std::string& str,
                                         EMITTER_MANIP strFormat,
                                         FlowType flowType,
                                         bool escapeNonAscii);


### PR DESCRIPTION
I have got a lot warnings from clang compiler:
```
yaml-cpp/src/emitterstate.h:28:24: warning: declaration shadows a variable in namespace 'YAML' [-Wshadow]
  enum value { NoType, Flow, Block };
                       ^
```
and my proposal is to use enum classes.