### PR TITLE
Fix parsing `{x:`

### DIFF
--- a/src/exp.h
+++ b/src/exp.h
@@ -155,7 +155,7 @@ inline const RegEx& PlainScalar() {
 inline const RegEx& PlainScalarInFlow() {
   static const RegEx e =
       !(BlankOrBreak() | RegEx("?,[]{}#&*!|>\'\"%@`", REGEX_OR) |
-        (RegEx("-:", REGEX_OR) + Blank()));
+        (RegEx("-:", REGEX_OR) + (Blank() | RegEx())));
   return e;
 }
 inline const RegEx& EndScalar() {

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1127,5 +1127,10 @@ TEST(NodeSpecTest, Ex8_22_BlockCollectionNodes) {
   EXPECT_EQ(1, doc["mapping"].size());
   EXPECT_EQ("bar", doc["mapping"]["foo"].as<std::string>());
 }
+
+TEST(NodeSpecTest, FlowMapNotClosed) {
+  EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
+}
+
 }
 }


### PR DESCRIPTION
Discovered-by: James Fish <jfish@pinterest.com>
Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>