### PR TITLE
[clang-tidy] use = default

### DIFF
--- a/util/read.cpp
+++ b/util/read.cpp
@@ -11,7 +11,7 @@ class NullEventHandler : public YAML::EventHandler {
   typedef YAML::Mark Mark;
   typedef YAML::anchor_t anchor_t;
 
-  NullEventHandler() {}
+  NullEventHandler() = default;
 
   virtual void OnDocumentStart(const Mark&) {}
   virtual void OnDocumentEnd() {}

--- a/util/sandbox.cpp
+++ b/util/sandbox.cpp
@@ -9,7 +9,7 @@ class NullEventHandler : public YAML::EventHandler {
   typedef YAML::Mark Mark;
   typedef YAML::anchor_t anchor_t;
 
-  NullEventHandler() {}
+  NullEventHandler() = default;
 
   virtual void OnDocumentStart(const Mark&) {}
   virtual void OnDocumentEnd() {}


### PR DESCRIPTION
Found with modernize-use-equals-default

Signed-off-by: Rosen Penev <rosenp@gmail.com>