### PR TITLE
[clang-tidy] convert to range loops

### DIFF
--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -209,9 +209,9 @@ node* node_data::get(node& key, shared_memory_holder /* pMemory */) const {
     return nullptr;
   }
 
-  for (node_map::const_iterator it = m_map.begin(); it != m_map.end(); ++it) {
-    if (it->first->is(key))
-      return it->second;
+  for (const auto& it : m_map) {
+    if (it.first->is(key))
+      return it.second;
   }
 
   return nullptr;
@@ -230,9 +230,9 @@ node& node_data::get(node& key, shared_memory_holder pMemory) {
       throw BadSubscript(m_mark, key);
   }
 
-  for (node_map::const_iterator it = m_map.begin(); it != m_map.end(); ++it) {
-    if (it->first->is(key))
-      return *it->second;
+  for (const auto& it : m_map) {
+    if (it.first->is(key))
+      return *it.second;
   }
 
   node& value = pMemory->create_node();

--- a/src/nodeevents.cpp
+++ b/src/nodeevents.cpp
@@ -32,8 +32,8 @@ void NodeEvents::Setup(const detail::node& node) {
     return;
 
   if (node.type() == NodeType::Sequence) {
-    for (detail::const_node_iterator it = node.begin(); it != node.end(); ++it)
-      Setup(**it);
+    for (const auto& it : node)
+      Setup(*it);
   } else if (node.type() == NodeType::Map) {
     for (detail::const_node_iterator it = node.begin(); it != node.end();
          ++it) {
@@ -77,9 +77,8 @@ void NodeEvents::Emit(const detail::node& node, EventHandler& handler,
       break;
     case NodeType::Sequence:
       handler.OnSequenceStart(Mark(), node.tag(), anchor, node.style());
-      for (detail::const_node_iterator it = node.begin(); it != node.end();
-           ++it)
-        Emit(**it, handler, am);
+      for (const auto& it : node)
+        Emit(*it, handler, am);
       handler.OnSequenceEnd();
       break;
     case NodeType::Map:


### PR DESCRIPTION
Found with modernize-loop-convert

Signed-off-by: Rosen Penev <rosenp@gmail.com>