### PR TITLE
fix issue590: add the support to null type for as<std::string>

### DIFF
--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -110,6 +110,8 @@ struct as_if<std::string, S> {
   const Node& node;
 
   std::string operator()(const S& fallback) const {
+    if (node.Type() == NodeType::Null)
+      return "null";
     if (node.Type() != NodeType::Scalar)
       return fallback;
     return node.Scalar();
@@ -138,6 +140,8 @@ struct as_if<std::string, void> {
   const Node& node;
 
   std::string operator()() const {
+    if (node.Type() == NodeType::Null)
+      return "null";
     if (node.Type() != NodeType::Scalar)
       throw TypedBadConversion<std::string>(node.Mark());
     return node.Scalar();

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -314,6 +314,8 @@ TEST(NodeTest, IncorrectFlow) {
 TEST(NodeTest, LoadTildeAsNull) {
   Node node = Load("~");
   ASSERT_TRUE(node.IsNull());
+  EXPECT_EQ(node.as<std::string>(), "null");
+  EXPECT_EQ(node.as<std::string>("~"), "null");
 }
 
 TEST(NodeTest, LoadNullWithStrTag) {


### PR DESCRIPTION
#590 

* Add the support to null type for `as<std::string>`.
* `as<std::string>` outputs the `"null"` for null type node. This can be changed as `"~"`, `"Null"`, etc.
