### PR TITLE
[clang-tidy] convert several functions to use references

### DIFF
--- a/include/yaml-cpp/node/detail/node_data.h
+++ b/include/yaml-cpp/node/detail/node_data.h
@@ -60,8 +60,8 @@ class YAML_CPP_API node_data {
   node_iterator end();
 
   // sequence
-  void push_back(node& node, shared_memory_holder pMemory);
-  void insert(node& key, node& value, shared_memory_holder pMemory);
+  void push_back(node& node, const shared_memory_holder& pMemory);
+  void insert(node& key, node& value, const shared_memory_holder& pMemory);
 
   // indexing
   template <typename Key>
@@ -71,9 +71,9 @@ class YAML_CPP_API node_data {
   template <typename Key>
   bool remove(const Key& key, shared_memory_holder pMemory);
 
-  node* get(node& key, shared_memory_holder pMemory) const;
-  node& get(node& key, shared_memory_holder pMemory);
-  bool remove(node& key, shared_memory_holder pMemory);
+  node* get(node& key, const shared_memory_holder& pMemory) const;
+  node& get(node& key, const shared_memory_holder& pMemory);
+  bool remove(node& key, const shared_memory_holder& pMemory);
 
   // map
   template <typename Key, typename Value>
@@ -91,8 +91,8 @@ class YAML_CPP_API node_data {
   void reset_map();
 
   void insert_map_pair(node& key, node& value);
-  void convert_to_map(shared_memory_holder pMemory);
-  void convert_sequence_to_map(shared_memory_holder pMemory);
+  void convert_to_map(const shared_memory_holder& pMemory);
+  void convert_sequence_to_map(const shared_memory_holder& pMemory);
 
   template <typename T>
   static node& convert_to_node(const T& rhs, shared_memory_holder pMemory);

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -175,7 +175,8 @@ node_iterator node_data::end() {
 }
 
 // sequence
-void node_data::push_back(node& node, shared_memory_holder /* pMemory */) {
+void node_data::push_back(node& node,
+                          const shared_memory_holder& /* pMemory */) {
   if (m_type == NodeType::Undefined || m_type == NodeType::Null) {
     m_type = NodeType::Sequence;
     reset_sequence();
@@ -187,7 +188,8 @@ void node_data::push_back(node& node, shared_memory_holder /* pMemory */) {
   m_sequence.push_back(&node);
 }
 
-void node_data::insert(node& key, node& value, shared_memory_holder pMemory) {
+void node_data::insert(node& key, node& value,
+                       const shared_memory_holder& pMemory) {
   switch (m_type) {
     case NodeType::Map:
       break;
@@ -204,7 +206,8 @@ void node_data::insert(node& key, node& value, shared_memory_holder pMemory) {
 }
 
 // indexing
-node* node_data::get(node& key, shared_memory_holder /* pMemory */) const {
+node* node_data::get(node& key,
+                     const shared_memory_holder& /* pMemory */) const {
   if (m_type != NodeType::Map) {
     return nullptr;
   }
@@ -217,7 +220,7 @@ node* node_data::get(node& key, shared_memory_holder /* pMemory */) const {
   return nullptr;
 }
 
-node& node_data::get(node& key, shared_memory_holder pMemory) {
+node& node_data::get(node& key, const shared_memory_holder& pMemory) {
   switch (m_type) {
     case NodeType::Map:
       break;
@@ -240,7 +243,7 @@ node& node_data::get(node& key, shared_memory_holder pMemory) {
   return value;
 }
 
-bool node_data::remove(node& key, shared_memory_holder /* pMemory */) {
+bool node_data::remove(node& key, const shared_memory_holder& /* pMemory */) {
   if (m_type != NodeType::Map)
     return false;
 
@@ -283,7 +286,7 @@ void node_data::insert_map_pair(node& key, node& value) {
     m_undefinedPairs.emplace_back(&key, &value);
 }
 
-void node_data::convert_to_map(shared_memory_holder pMemory) {
+void node_data::convert_to_map(const shared_memory_holder& pMemory) {
   switch (m_type) {
     case NodeType::Undefined:
     case NodeType::Null:
@@ -301,7 +304,7 @@ void node_data::convert_to_map(shared_memory_holder pMemory) {
   }
 }
 
-void node_data::convert_sequence_to_map(shared_memory_holder pMemory) {
+void node_data::convert_sequence_to_map(const shared_memory_holder& pMemory) {
   assert(m_type == NodeType::Sequence);
 
   reset_map();


### PR DESCRIPTION
Found with performance-unnecessary-value-param

Signed-off-by: Rosen Penev <rosenp@gmail.com>