### PR TITLE
trigger installation through add_subdirectory from another CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,11 @@ find_program(YAML_CPP_CLANG_FORMAT_EXE NAMES clang-format)
 option(YAML_CPP_BUILD_CONTRIB "Enable yaml-cpp contrib in library" ON)
 option(YAML_CPP_BUILD_TOOLS "Enable parse tools" ON)
 option(YAML_BUILD_SHARED_LIBS "Build yaml-cpp shared library" ${BUILD_SHARED_LIBS})
+option(YAML_CPP_INSTALL "Enable generation of yaml-cpp install targets" ON)
 
 cmake_dependent_option(YAML_CPP_BUILD_TESTS
   "Enable yaml-cpp tests" ON
   "BUILD_TESTING;CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
-cmake_dependent_option(YAML_CPP_INSTALL
-  "Enable generation of yaml-cpp install targets" ON
-  "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 cmake_dependent_option(YAML_MSVC_SHARED_RT
   "MSVC: Build yaml-cpp with shared runtime libs (/MD)" ON
   "MSVC" OFF)


### PR DESCRIPTION
fix installation while building with add_subdirectory from another CMakeLists.txt.

As #741 mentioned. I'm not quite understand, why installation should be disable while used as a subdirectory?
