### PR TITLE
[clang-tidy] use raw strings for easier readability

### DIFF
--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -373,15 +373,15 @@ bool WriteChar(ostream_wrapper& out, char ch) {
   if (('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z')) {
     out << ch;
   } else if (ch == '\"') {
-    out << "\"\\\"\"";
+    out << R"("\"")";
   } else if (ch == '\t') {
-    out << "\"\\t\"";
+    out << R"("\t")";
   } else if (ch == '\n') {
-    out << "\"\\n\"";
+    out << R"("\n")";
   } else if (ch == '\b') {
-    out << "\"\\b\"";
+    out << R"("\b")";
   } else if (ch == '\\') {
-    out << "\"\\\\\"";
+    out << R"("\\")";
   } else if (0x20 <= ch && ch <= 0x7e) {
     out << "\"" << ch << "\"";
   } else {

--- a/src/exp.cpp
+++ b/src/exp.cpp
@@ -103,7 +103,7 @@ std::string Escape(Stream& in) {
     case 'e':
       return "\x1B";
     case ' ':
-      return "\x20";
+      return R"( )";
     case '\"':
       return "\"";
     case '\'':


### PR DESCRIPTION
Found with modernize-raw-string-literal

Signed-off-by: Rosen Penev <rosenp@gmail.com>