### PR TITLE
Support to escape CR (\r) in load/emit

### DIFF
--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -176,11 +176,11 @@ bool IsValidPlainScalar(const std::string& str, FlowType::value flowType,
   static const RegEx& disallowed_flow =
       Exp::EndScalarInFlow() | (Exp::BlankOrBreak() + Exp::Comment()) |
       Exp::NotPrintable() | Exp::Utf8_ByteOrderMark() | Exp::Break() |
-      Exp::Tab();
+      Exp::Tab() | Exp::CR();
   static const RegEx& disallowed_block =
       Exp::EndScalar() | (Exp::BlankOrBreak() + Exp::Comment()) |
       Exp::NotPrintable() | Exp::Utf8_ByteOrderMark() | Exp::Break() |
-      Exp::Tab();
+      Exp::Tab() | Exp::CR();
   const RegEx& disallowed =
       flowType == FlowType::Flow ? disallowed_flow : disallowed_block;
 

--- a/src/exp.h
+++ b/src/exp.h
@@ -69,7 +69,7 @@ inline const RegEx& Hex() {
 inline const RegEx& NotPrintable() {
   static const RegEx e =
       RegEx(0) |
-      RegEx("\x01\x02\x03\x04\x05\x06\x07\x08\x0B\x0C\x7F", REGEX_OR) |
+      RegEx("\x01\x02\x03\x04\x05\x06\x07\x08\x0B\x0C\x0D\x7F", REGEX_OR) |
       RegEx(0x0E, 0x1F) |
       (RegEx('\xC2') + (RegEx('\x80', '\x84') | RegEx('\x86', '\x9F')));
   return e;

--- a/src/exp.h
+++ b/src/exp.h
@@ -32,6 +32,10 @@ inline const RegEx& Tab() {
   static const RegEx e = RegEx('\t');
   return e;
 }
+inline const RegEx& CR() {
+  static const RegEx e = RegEx('\r');
+  return e;
+}
 inline const RegEx& Blank() {
   static const RegEx e = Space() | Tab();
   return e;
@@ -69,7 +73,7 @@ inline const RegEx& Hex() {
 inline const RegEx& NotPrintable() {
   static const RegEx e =
       RegEx(0) |
-      RegEx("\x01\x02\x03\x04\x05\x06\x07\x08\x0B\x0C\x0D\x7F", REGEX_OR) |
+      RegEx("\x01\x02\x03\x04\x05\x06\x07\x08\x0B\x0C\x7F", REGEX_OR) |
       RegEx(0x0E, 0x1F) |
       (RegEx('\xC2') + (RegEx('\x80', '\x84') | RegEx('\x86', '\x9F')));
   return e;

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -1127,6 +1127,17 @@ TEST_F(EmitterTest, SingleChar) {
   ExpectEmit("- a\n- \":\"\n- \"\\x10\"\n- \"\\n\"\n- \" \"\n- \"\\t\"");
 }
 
+TEST_F(EmitterTest, EscapeCarriageReturn) {
+  out << "aaa\rbbb";
+  ExpectEmit("\"aaa\\rbbb\"");
+}
+
+TEST_F(EmitterTest, EscapeCarriageReturnOnNode) {
+  Node n(Load("\"aaa\rbbb\""));
+  out << n;
+  ExpectEmit("\"aaa\\rbbb\"");
+}
+
 TEST_F(EmitterTest, DefaultPrecision) {
   out << BeginSeq;
   out << 1.3125f;


### PR DESCRIPTION
#607 