### PR TITLE
implement convert for stl containers allowing for custom allocators

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -193,17 +193,17 @@ struct convert<bool> {
 };
 
 // std::map
-template <typename K, typename V>
-struct convert<std::map<K, V>> {
-  static Node encode(const std::map<K, V>& rhs) {
+template <typename K, typename V, typename C, typename A>
+struct convert<std::map<K, V, C, A>> {
+  static Node encode(const std::map<K, V, C, A>& rhs) {
     Node node(NodeType::Map);
-    for (typename std::map<K, V>::const_iterator it = rhs.begin();
+    for (typename std::map<K, V, C, A>::const_iterator it = rhs.begin();
          it != rhs.end(); ++it)
       node.force_insert(it->first, it->second);
     return node;
   }
 
-  static bool decode(const Node& node, std::map<K, V>& rhs) {
+  static bool decode(const Node& node, std::map<K, V, C, A>& rhs) {
     if (!node.IsMap())
       return false;
 
@@ -220,17 +220,17 @@ struct convert<std::map<K, V>> {
 };
 
 // std::vector
-template <typename T>
-struct convert<std::vector<T>> {
-  static Node encode(const std::vector<T>& rhs) {
+template <typename T, typename A>
+struct convert<std::vector<T, A>> {
+  static Node encode(const std::vector<T, A>& rhs) {
     Node node(NodeType::Sequence);
-    for (typename std::vector<T>::const_iterator it = rhs.begin();
+    for (typename std::vector<T, A>::const_iterator it = rhs.begin();
          it != rhs.end(); ++it)
       node.push_back(*it);
     return node;
   }
 
-  static bool decode(const Node& node, std::vector<T>& rhs) {
+  static bool decode(const Node& node, std::vector<T, A>& rhs) {
     if (!node.IsSequence())
       return false;
 
@@ -247,17 +247,17 @@ struct convert<std::vector<T>> {
 };
 
 // std::list
-template <typename T>
-struct convert<std::list<T>> {
-  static Node encode(const std::list<T>& rhs) {
+template <typename T, typename A>
+struct convert<std::list<T,A>> {
+  static Node encode(const std::list<T,A>& rhs) {
     Node node(NodeType::Sequence);
-    for (typename std::list<T>::const_iterator it = rhs.begin();
+    for (typename std::list<T,A>::const_iterator it = rhs.begin();
          it != rhs.end(); ++it)
       node.push_back(*it);
     return node;
   }
 
-  static bool decode(const Node& node, std::list<T>& rhs) {
+  static bool decode(const Node& node, std::list<T,A>& rhs) {
     if (!node.IsSequence())
       return false;
 


### PR DESCRIPTION
This extends `convert` for `list`, `vector`, and `map` to be useful to users venturing astray from the default stl container parameters.

For example, I ran into this while decoding into a vector with a custom allocator for alignment.
see: [Using STL Containers with Eigen](https://eigen.tuxfamily.org/dox/group__TopicStlContainers.html)

For testing, I attempted to create the simplest allocator I could, named `CustomAllocator` which is just an adapter to `malloc` and `free`.

Similar issues could crop up in the usage of `std::string` rather than `std::basic_string`, but that seemed a lot more invasive and so I did not complete work on that.