### PR TITLE
Make debug postfix optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,12 +108,16 @@ target_sources(yaml-cpp
   PRIVATE
     $<$<BOOL:${YAML_CPP_BUILD_CONTRIB}>:${yaml-cpp-contrib-sources}>
     ${yaml-cpp-sources})
+    
+if (NOT DEFINED CMAKE_DEBUG_POSTFIX)
+  set(CMAKE_DEBUG_POSTFIX "d")
+endif()
 
 set_target_properties(yaml-cpp PROPERTIES
   VERSION "${PROJECT_VERSION}"
   SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
   PROJECT_LABEL "yaml-cpp ${yaml-cpp-label-postfix}"
-  DEBUG_POSTFIX d)
+  DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
 
 configure_package_config_file(
   "${PROJECT_SOURCE_DIR}/yaml-cpp-config.cmake.in"


### PR DESCRIPTION
Library debug postfix might not be suitable for cross platform project, and usually require extra work of link against prebuilt yaml-cpp.

Generally, Xcode project output library to these directories:
```
    Debug
    Release
    Debug-iphoneos
    Release-iphoneos
    Debug-iphonesimulator
    Release-iphonesimulator
```

Another Xcode project usually configured its build setting as follow, and expects library name to be same between Release and Debug
```
    LIBRARY_SEARCH_PATHS=$(CONFIGURATION)$(EFFECT_PLATFORM_NAME)
    OTHER_LDFLAGS= $(inherited) -lyaml-cpp
```