### PR TITLE
[clang-tidy] use bool literals

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -51,7 +51,7 @@ std::vector<Node> LoadAll(std::istream& input) {
   std::vector<Node> docs;
 
   Parser parser(input);
-  while (1) {
+  while (true) {
     NodeBuilder builder;
     if (!parser.HandleNextDocument(builder)) {
       break;

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -51,7 +51,7 @@ Token& Scanner::peek() {
 Mark Scanner::mark() const { return INPUT.mark(); }
 
 void Scanner::EnsureTokensInQueue() {
-  while (1) {
+  while (true) {
     if (!m_tokens.empty()) {
       Token& token = m_tokens.front();
 
@@ -174,7 +174,7 @@ void Scanner::ScanNextToken() {
 }
 
 void Scanner::ScanToNextToken() {
-  while (1) {
+  while (true) {
     // first eat whitespace
     while (INPUT && IsWhitespaceToBeEaten(INPUT.peek())) {
       if (InBlockContext() && Exp::Tab().Matches(INPUT)) {

--- a/src/scantoken.cpp
+++ b/src/scantoken.cpp
@@ -37,7 +37,7 @@ void Scanner::ScanDirective() {
     token.value += INPUT.get();
 
   // read parameters
-  while (1) {
+  while (true) {
     // first get rid of whitespace
     while (Exp::Blank().Matches(INPUT))
       INPUT.eat(1);

--- a/src/singledocparser.cpp
+++ b/src/singledocparser.cpp
@@ -166,7 +166,7 @@ void SingleDocParser::HandleBlockSequence(EventHandler& eventHandler) {
   m_scanner.pop();
   m_pCollectionStack->PushCollectionType(CollectionType::BlockSeq);
 
-  while (1) {
+  while (true) {
     if (m_scanner.empty())
       throw ParserException(m_scanner.mark(), ErrorMsg::END_OF_SEQ);
 
@@ -199,7 +199,7 @@ void SingleDocParser::HandleFlowSequence(EventHandler& eventHandler) {
   m_scanner.pop();
   m_pCollectionStack->PushCollectionType(CollectionType::FlowSeq);
 
-  while (1) {
+  while (true) {
     if (m_scanner.empty())
       throw ParserException(m_scanner.mark(), ErrorMsg::END_OF_SEQ_FLOW);
 
@@ -252,7 +252,7 @@ void SingleDocParser::HandleBlockMap(EventHandler& eventHandler) {
   m_scanner.pop();
   m_pCollectionStack->PushCollectionType(CollectionType::BlockMap);
 
-  while (1) {
+  while (true) {
     if (m_scanner.empty())
       throw ParserException(m_scanner.mark(), ErrorMsg::END_OF_MAP);
 
@@ -291,7 +291,7 @@ void SingleDocParser::HandleFlowMap(EventHandler& eventHandler) {
   m_scanner.pop();
   m_pCollectionStack->PushCollectionType(CollectionType::FlowMap);
 
-  while (1) {
+  while (true) {
     if (m_scanner.empty())
       throw ParserException(m_scanner.mark(), ErrorMsg::END_OF_MAP_FLOW);
 
@@ -376,7 +376,7 @@ void SingleDocParser::ParseProperties(std::string& tag, anchor_t& anchor,
   anchor_name.clear();
   anchor = NullAnchor;
 
-  while (1) {
+  while (true) {
     if (m_scanner.empty())
       return;
 


### PR DESCRIPTION
Found with modernize-use-bool-literals

Signed-off-by: Rosen Penev <rosenp@gmail.com>