### PR TITLE
Bazel: Include yaml-cpp as system headers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,7 +8,7 @@ cc_library(
 cc_library(
     name = "yaml-cpp",
     visibility = ["//visibility:public"],
-    strip_include_prefix = "include",
+    includes = ["include"],
     hdrs = glob(["include/**/*.h"]),
     srcs = glob(["src/**/*.cpp", "src/**/*.h"]),
 )


### PR DESCRIPTION
This PR changes the Bazel build file to use `includes` instead of `strip_include_prefix`, by doing so, when yaml-cpp is added to another project it is included as system library (`-isystem ...`) and warnings are ignored. Otherwise it fails to compile on configurations with very strict warning policies.

On a side note, these are the warnings I'm getting, may be worth taking a look
```
yaml-cpp/emitterstyle.h:12:25: error: declaration shadows a variable in namespace 'YAML' [-Werror,-Wshadow]
  enum value { Default, Block, Flow };
                        ^
yaml-cpp/emittermanip.h:52:3: note: previous declaration is here
  Block,
  ^

yaml-cpp/emitterstyle.h:12:32: error: declaration shadows a variable in namespace 'YAML' [-Werror,-Wshadow]
  enum value { Default, Block, Flow };
                               ^
yaml-cpp/emittermanip.h:51:3: note: previous declaration is here
  Flow,
  ^

yaml-cpp/node/type.h:12:27: error: declaration shadows a variable in namespace 'YAML' [-Werror,-Wshadow]
  enum value { Undefined, Null, Scalar, Sequence, Map };
                          ^
yaml-cpp/null.h:23:27: note: previous declaration is here
extern YAML_CPP_API _Null Null;
                          ^
```

Btw, awesome library, thanks a lot!