### PR TITLE
[clang-tidy] use override

### DIFF
--- a/util/read.cpp
+++ b/util/read.cpp
@@ -13,18 +13,18 @@ class NullEventHandler : public YAML::EventHandler {
 
   NullEventHandler() {}
 
-  virtual void OnDocumentStart(const Mark&) {}
-  virtual void OnDocumentEnd() {}
-  virtual void OnNull(const Mark&, anchor_t) {}
-  virtual void OnAlias(const Mark&, anchor_t) {}
-  virtual void OnScalar(const Mark&, const std::string&, anchor_t,
-                        const std::string&) {}
-  virtual void OnSequenceStart(const Mark&, const std::string&, anchor_t,
-                               YAML::EmitterStyle::value style) {}
-  virtual void OnSequenceEnd() {}
-  virtual void OnMapStart(const Mark&, const std::string&, anchor_t,
-                          YAML::EmitterStyle::value style) {}
-  virtual void OnMapEnd() {}
+  void OnDocumentStart(const Mark&) override {}
+  void OnDocumentEnd() override {}
+  void OnNull(const Mark&, anchor_t) override {}
+  void OnAlias(const Mark&, anchor_t) override {}
+  void OnScalar(const Mark&, const std::string&, anchor_t,
+                const std::string&) override {}
+  void OnSequenceStart(const Mark&, const std::string&, anchor_t,
+                       YAML::EmitterStyle::value style) override {}
+  void OnSequenceEnd() override {}
+  void OnMapStart(const Mark&, const std::string&, anchor_t,
+                  YAML::EmitterStyle::value style) override {}
+  void OnMapEnd() override {}
 };
 
 void run(std::istream& in) {

--- a/util/sandbox.cpp
+++ b/util/sandbox.cpp
@@ -11,18 +11,18 @@ class NullEventHandler : public YAML::EventHandler {
 
   NullEventHandler() {}
 
-  virtual void OnDocumentStart(const Mark&) {}
-  virtual void OnDocumentEnd() {}
-  virtual void OnNull(const Mark&, anchor_t) {}
-  virtual void OnAlias(const Mark&, anchor_t) {}
-  virtual void OnScalar(const Mark&, const std::string&, anchor_t,
-                        const std::string&) {}
-  virtual void OnSequenceStart(const Mark&, const std::string&, anchor_t,
-                               YAML::EmitterStyle::value style) {}
-  virtual void OnSequenceEnd() {}
-  virtual void OnMapStart(const Mark&, const std::string&, anchor_t,
-                          YAML::EmitterStyle::value style) {}
-  virtual void OnMapEnd() {}
+  void OnDocumentStart(const Mark&) override {}
+  void OnDocumentEnd() override {}
+  void OnNull(const Mark&, anchor_t) override {}
+  void OnAlias(const Mark&, anchor_t) override {}
+  void OnScalar(const Mark&, const std::string&, anchor_t,
+                const std::string&) override {}
+  void OnSequenceStart(const Mark&, const std::string&, anchor_t,
+                       YAML::EmitterStyle::value style) override {}
+  void OnSequenceEnd() override {}
+  void OnMapStart(const Mark&, const std::string&, anchor_t,
+                  YAML::EmitterStyle::value style) override {}
+  void OnMapEnd() override {}
 };
 
 int main() {


### PR DESCRIPTION
Found with modernize-use-override

Signed-off-by: Rosen Penev <rosenp@gmail.com>