### PR TITLE
[clang-tidy] do not use return after else

### DIFF
--- a/src/contrib/graphbuilder.cpp
+++ b/src/contrib/graphbuilder.cpp
@@ -10,8 +10,7 @@ void* BuildGraphOfNextDocument(Parser& parser,
   GraphBuilderAdapter eventHandler(graphBuilder);
   if (parser.HandleNextDocument(eventHandler)) {
     return eventHandler.RootNode();
-  } else {
-    return nullptr;
   }
+  return nullptr;
 }
 }  // namespace YAML

--- a/src/emitterstate.cpp
+++ b/src/emitterstate.cpp
@@ -94,14 +94,12 @@ EmitterNodeType::value EmitterState::NextGroupType(
   if (type == GroupType::Seq) {
     if (GetFlowType(type) == Block)
       return EmitterNodeType::BlockSeq;
-    else
-      return EmitterNodeType::FlowSeq;
-  } else {
-    if (GetFlowType(type) == Block)
-      return EmitterNodeType::BlockMap;
-    else
-      return EmitterNodeType::FlowMap;
+    return EmitterNodeType::FlowSeq;
   }
+
+  if (GetFlowType(type) == Block)
+    return EmitterNodeType::BlockMap;
+  return EmitterNodeType::FlowMap;
 
   // can't happen
   assert(false);
@@ -156,9 +154,8 @@ void EmitterState::EndedGroup(GroupType::value type) {
   if (m_groups.empty()) {
     if (type == GroupType::Seq) {
       return SetError(ErrorMsg::UNEXPECTED_END_SEQ);
-    } else {
-      return SetError(ErrorMsg::UNEXPECTED_END_MAP);
     }
+    return SetError(ErrorMsg::UNEXPECTED_END_MAP);
   }
 
   // get rid of the current group

--- a/src/exp.cpp
+++ b/src/exp.cpp
@@ -54,14 +54,16 @@ std::string Escape(Stream& in, int codeLength) {
   // now break it up into chars
   if (value <= 0x7F)
     return Str(value);
-  else if (value <= 0x7FF)
+
+  if (value <= 0x7FF)
     return Str(0xC0 + (value >> 6)) + Str(0x80 + (value & 0x3F));
-  else if (value <= 0xFFFF)
+
+  if (value <= 0xFFFF)
     return Str(0xE0 + (value >> 12)) + Str(0x80 + ((value >> 6) & 0x3F)) +
            Str(0x80 + (value & 0x3F));
-  else
-    return Str(0xF0 + (value >> 18)) + Str(0x80 + ((value >> 12) & 0x3F)) +
-           Str(0x80 + ((value >> 6) & 0x3F)) + Str(0x80 + (value & 0x3F));
+
+  return Str(0xF0 + (value >> 18)) + Str(0x80 + ((value >> 12) & 0x3F)) +
+         Str(0x80 + ((value >> 6) & 0x3F)) + Str(0x80 + (value & 0x3F));
 }
 
 // Escape

--- a/src/scanscalar.cpp
+++ b/src/scanscalar.cpp
@@ -47,7 +47,8 @@ std::string ScanScalar(Stream& INPUT, ScanScalarParams& params) {
       if (INPUT.column() == 0 && Exp::DocIndicator().Matches(INPUT)) {
         if (params.onDocIndicator == BREAK) {
           break;
-        } else if (params.onDocIndicator == THROW) {
+        }
+        if (params.onDocIndicator == THROW) {
           throw ParserException(INPUT.mark(), ErrorMsg::DOC_IN_SCALAR);
         }
       }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -350,7 +350,9 @@ void Stream::StreamInUtf16() const {
     // Trailing (low) surrogate...ugh, wrong order
     QueueUnicodeCodepoint(m_readahead, CP_REPLACEMENT_CHARACTER);
     return;
-  } else if (ch >= 0xD800 && ch < 0xDC00) {
+  }
+
+  if (ch >= 0xD800 && ch < 0xDC00) {
     // ch is a leading (high) surrogate
 
     // Four byte UTF-8 code point
@@ -375,11 +377,10 @@ void Stream::StreamInUtf16() const {
           // Easiest case: queue the codepoint and return
           QueueUnicodeCodepoint(m_readahead, ch);
           return;
-        } else {
-          // Start the loop over with the new high surrogate
-          ch = chLow;
-          continue;
         }
+        // Start the loop over with the new high surrogate
+        ch = chLow;
+        continue;
       }
 
       // Select the payload bits from the high surrogate


### PR DESCRIPTION
Found with readability-else-after-return

Signed-off-by: Rosen Penev <rosenp@gmail.com>