### PR TITLE
[clang-tidy] use emplace_back

### DIFF
--- a/src/nodebuilder.cpp
+++ b/src/nodebuilder.cpp
@@ -92,7 +92,7 @@ void NodeBuilder::Push(detail::node& node) {
 
   m_stack.push_back(&node);
   if (needsKey)
-    m_keys.push_back(PushedKey(&node, false));
+    m_keys.emplace_back(&node, false);
 }
 
 void NodeBuilder::Pop() {


### PR DESCRIPTION
Found with modernize-use-emplace

Signed-off-by: Rosen Penev <rosenp@gmail.com>