### PR TITLE
Solve compilation warnings and errors in VS2019

### DIFF
--- a/include/yaml-cpp/node/detail/node_iterator.h
+++ b/include/yaml-cpp/node/detail/node_iterator.h
@@ -52,10 +52,7 @@ struct node_iterator_type<const V> {
 };
 
 template <typename V>
-class node_iterator_base
-    : public std::iterator<std::forward_iterator_tag, node_iterator_value<V>,
-                           std::ptrdiff_t, node_iterator_value<V>*,
-                           node_iterator_value<V>> {
+class node_iterator_base {
  private:
   struct enabler {};
 
@@ -68,9 +65,13 @@ class node_iterator_base
   };
 
  public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = node_iterator_value<V>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = node_iterator_value<V>*;
+  using reference = node_iterator_value<V>;
   using SeqIter = typename node_iterator_type<V>::seq;
   using MapIter = typename node_iterator_type<V>::map;
-  using value_type = node_iterator_value<V>;
 
   node_iterator_base()
       : m_type(iterator_type::NoneType), m_seqIt(), m_mapIt(), m_mapEnd() {}


### PR DESCRIPTION
Hi,

These changes solve warnings and error that show up when using Visual Studio 2019 with the C++ standard set to C++ 17.

The first commit updates the version of Google test in the "test" directory from v1.8.0 to v1.10.0 (related ticket: #623).

The second commit removes the use of `std::iterator` which is deprecated in C++ 17.  This was addressed before by #574 and #575, but `std::iterator` is used again the current master branch.

I tested everything with CMake here, but I'm not very familiar with Bazel, so I'm not sure if anything needs to be updated there.

Cheers,

Romain