### PR TITLE
Add NodeTest EqualRepresentationAfterMoveAssignment

### DIFF
--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -9,6 +9,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include <sstream>
+
 using ::testing::AnyOf;
 using ::testing::Eq;
 
@@ -133,6 +135,20 @@ TEST(NodeTest, NodeAssignment) {
   EXPECT_EQ(node1[1], node2[1]);
   EXPECT_EQ(node1[2], node2[2]);
   EXPECT_EQ(node1[3], node2[3]);
+}
+
+TEST(NodeTest, EqualRepresentationAfterMoveAssignment) {
+  Node node1;
+  Node node2;
+  std::ostringstream ss1, ss2;
+  node1["foo"] = "bar";
+  ss1 << node1;
+  node2["hello"] = "world";
+  node2 = std::move(node1);
+  ss2 << node2;
+  EXPECT_FALSE(node2["hello"]);
+  EXPECT_EQ("bar", node2["foo"].as<std::string>());
+  EXPECT_EQ(ss1.str(), ss2.str());
 }
 
 TEST(NodeTest, MapElementRemoval) {


### PR DESCRIPTION
Add check that a move assigned Node gets the same representation as the
moved-from Node had before the move.

Signed-off-by: Ted Lyngmo <ted@lyncon.se>