### PR TITLE
partially fix clang compilation

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -225,8 +225,8 @@ template <typename K, typename V, typename C, typename A>
 struct convert<std::map<K, V, C, A>> {
   static Node encode(const std::map<K, V, C, A>& rhs) {
     Node node(NodeType::Map);
-    for (const auto& it : rhs)
-      node.force_insert(it.first, it.second);
+    for (const auto& element : rhs)
+      node.force_insert(element.first, element.second);
     return node;
   }
 
@@ -235,12 +235,12 @@ struct convert<std::map<K, V, C, A>> {
       return false;
 
     rhs.clear();
-    for (const auto& it : node)
+    for (const auto& element : node)
 #if defined(__GNUC__) && __GNUC__ < 4
       // workaround for GCC 3:
-      rhs[it.first.template as<K>()] = it.second.template as<V>();
+      rhs[element.first.template as<K>()] = element.second.template as<V>();
 #else
-      rhs[it.first.as<K>()] = it.second.as<V>();
+      rhs[element.first.as<K>()] = element.second.as<V>();
 #endif
     return true;
   }
@@ -251,7 +251,8 @@ template <typename T, typename A>
 struct convert<std::vector<T, A>> {
   static Node encode(const std::vector<T, A>& rhs) {
     Node node(NodeType::Sequence);
-    std::copy(rhs.begin(), rhs.end(), std::back_inserter(rhs));
+    for (const auto& element : rhs)
+      node.push_back(element);
     return node;
   }
 
@@ -260,12 +261,12 @@ struct convert<std::vector<T, A>> {
       return false;
 
     rhs.clear();
-    for (const auto& it : node)
+    for (const auto& element : node)
 #if defined(__GNUC__) && __GNUC__ < 4
       // workaround for GCC 3:
-      rhs.push_back(it.template as<T>());
+      rhs.push_back(element.template as<T>());
 #else
-      rhs.push_back(it.as<T>());
+      rhs.push_back(element.as<T>());
 #endif
     return true;
   }
@@ -276,7 +277,8 @@ template <typename T, typename A>
 struct convert<std::list<T,A>> {
   static Node encode(const std::list<T,A>& rhs) {
     Node node(NodeType::Sequence);
-    std::copy(rhs.begin(), rhs.end(), std::back_inserter(rhs));
+    for (const auto& element : rhs)
+      node.push_back(element);
     return node;
   }
 
@@ -285,12 +287,12 @@ struct convert<std::list<T,A>> {
       return false;
 
     rhs.clear();
-    for (const auto& it : node)
+    for (const auto& element : node)
 #if defined(__GNUC__) && __GNUC__ < 4
       // workaround for GCC 3:
-      rhs.push_back(it.template as<T>());
+      rhs.push_back(element.template as<T>());
 #else
-      rhs.push_back(it.as<T>());
+      rhs.push_back(element.as<T>());
 #endif
     return true;
   }
@@ -301,7 +303,9 @@ template <typename T, std::size_t N>
 struct convert<std::array<T, N>> {
   static Node encode(const std::array<T, N>& rhs) {
     Node node(NodeType::Sequence);
-    std::copy(rhs.begin(), rhs.end(), std::back_inserter(rhs));
+    for (const auto& element : rhs) {
+      node.push_back(element);
+    }
     return node;
   }
 

--- a/include/yaml-cpp/node/detail/impl.h
+++ b/include/yaml-cpp/node/detail/impl.h
@@ -158,7 +158,7 @@ inline node& node_data::get(const Key& key, shared_memory_holder pMemory) {
   });
 
   if (it != m_map.end()) {
-    return it->second;
+    return *it->second;
   }
 
   node& k = convert_to_node(key, pMemory);

--- a/include/yaml-cpp/stlemitter.h
+++ b/include/yaml-cpp/stlemitter.h
@@ -16,8 +16,8 @@ namespace YAML {
 template <typename Seq>
 inline Emitter& EmitSeq(Emitter& emitter, const Seq& seq) {
   emitter << BeginSeq;
-  for (typename Seq::const_iterator it = seq.begin(); it != seq.end(); ++it)
-    emitter << *it;
+  for (const auto& emit : seq)
+    emitter << emit;
   emitter << EndSeq;
   return emitter;
 }
@@ -41,8 +41,8 @@ template <typename K, typename V>
 inline Emitter& operator<<(Emitter& emitter, const std::map<K, V>& m) {
   typedef typename std::map<K, V> map;
   emitter << BeginMap;
-  for (typename map::const_iterator it = m.begin(); it != m.end(); ++it)
-    emitter << Key << it->first << Value << it->second;
+  for (const auto& emit : m)
+    emitter << Key << emit.first << Value << emit.second;
   emitter << EndMap;
   return emitter;
 }

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cassert>
 #include <iterator>
 #include <sstream>

--- a/src/nodeevents.cpp
+++ b/src/nodeevents.cpp
@@ -32,13 +32,12 @@ void NodeEvents::Setup(const detail::node& node) {
     return;
 
   if (node.type() == NodeType::Sequence) {
-    for (const auto& it : node)
-      Setup(*it);
+    for (auto element : node)
+      Setup(*element);
   } else if (node.type() == NodeType::Map) {
-    for (detail::const_node_iterator it = node.begin(); it != node.end();
-         ++it) {
-      Setup(*it->first);
-      Setup(*it->second);
+    for (auto element : node) {
+      Setup(*element.first);
+      Setup(*element.second);
     }
   }
 }
@@ -77,16 +76,15 @@ void NodeEvents::Emit(const detail::node& node, EventHandler& handler,
       break;
     case NodeType::Sequence:
       handler.OnSequenceStart(Mark(), node.tag(), anchor, node.style());
-      for (const auto& it : node)
-        Emit(*it, handler, am);
+      for (auto element : node)
+        Emit(*element, handler, am);
       handler.OnSequenceEnd();
       break;
     case NodeType::Map:
       handler.OnMapStart(Mark(), node.tag(), anchor, node.style());
-      for (detail::const_node_iterator it = node.begin(); it != node.end();
-           ++it) {
-        Emit(*it->first, handler, am);
-        Emit(*it->second, handler, am);
+      for (auto element : node) {
+        Emit(*element.first, handler, am);
+        Emit(*element.second, handler, am);
       }
       handler.OnMapEnd();
       break;

--- a/src/setting.h
+++ b/src/setting.h
@@ -83,9 +83,8 @@ class SettingChanges {
   }
 
   void restore() YAML_CPP_NOEXCEPT {
-    for (setting_changes::const_iterator it = m_settingChanges.begin();
-         it != m_settingChanges.end(); ++it)
-      (*it)->pop();
+    for (const auto& setting : m_settingChanges)
+      setting->pop();
   }
 
   void push(std::unique_ptr<SettingChangeBase> pSettingChange) {

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -254,7 +254,7 @@ TEST(NodeTest, IncompleteJson) {
       {"JSON map without end brace", "{\"access\":\"abc\"",
        ErrorMsg::END_OF_MAP_FLOW},
   };
-  for (const ParserExceptionTestCase test : tests) {
+  for (const ParserExceptionTestCase& test : tests) {
     try {
       Load(test.input);
       FAIL() << "Expected exception " << test.expected_exception << " for "


### PR DESCRIPTION
Missing header and mistaken algorithm usage.

Also removed it name from range loops. It's not correct.

Signed-off-by: Rosen Penev <rosenp@gmail.com>