### PR TITLE
fix bug from issue298:Emitter stylings settings overridden by node settings.

### DIFF
--- a/include/yaml-cpp/emitter.h
+++ b/include/yaml-cpp/emitter.h
@@ -58,6 +58,7 @@ class YAML_CPP_API Emitter {
   bool SetPostCommentIndent(std::size_t n);
   bool SetFloatPrecision(std::size_t n);
   bool SetDoublePrecision(std::size_t n);
+  void RestoreGlobalModifiedSettings();
 
   // local setters
   Emitter& SetLocalValue(EMITTER_MANIP value);

--- a/src/emitfromevents.cpp
+++ b/src/emitfromevents.cpp
@@ -59,6 +59,8 @@ void EmitFromEvents::OnSequenceStart(const Mark&, const std::string& tag,
     default:
       break;
   }
+  // Restore the global settings to eliminate the override from node style
+  m_emitter.RestoreGlobalModifiedSettings();
   m_emitter << BeginSeq;
   m_stateStack.push(State::WaitingForSequenceEntry);
 }
@@ -83,6 +85,8 @@ void EmitFromEvents::OnMapStart(const Mark&, const std::string& tag,
     default:
       break;
   }
+  // Restore the global settings to eliminate the override from node style
+  m_emitter.RestoreGlobalModifiedSettings();
   m_emitter << BeginMap;
   m_stateStack.push(State::WaitingForKey);
 }

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -86,6 +86,10 @@ bool Emitter::SetDoublePrecision(std::size_t n) {
   return m_pState->SetDoublePrecision(n, FmtScope::Global);
 }
 
+void Emitter::RestoreGlobalModifiedSettings() {
+  m_pState->RestoreGlobalModifiedSettings();
+}
+
 // SetLocalValue
 // . Either start/end a group, or set a modifier locally
 Emitter& Emitter::SetLocalValue(EMITTER_MANIP value) {

--- a/src/emitterstate.cpp
+++ b/src/emitterstate.cpp
@@ -217,6 +217,10 @@ std::size_t EmitterState::LastIndent() const {
 
 void EmitterState::ClearModifiedSettings() { m_modifiedSettings.clear(); }
 
+void EmitterState::RestoreGlobalModifiedSettings() {
+  m_globalModifiedSettings.restore();
+}
+
 bool EmitterState::SetOutputCharset(EMITTER_MANIP value,
                                     FmtScope::value scope) {
   switch (value) {

--- a/src/emitterstate.h
+++ b/src/emitterstate.h
@@ -72,6 +72,7 @@ class EmitterState {
   bool HasBegunContent() const { return m_hasAnchor || m_hasTag; }
 
   void ClearModifiedSettings();
+  void RestoreGlobalModifiedSettings();
 
   // formatters
   void SetLocalValue(EMITTER_MANIP value);

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -732,6 +732,31 @@ TEST_F(EmitterTest, GlobalLongKeyOnMap) {
 : *value)");
 }
 
+TEST_F(EmitterTest, GlobalSettingStyleOnSeqNode) {
+  Node n(Load(R"(foo:
+  - 1
+  - 2
+  - 3
+bar: aa)"));
+  out.SetSeqFormat(YAML::Flow);
+  out << n;
+  ExpectEmit(R"(foo: [1, 2, 3]
+bar: aa)");
+}
+
+TEST_F(EmitterTest, GlobalSettingStyleOnMapNode) {
+  Node n(Load(R"(-
+  foo: a
+  bar: b
+- 2
+- 3)"));
+  out.SetMapFormat(YAML::Flow);
+  out << n;
+  ExpectEmit(R"(- {foo: a, bar: b}
+- 2
+- 3)");
+}
+
 TEST_F(EmitterTest, ComplexGlobalSettings) {
   out << BeginSeq;
   out << Block;


### PR DESCRIPTION
fix #298

Restore the global settings to eliminate the override from node style in `EmitFromEvents::OnSequenceStart()`.