### PR TITLE
Pass a mark to BadSubscript exception

### DIFF
--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -248,8 +248,8 @@ class YAML_CPP_API BadDereference : public RepresentationException {
 class YAML_CPP_API BadSubscript : public RepresentationException {
  public:
   template <typename Key>
-  BadSubscript(const Key& key)
-      : RepresentationException(Mark::null_mark(),
+  BadSubscript(const Mark& mark_, const Key& key)
+      : RepresentationException(mark_,
                                 ErrorMsg::BAD_SUBSCRIPT_WITH_KEY(key)) {}
   BadSubscript(const BadSubscript&) = default;
   ~BadSubscript() YAML_CPP_NOEXCEPT override;

--- a/include/yaml-cpp/node/detail/impl.h
+++ b/include/yaml-cpp/node/detail/impl.h
@@ -122,7 +122,7 @@ inline node* node_data::get(const Key& key,
         return pNode;
       return nullptr;
     case NodeType::Scalar:
-      throw BadSubscript(key);
+      throw BadSubscript(m_mark, key);
   }
 
   for (node_map::const_iterator it = m_map.begin(); it != m_map.end(); ++it) {
@@ -150,7 +150,7 @@ inline node& node_data::get(const Key& key, shared_memory_holder pMemory) {
       convert_to_map(pMemory);
       break;
     case NodeType::Scalar:
-      throw BadSubscript(key);
+      throw BadSubscript(m_mark, key);
   }
 
   for (node_map::const_iterator it = m_map.begin(); it != m_map.end(); ++it) {

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -196,7 +196,7 @@ void node_data::insert(node& key, node& value, shared_memory_holder pMemory) {
       convert_to_map(pMemory);
       break;
     case NodeType::Scalar:
-      throw BadSubscript(key);
+      throw BadSubscript(m_mark, key);
   }
 
   insert_map_pair(key, value);
@@ -226,7 +226,7 @@ node& node_data::get(node& key, shared_memory_holder pMemory) {
       convert_to_map(pMemory);
       break;
     case NodeType::Scalar:
-      throw BadSubscript(key);
+      throw BadSubscript(m_mark, key);
   }
 
   for (node_map::const_iterator it = m_map.begin(); it != m_map.end(); ++it) {


### PR DESCRIPTION
It's clearly related to an existing node, so it can have a mark and give an error location.

For me, this was triggered by a user who forgot a `:` after a key name. Not all that unlikely and pretty hard to spot if you don't know where to look. With this patch, I get a proper error message instead of a default (`-1`) mark.