### PR TITLE
fix issue917: handle the trailing TAB of block scalar

### DIFF
--- a/src/scanscalar.cpp
+++ b/src/scanscalar.cpp
@@ -204,7 +204,7 @@ std::string ScanScalar(Stream& INPUT, ScanScalarParams& params) {
 
   // post-processing
   if (params.trimTrailingSpaces) {
-    std::size_t pos = scalar.find_last_not_of(' ');
+    std::size_t pos = scalar.find_last_not_of(" \t");
     if (lastEscapedChar != std::string::npos) {
       if (pos < lastEscapedChar || pos == std::string::npos) {
         pos = lastEscapedChar;

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -284,6 +284,11 @@ TEST(NodeTest, SpecialFlow) {
       {"{:a}", NodeType::Map, 1, "{:a: ~}"},
       {"{,}", NodeType::Map, 1, "{~: ~}"},
       {"{a:,}", NodeType::Map, 1, "{a: ~}"},
+      //testcase for the trailing TAB of scalar
+      {"key\t: value\t", NodeType::Map, 1, "key: value"},
+      {"key\t: value\t #comment", NodeType::Map, 1, "key: value"},
+      {"{key\t: value\t}", NodeType::Map, 1, "{key: value}"},
+      {"{key\t: value\t #comment\n}", NodeType::Map, 1, "{key: value}"},
   };
   for (const SingleNodeTestCase& test : tests) {
     Node node = Load(test.input);


### PR DESCRIPTION
fix #917

+ For this issue, I think the `TAB` belongs to the separation spaces in spec v1.2 and the trailing `TAB` of scalar should be trimed.
+ the pyyaml do not allow the trailing TAB of block scalar and will throw the "found character '\t' that cannot start any token".   I think this is because pyyaml does not support the  spec v1.2 perfectly.