### PR TITLE
Fix clang format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ endif()
 if (YAML_CPP_CLANG_FORMAT_EXE)
   add_custom_target(format
     COMMAND clang-format --style=file -i $<TARGET_PROPERTY:yaml-cpp,SOURCES>
+    COMMAND_EXPAND_LISTS
     COMMENT "Running clang-format"
     VERBATIM)
 endif()

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -97,4 +97,4 @@ std::vector<unsigned char> DecodeBase64(const std::string &input) {
   ret.resize(out - &ret[0]);
   return ret;
 }
-}
+}  // namespace YAML

--- a/src/contrib/graphbuilder.cpp
+++ b/src/contrib/graphbuilder.cpp
@@ -14,4 +14,4 @@ void* BuildGraphOfNextDocument(Parser& parser,
     return nullptr;
   }
 }
-}
+}  // namespace YAML

--- a/src/contrib/graphbuilderadapter.cpp
+++ b/src/contrib/graphbuilderadapter.cpp
@@ -91,4 +91,4 @@ void GraphBuilderAdapter::DispositionNode(void *pNode) {
     m_builder.AppendToSequence(pContainer, pNode);
   }
 }
-}
+}  // namespace YAML

--- a/src/depthguard.cpp
+++ b/src/depthguard.cpp
@@ -2,9 +2,8 @@
 
 namespace YAML {
 
-DeepRecursion::DeepRecursion(int depth, const Mark& mark_, const std::string& msg_)
-    : ParserException(mark_, msg_),
-      m_depth(depth) {
-}
+DeepRecursion::DeepRecursion(int depth, const Mark& mark_,
+                             const std::string& msg_)
+    : ParserException(mark_, msg_), m_depth(depth) {}
 
-} // namespace YAML
+}  // namespace YAML

--- a/src/emit.cpp
+++ b/src/emit.cpp
@@ -1,7 +1,7 @@
 #include "yaml-cpp/node/emit.h"
+#include "nodeevents.h"
 #include "yaml-cpp/emitfromevents.h"
 #include "yaml-cpp/emitter.h"
-#include "nodeevents.h"
 
 namespace YAML {
 Emitter& operator<<(Emitter& out, const Node& node) {

--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -17,4 +17,4 @@ BadPushback::~BadPushback() YAML_CPP_NOEXCEPT = default;
 BadInsert::~BadInsert() YAML_CPP_NOEXCEPT = default;
 EmitterException::~EmitterException() YAML_CPP_NOEXCEPT = default;
 BadFile::~BadFile() YAML_CPP_NOEXCEPT = default;
-}
+}  // namespace YAML

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -22,5 +22,5 @@ node& memory::create_node() {
 void memory::merge(const memory& rhs) {
   m_nodes.insert(rhs.m_nodes.begin(), rhs.m_nodes.end());
 }
-}
-}
+}  // namespace detail
+}  // namespace YAML

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -9,4 +9,4 @@ Node Clone(const Node& node) {
   events.Emit(builder);
   return builder.Root();
 }
-}
+}  // namespace YAML

--- a/src/null.cpp
+++ b/src/null.cpp
@@ -7,4 +7,4 @@ bool IsNullString(const std::string& str) {
   return str.empty() || str == "~" || str == "null" || str == "Null" ||
          str == "NULL";
 }
-}
+}  // namespace YAML

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -3,10 +3,10 @@
 #include <fstream>
 #include <sstream>
 
-#include "yaml-cpp/node/node.h"
-#include "yaml-cpp/node/impl.h"
-#include "yaml-cpp/parser.h"
 #include "nodebuilder.h"
+#include "yaml-cpp/node/impl.h"
+#include "yaml-cpp/node/node.h"
+#include "yaml-cpp/parser.h"
 
 namespace YAML {
 Node Load(const std::string& input) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -17,9 +17,7 @@ Parser::Parser(std::istream& in) : Parser() { Load(in); }
 
 Parser::~Parser() = default;
 
-Parser::operator bool() const {
-  return m_pScanner && !m_pScanner->empty();
-}
+Parser::operator bool() const { return m_pScanner && !m_pScanner->empty(); }
 
 void Parser::Load(std::istream& in) {
   m_pScanner.reset(new Scanner(in));

--- a/src/scanscalar.cpp
+++ b/src/scanscalar.cpp
@@ -247,4 +247,4 @@ std::string ScanScalar(Stream& INPUT, ScanScalarParams& params) {
 
   return scalar;
 }
-}
+}  // namespace YAML

--- a/src/scantag.cpp
+++ b/src/scantag.cpp
@@ -78,4 +78,4 @@ const std::string ScanTagSuffix(Stream& INPUT) {
 
   return tag;
 }
-}
+}  // namespace YAML

--- a/src/simplekey.cpp
+++ b/src/simplekey.cpp
@@ -5,7 +5,11 @@ namespace YAML {
 struct Mark;
 
 Scanner::SimpleKey::SimpleKey(const Mark& mark_, std::size_t flowLevel_)
-    : mark(mark_), flowLevel(flowLevel_), pIndent(nullptr), pMapStart(nullptr), pKey(nullptr) {}
+    : mark(mark_),
+      flowLevel(flowLevel_),
+      pIndent(nullptr),
+      pMapStart(nullptr),
+      pKey(nullptr) {}
 
 void Scanner::SimpleKey::Validate() {
   // Note: pIndent will *not* be garbage here;
@@ -125,4 +129,4 @@ void Scanner::PopAllSimpleKeys() {
   while (!m_simpleKeys.empty())
     m_simpleKeys.pop();
 }
-}
+}  // namespace YAML

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -151,7 +151,8 @@ inline UtfIntroCharType IntroCharTypeOf(std::istream::int_type ch) {
 
 inline char Utf8Adjust(unsigned long ch, unsigned char lead_bits,
                        unsigned char rshift) {
-  const unsigned char header = static_cast<unsigned char>(((1 << lead_bits) - 1) << (8 - lead_bits));
+  const unsigned char header =
+      static_cast<unsigned char>(((1 << lead_bits) - 1) << (8 - lead_bits));
   const unsigned char mask = (0xFF >> (lead_bits + 1));
   return static_cast<char>(
       static_cast<unsigned char>(header | ((ch >> rshift) & mask)));
@@ -273,7 +274,7 @@ char Stream::get() {
 // . Extracts 'n' characters from the stream and updates our position
 std::string Stream::get(int n) {
   std::string ret;
-  if(n > 0) {
+  if (n > 0) {
     ret.reserve(static_cast<std::string::size_type>(n));
     for (int i = 0; i < n; i++)
       ret += get();


### PR DESCRIPTION
When working on a separate PR, I got a message about following the contribution guidelines, so I went to do that.

`make format` seemed to be running `clang-format` with a cmake list instead of a space delimited list  suitable for command line arguments.

In this PR, `CMakeLists.txt` was updated to have `add_custom_command` use the `COMMAND_EXPAND_LISTS` to expand appropriately.

Once this was working, I made a second commit with the changes made by `clang-format`.