### PR TITLE
Fix size() after removing node from sequence

### DIFF
--- a/include/yaml-cpp/node/detail/impl.h
+++ b/include/yaml-cpp/node/detail/impl.h
@@ -58,7 +58,9 @@ struct get_idx<Key, typename std::enable_if<std::is_signed<Key>::value>::type> {
 
 template <typename Key, typename Enable = void>
 struct remove_idx {
-  static bool remove(std::vector<node*>&, const Key&) { return false; }
+  static bool remove(std::vector<node*>&, const Key&, std::size_t*) {
+    return false;
+  }
 };
 
 template <typename Key>
@@ -66,11 +68,14 @@ struct remove_idx<
     Key, typename std::enable_if<std::is_unsigned<Key>::value &&
                                  !std::is_same<Key, bool>::value>::type> {
 
-  static bool remove(std::vector<node*>& sequence, const Key& key) {
+  static bool remove(std::vector<node*>& sequence, const Key& key,
+                     std::size_t* seqSize) {
     if (key >= sequence.size()) {
       return false;
     } else {
+      bool defined = sequence[key]->is_defined();
       sequence.erase(sequence.begin() + key);
+      *seqSize -= static_cast<size_t>(defined && *seqSize > key);
       return true;
     }
   }
@@ -80,9 +85,10 @@ template <typename Key>
 struct remove_idx<Key,
                   typename std::enable_if<std::is_signed<Key>::value>::type> {
 
-  static bool remove(std::vector<node*>& sequence, const Key& key) {
+  static bool remove(std::vector<node*>& sequence, const Key& key,
+                     std::size_t* seqSize) {
     return key >= 0 ? remove_idx<std::size_t>::remove(
-                          sequence, static_cast<std::size_t>(key))
+                          sequence, static_cast<std::size_t>(key), seqSize)
                     : false;
   }
 };
@@ -161,7 +167,7 @@ inline node& node_data::get(const Key& key, shared_memory_holder pMemory) {
 template <typename Key>
 inline bool node_data::remove(const Key& key, shared_memory_holder pMemory) {
   if (m_type == NodeType::Sequence) {
-    return remove_idx<Key>::remove(m_sequence, key);
+    return remove_idx<Key>::remove(m_sequence, key, &m_seqSize);
   } else if (m_type == NodeType::Map) {
     kv_pairs::iterator it = m_undefinedPairs.begin();
     while (it != m_undefinedPairs.end()) {

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -59,6 +59,19 @@ TEST(NodeTest, SequenceElementRemoval) {
   EXPECT_EQ("c", node[1].as<std::string>());
 }
 
+TEST(NodeTest, SequenceElementRemovalSizeCheck) {
+  Node node;
+  node[0] = "a";
+  node[1] = "b";
+  node[2] = "c";
+  EXPECT_EQ(3, node.size());
+  node.remove(1);
+  EXPECT_TRUE(node.IsSequence());
+  EXPECT_EQ(2, node.size());
+  EXPECT_EQ("a", node[0].as<std::string>());
+  EXPECT_EQ("c", node[1].as<std::string>());
+}
+
 TEST(NodeTest, SequenceFirstElementRemoval) {
   Node node;
   node[0] = "a";
@@ -71,11 +84,37 @@ TEST(NodeTest, SequenceFirstElementRemoval) {
   EXPECT_EQ("c", node[1].as<std::string>());
 }
 
+TEST(NodeTest, SequenceFirstElementRemovalSizeCheck) {
+  Node node;
+  node[0] = "a";
+  node[1] = "b";
+  node[2] = "c";
+  EXPECT_EQ(3, node.size());
+  node.remove(0);
+  EXPECT_TRUE(node.IsSequence());
+  EXPECT_EQ(2, node.size());
+  EXPECT_EQ("b", node[0].as<std::string>());
+  EXPECT_EQ("c", node[1].as<std::string>());
+}
+
 TEST(NodeTest, SequenceLastElementRemoval) {
   Node node;
   node[0] = "a";
   node[1] = "b";
   node[2] = "c";
+  node.remove(2);
+  EXPECT_TRUE(node.IsSequence());
+  EXPECT_EQ(2, node.size());
+  EXPECT_EQ("a", node[0].as<std::string>());
+  EXPECT_EQ("b", node[1].as<std::string>());
+}
+
+TEST(NodeTest, SequenceLastElementRemovalSizeCheck) {
+  Node node;
+  node[0] = "a";
+  node[1] = "b";
+  node[2] = "c";
+  EXPECT_EQ(3, node.size());
   node.remove(2);
   EXPECT_TRUE(node.IsSequence());
   EXPECT_EQ(2, node.size());


### PR DESCRIPTION
I found a bug with sequence nodes wherein size() does not decrease when removing by index.

It was tricky because if node.size() had not been called prior to removing the node by index then the m_seqSize variable would never have been increased to begin with, so the first call to node.size() would then be correct. I added unit tests which call node.size() prior to calling node.remove(idx) which fail without the fix and pass with it.

The symptom of this was in a for loop like this:

```c++
for (size_t i=0; i < seqNode.size(); ++i) {
    if (seqNode[i].Scalar() == someValue) {
        seqNode.remove(i--);
    }
}
```
If there was more than one element removed in that loop, seqNode would convert to Map node!