### PR TITLE
[clang-tidy] fix inconsistent declaration

### DIFF
--- a/src/scanscalar.h
+++ b/src/scanscalar.h
@@ -57,7 +57,7 @@ struct ScanScalarParams {
   bool leadingSpaces;
 };
 
-std::string ScanScalar(Stream& INPUT, ScanScalarParams& info);
+std::string ScanScalar(Stream& INPUT, ScanScalarParams& params);
 }
 
 #endif  // SCANSCALAR_H_62B23520_7C8E_11DE_8A39_0800200C9A66


### PR DESCRIPTION
Found with readability-inconsistent-declaration-parameter-name

Signed-off-by: Rosen Penev <rosenp@gmail.com>