### PR TITLE
refactor to allow MSVC without #define NOMINMAX

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -120,8 +120,8 @@ typename std::enable_if<(std::is_same<T, unsigned char>::value ||
 ConvertStreamTo(std::stringstream& stream, T& rhs) {
   int num;
   if ((stream >> std::noskipws >> num) && (stream >> std::ws).eof()) {
-    if (num >= std::numeric_limits<T>::min() &&
-        num <= std::numeric_limits<T>::max()) {
+    if (num >= (std::numeric_limits<T>::min)() &&
+        num <= (std::numeric_limits<T>::max)()) {
       rhs = num;
       return true;
     }


### PR DESCRIPTION
fix for https://github.com/jbeder/yaml-cpp/issues/904

reference: https://github.com/microsoft/cppwinrt/issues/479