### PR TITLE
Tag null

### DIFF
--- a/src/singledocparser.cpp
+++ b/src/singledocparser.cpp
@@ -90,15 +90,16 @@ void SingleDocParser::HandleNode(EventHandler& eventHandler) {
 
   const Token& token = m_scanner.peek();
 
-  if (token.type == Token::PLAIN_SCALAR && IsNullString(token.value)) {
+  // add non-specific tags
+  if (tag.empty())
+    tag = (token.type == Token::NON_PLAIN_SCALAR ? "!" : "?");
+  
+  if (token.type == Token::PLAIN_SCALAR 
+      && tag.compare("?") == 0 && IsNullString(token.value)) {
     eventHandler.OnNull(mark, anchor);
     m_scanner.pop();
     return;
   }
-
-  // add non-specific tags
-  if (tag.empty())
-    tag = (token.type == Token::NON_PLAIN_SCALAR ? "!" : "?");
 
   // now split based on what kind of node we should be
   switch (token.type) {


### PR DESCRIPTION
yaml-cpp will ignore the tag information when load the null.
```
Load:
    !!str null
output:
    ~
```
After changes, the result is
```
Load:
    !!str null
output:
    !<tag:yaml.org,2002:str> null
```