### PR TITLE
fix issue740: parse colon in plain scalar correctly

### DIFF
--- a/src/exp.h
+++ b/src/exp.h
@@ -110,7 +110,7 @@ inline const RegEx& Value() {
   return e;
 }
 inline const RegEx& ValueInFlow() {
-  static const RegEx e = RegEx(':') + (BlankOrBreak() | RegEx(",}", REGEX_OR));
+  static const RegEx e = RegEx(':') + (BlankOrBreak() | RegEx(",]}", REGEX_OR));
   return e;
 }
 inline const RegEx& ValueInJSONFlow() {
@@ -164,7 +164,8 @@ inline const RegEx& EndScalar() {
 }
 inline const RegEx& EndScalarInFlow() {
   static const RegEx e =
-      (RegEx(':') + (BlankOrBreak() | RegEx())) | RegEx(",?[]{}", REGEX_OR);
+      (RegEx(':') + (BlankOrBreak() | RegEx() | RegEx(",]}", REGEX_OR))) |
+      RegEx(",?[]{}", REGEX_OR);
   return e;
 }
 

--- a/src/exp.h
+++ b/src/exp.h
@@ -164,8 +164,7 @@ inline const RegEx& EndScalar() {
 }
 inline const RegEx& EndScalarInFlow() {
   static const RegEx e =
-      (RegEx(':') + (BlankOrBreak() | RegEx() | RegEx(",]}", REGEX_OR))) |
-      RegEx(",?[]{}", REGEX_OR);
+      (RegEx(':') + (BlankOrBreak() | RegEx())) | RegEx(",?[]{}", REGEX_OR);
   return e;
 }
 

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -246,15 +246,59 @@ struct ParserExceptionTestCase {
 
 TEST(NodeTest, IncompleteJson) {
   std::vector<ParserExceptionTestCase> tests = {
-      {"JSON map without value", "{\"access\"", ErrorMsg::END_OF_MAP_FLOW},
-      {"JSON map with colon but no value", "{\"access\":",
-       ErrorMsg::END_OF_MAP_FLOW},
-      {"JSON map with unclosed value quote", "{\"access\":\"",
-       ErrorMsg::END_OF_MAP_FLOW},
-      {"JSON map without end brace", "{\"access\":\"abc\"",
-       ErrorMsg::END_OF_MAP_FLOW},
+    {"JSON map without value", "{\"access\"", ErrorMsg::END_OF_MAP_FLOW},
+    {"JSON map with colon but no value", "{\"access\":",
+     ErrorMsg::END_OF_MAP_FLOW},
+    {"JSON map with unclosed value quote", "{\"access\":\"",
+     ErrorMsg::END_OF_MAP_FLOW},
+    {"JSON map without end brace", "{\"access\":\"abc\"",
+     ErrorMsg::END_OF_MAP_FLOW},
   };
   for (const ParserExceptionTestCase& test : tests) {
+    try {
+      Load(test.input);
+      FAIL() << "Expected exception " << test.expected_exception << " for "
+             << test.name << ", input: " << test.input;
+    } catch (const ParserException& e) {
+      EXPECT_EQ(test.expected_exception, e.msg);
+    }
+  }
+}
+
+struct SingleNodeTestCase {
+  std::string input;
+  NodeType::value nodeType;
+  int nodeSize;
+  std::string expected_content;
+};
+
+TEST(NodeTest, SpecialFlow) {
+  std::vector<SingleNodeTestCase> tests = {
+    {"[,]", NodeType::Sequence, 1, "[~]"},
+    {"[a:]", NodeType::Sequence, 1, "[\"a:\"]"},
+    {"[:a]", NodeType::Sequence, 1, "[:a]"},
+    {"[:]", NodeType::Sequence, 1, "[\":\"]"},
+    {"{:}", NodeType::Map, 1, "{~: ~}"},
+    {"{,}", NodeType::Map, 1, "{~: ~}"},
+    {"{a:}", NodeType::Map, 1, "{\"a:\": ~}"},
+    {"{:a}", NodeType::Map, 1, "{:a: ~}"},
+  };
+  for (const SingleNodeTestCase& test : tests) {
+    Node node = Load(test.input);
+    Emitter emitter;
+    emitter << node;
+    EXPECT_EQ(test.nodeType, node.Type());
+    EXPECT_EQ(test.nodeSize, node.size());
+    EXPECT_EQ(test.expected_content, std::string(emitter.c_str()));
+  }
+}
+
+TEST(NodeTest, IncorrectFlow) {
+  std::vector<ParserExceptionTestCase> tests = {
+    {"Incorrect yaml: \"{:]\"", "{:]", ErrorMsg::FLOW_END},
+    {"Incorrect yaml: \"[:}\"", "[:}", ErrorMsg::FLOW_END},
+  };
+  for (const ParserExceptionTestCase test : tests) {
     try {
       Load(test.input);
       FAIL() << "Expected exception " << test.expected_exception << " for "

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -246,13 +246,13 @@ struct ParserExceptionTestCase {
 
 TEST(NodeTest, IncompleteJson) {
   std::vector<ParserExceptionTestCase> tests = {
-    {"JSON map without value", "{\"access\"", ErrorMsg::END_OF_MAP_FLOW},
-    {"JSON map with colon but no value", "{\"access\":",
-     ErrorMsg::END_OF_MAP_FLOW},
-    {"JSON map with unclosed value quote", "{\"access\":\"",
-     ErrorMsg::END_OF_MAP_FLOW},
-    {"JSON map without end brace", "{\"access\":\"abc\"",
-     ErrorMsg::END_OF_MAP_FLOW},
+      {"JSON map without value", "{\"access\"", ErrorMsg::END_OF_MAP_FLOW},
+      {"JSON map with colon but no value", "{\"access\":",
+       ErrorMsg::END_OF_MAP_FLOW},
+      {"JSON map with unclosed value quote", "{\"access\":\"",
+       ErrorMsg::END_OF_MAP_FLOW},
+      {"JSON map without end brace", "{\"access\":\"abc\"",
+       ErrorMsg::END_OF_MAP_FLOW},
   };
   for (const ParserExceptionTestCase& test : tests) {
     try {
@@ -274,14 +274,16 @@ struct SingleNodeTestCase {
 
 TEST(NodeTest, SpecialFlow) {
   std::vector<SingleNodeTestCase> tests = {
-    {"[,]", NodeType::Sequence, 1, "[~]"},
-    {"[a:]", NodeType::Sequence, 1, "[\"a:\"]"},
-    {"[:a]", NodeType::Sequence, 1, "[:a]"},
-    {"[:]", NodeType::Sequence, 1, "[\":\"]"},
-    {"{:}", NodeType::Map, 1, "{~: ~}"},
-    {"{,}", NodeType::Map, 1, "{~: ~}"},
-    {"{a:}", NodeType::Map, 1, "{\"a:\": ~}"},
-    {"{:a}", NodeType::Map, 1, "{:a: ~}"},
+      {"[:]", NodeType::Sequence, 1, "[{~: ~}]"},
+      {"[a:]", NodeType::Sequence, 1, "[{a: ~}]"},
+      {"[:a]", NodeType::Sequence, 1, "[:a]"},
+      {"[,]", NodeType::Sequence, 1, "[~]"},
+      {"[a:,]", NodeType::Sequence, 1, "[{a: ~}]"},
+      {"{:}", NodeType::Map, 1, "{~: ~}"},
+      {"{a:}", NodeType::Map, 1, "{a: ~}"},
+      {"{:a}", NodeType::Map, 1, "{:a: ~}"},
+      {"{,}", NodeType::Map, 1, "{~: ~}"},
+      {"{a:,}", NodeType::Map, 1, "{a: ~}"},
   };
   for (const SingleNodeTestCase& test : tests) {
     Node node = Load(test.input);

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -552,7 +552,7 @@ const char *ex7_2 =
 
 const char *ex7_3 =
     "{\n"
-    "  ? foo : ,\n"
+    "  ? foo :,\n"
     "  : bar,\n"
     "}\n";
 
@@ -641,8 +641,8 @@ const char *ex7_17 =
     "{\n"
     "unquoted : \"separate\",\n"
     "http://foo.com,\n"
-    "omitted value: ,\n"
-    " : omitted key,\n"
+    "omitted value:,\n"
+    ": omitted key,\n"
     "}";
 
 const char *ex7_18 =

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -552,7 +552,7 @@ const char *ex7_2 =
 
 const char *ex7_3 =
     "{\n"
-    "  ? foo :,\n"
+    "  ? foo : ,\n"
     "  : bar,\n"
     "}\n";
 
@@ -641,8 +641,8 @@ const char *ex7_17 =
     "{\n"
     "unquoted : \"separate\",\n"
     "http://foo.com,\n"
-    "omitted value:,\n"
-    ": omitted key,\n"
+    "omitted value: ,\n"
+    " : omitted key,\n"
     "}";
 
 const char *ex7_18 =


### PR DESCRIPTION
According to the yaml specification, a colon can be seen as a part of a plain scalar if it is not followed by white space in most cases.

https://github.com/jbeder/yaml-cpp/blob/3f381f13a07f007941b250e1563f67ded4dc8b1a/src/exp.h#L167

 In function EndScalarInFlow() , `RegEx(':')+RegEx(",]}", REGEX_OR) `means if a ":" is followed by a  ","  or  " ] "   or  " }", the ":" will not be a part of a plain scalar. It is against the spec, so I removed it, and this solved the problem of #740 and #899.

`*ex7_3` and `*ex7_17` in `specexamples.h` have a little difference with the spec content, This difference will cause the corresponding testcases can't work as expected because of the new rule. I changed them to be the same as spec.