### PR TITLE
Fix 'comparison object must be invocable as const'

### DIFF
--- a/include/yaml-cpp/node/detail/node.h
+++ b/include/yaml-cpp/node/detail/node.h
@@ -20,7 +20,7 @@ namespace detail {
 class node {
  private:
   struct less {
-    bool operator ()(const node* l, const node* r) {return l->m_index < r->m_index;}
+    bool operator ()(const node* l, const node* r) const {return l->m_index < r->m_index;}
   };
 
  public:


### PR DESCRIPTION
Latest gcc 9.3.0 compiler throws an error when compiling with latest headers:
```
/usr/include/c++/9.3.0/bits/stl_tree.h: In instantiation of 'static const _Key& std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_S_key(std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_Const_Link_type) [with _Key = YAML::detail::node*; _Val = YAML::detail::node*; _KeyOfValue = std::_Identity<YAML::detail::node*>; _Compare = YAML::detail::node::less; _Alloc = std::allocator<YAML::detail::node*>; std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_Const_Link_type = const std::_Rb_tree_node<YAML::detail::node*>*]':
/usr/include/c++/9.3.0/bits/stl_tree.h:2095:47:   required from 'std::pair<std::_Rb_tree_node_base*, std::_Rb_tree_node_base*> std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_M_get_insert_unique_pos(const key_type&) [with _Key = YAML::detail::node*; _Val = YAML::detail::node*; _KeyOfValue = std::_Identity<YAML::detail::node*>; _Compare = YAML::detail::node::less; _Alloc = std::allocator<YAML::detail::node*>; std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::key_type = YAML::detail::node*]'
/usr/include/c++/9.3.0/bits/stl_tree.h:2148:4:   required from 'std::pair<std::_Rb_tree_iterator<_Val>, bool> std::_Rb_tree<_Key, _Val, _KeyOfValue, _Compare, _Alloc>::_M_insert_unique(_Arg&&) [with _Arg = YAML::detail::node*; _Key = YAML::detail::node*; _Val = YAML::detail::node*; _KeyOfValue = std::_Identity<YAML::detail::node*>; _Compare = YAML::detail::node::less; _Alloc = std::allocator<YAML::detail::node*>]'
/usr/include/c++/9.3.0/bits/stl_set.h:520:48:   required from 'std::pair<typename std::_Rb_tree<_Key, _Key, std::_Identity<_Tp>, _Compare, typename __gnu_cxx::__alloc_traits<_Alloc>::rebind<_Key>::other>::const_iterator, bool> std::set<_Key, _Compare, _Alloc>::insert(std::set<_Key, _Compare, _Alloc>::value_type&&) [with _Key = YAML::detail::node*; _Compare = YAML::detail::node::less; _Alloc = std::allocator<YAML::detail::node*>; typename std::_Rb_tree<_Key, _Key, std::_Identity<_Tp>, _Compare, typename __gnu_cxx::__alloc_traits<_Alloc>::rebind<_Key>::other>::const_iterator = std::_Rb_tree_const_iterator<YAML::detail::node*>; std::set<_Key, _Compare, _Alloc>::value_type = YAML::detail::node*]'
/usr/local/include/yaml-cpp/node/detail/node.h:60:33:   required from here
/usr/include/c++/9.3.0/bits/stl_tree.h:780:8: error: static assertion failed: comparison object must be invocable as const
  780 |        is_invocable_v<const _Compare&, const _Key&, const _Key&>,
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Adding a `const` keyword to the comparer `less` fixed that.