### PR TITLE
fix issue743: handle the empty content of flow sep/map correctly during emitting.

### DIFF
--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -205,6 +205,7 @@ void Emitter::EmitBeginSeq() {
 void Emitter::EmitEndSeq() {
   if (!good())
     return;
+  FlowType::value originalType = m_pState->CurGroupFlowType();
 
   if (m_pState->CurGroupChildCount() == 0)
     m_pState->ForceFlow();
@@ -213,8 +214,12 @@ void Emitter::EmitEndSeq() {
     if (m_stream.comment())
       m_stream << "\n";
     m_stream << IndentTo(m_pState->CurIndent());
-    if (m_pState->CurGroupChildCount() == 0)
+    if (originalType == FlowType::Block) {
       m_stream << "[";
+    } else {
+      if (m_pState->CurGroupChildCount() == 0 && !m_pState->HasBegunNode())
+        m_stream << "[";
+    }
     m_stream << "]";
   }
 
@@ -235,6 +240,7 @@ void Emitter::EmitBeginMap() {
 void Emitter::EmitEndMap() {
   if (!good())
     return;
+  FlowType::value originalType = m_pState->CurGroupFlowType();
 
   if (m_pState->CurGroupChildCount() == 0)
     m_pState->ForceFlow();
@@ -243,8 +249,12 @@ void Emitter::EmitEndMap() {
     if (m_stream.comment())
       m_stream << "\n";
     m_stream << IndentTo(m_pState->CurIndent());
-    if (m_pState->CurGroupChildCount() == 0)
+    if (originalType == FlowType::Block) {
       m_stream << "{";
+    } else {
+      if (m_pState->CurGroupChildCount() == 0 && !m_pState->HasBegunNode())
+        m_stream << "{";
+    }
     m_stream << "}";
   }
 

--- a/src/emitterstate.cpp
+++ b/src/emitterstate.cpp
@@ -160,11 +160,12 @@ void EmitterState::EndedGroup(GroupType::value type) {
     return SetError(ErrorMsg::UNEXPECTED_END_MAP);
   }
 
-  // if have the unhandled Tag/Anchor, set the error message
-  if (m_hasTag)
+  if (m_hasTag) {
     SetError(ErrorMsg::INVALID_TAG);
-  if (m_hasAnchor)
+  }
+  if (m_hasAnchor) {
     SetError(ErrorMsg::INVALID_ANCHOR);
+  }
 
   // get rid of the current group
   {

--- a/src/emitterstate.cpp
+++ b/src/emitterstate.cpp
@@ -160,6 +160,12 @@ void EmitterState::EndedGroup(GroupType::value type) {
     return SetError(ErrorMsg::UNEXPECTED_END_MAP);
   }
 
+  // if have the unhandled Tag/Anchor, set the error message
+  if (m_hasTag)
+    SetError(ErrorMsg::INVALID_TAG);
+  if (m_hasAnchor)
+    SetError(ErrorMsg::INVALID_ANCHOR);
+
   // get rid of the current group
   {
     std::unique_ptr<Group> pFinishedGroup = std::move(m_groups.back());

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -138,6 +138,70 @@ TEST_F(EmitterTest, EmptyFlowSeq) {
   ExpectEmit("[]");
 }
 
+TEST_F(EmitterTest, EmptyBlockSeqWithBegunContent) {
+  out << BeginSeq;
+  out << BeginSeq << Comment("comment") << EndSeq;
+  out << BeginSeq << Newline << EndSeq;
+  out << BeginSeq << Anchor("test") << EndSeq;
+  out << BeginSeq << VerbatimTag("foo") << EndSeq;
+  out << EndSeq;
+
+  ExpectEmit(R"(-
+# comment
+  []
+-
+
+  []
+-
+  - &test[]
+-
+  - !<foo>[])");
+}
+
+TEST_F(EmitterTest, EmptyBlockMapWithBegunContent) {
+  out << BeginSeq;
+  out << BeginMap << Comment("comment") << EndMap;
+  out << BeginMap << Newline << EndMap;
+  out << BeginMap << Anchor("test") << EndMap;
+  out << BeginMap << VerbatimTag("foo") << EndMap;
+  out << EndSeq;
+
+  ExpectEmit(R"(-  # comment
+  {}
+-
+  {}
+- &test{}
+- !<foo>{})");
+}
+
+TEST_F(EmitterTest, EmptyFlowSeqWithBegunContent) {
+  out << Flow;
+  out << BeginSeq;
+  out << BeginSeq << Comment("comment") << EndSeq;
+  out << BeginSeq << Newline << EndSeq;
+  out << BeginSeq << Anchor("test") << EndSeq;
+  out << BeginSeq << VerbatimTag("foo") << EndSeq;
+  out << EndSeq;
+
+  ExpectEmit(R"([[  # comment
+  ], [
+  ], [&test], [!<foo>]])");
+}
+
+TEST_F(EmitterTest, EmptyFlowMapWithBegunContent) {
+  out << Flow;
+  out << BeginSeq;
+  out << BeginMap << Comment("comment") << EndMap;
+  out << BeginMap << Newline << EndMap;
+  out << BeginMap << Anchor("test") << EndMap;
+  out << BeginMap << VerbatimTag("foo") << EndMap;
+  out << EndSeq;
+
+  ExpectEmit(R"([{  # comment
+  }, {
+  }, {&test}, {!<foo>}])");
+}
+
 TEST_F(EmitterTest, NestedBlockSeq) {
   out << BeginSeq;
   out << "item 1";

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -142,8 +142,6 @@ TEST_F(EmitterTest, EmptyBlockSeqWithBegunContent) {
   out << BeginSeq;
   out << BeginSeq << Comment("comment") << EndSeq;
   out << BeginSeq << Newline << EndSeq;
-  out << BeginSeq << Anchor("test") << EndSeq;
-  out << BeginSeq << VerbatimTag("foo") << EndSeq;
   out << EndSeq;
 
   ExpectEmit(R"(-
@@ -151,27 +149,19 @@ TEST_F(EmitterTest, EmptyBlockSeqWithBegunContent) {
   []
 -
 
-  []
--
-  - &test[]
--
-  - !<foo>[])");
+  [])");
 }
 
 TEST_F(EmitterTest, EmptyBlockMapWithBegunContent) {
   out << BeginSeq;
   out << BeginMap << Comment("comment") << EndMap;
   out << BeginMap << Newline << EndMap;
-  out << BeginMap << Anchor("test") << EndMap;
-  out << BeginMap << VerbatimTag("foo") << EndMap;
   out << EndSeq;
 
   ExpectEmit(R"(-  # comment
   {}
 -
-  {}
-- &test{}
-- !<foo>{})");
+  {})");
 }
 
 TEST_F(EmitterTest, EmptyFlowSeqWithBegunContent) {
@@ -179,13 +169,11 @@ TEST_F(EmitterTest, EmptyFlowSeqWithBegunContent) {
   out << BeginSeq;
   out << BeginSeq << Comment("comment") << EndSeq;
   out << BeginSeq << Newline << EndSeq;
-  out << BeginSeq << Anchor("test") << EndSeq;
-  out << BeginSeq << VerbatimTag("foo") << EndSeq;
   out << EndSeq;
 
   ExpectEmit(R"([[  # comment
   ], [
-  ], [&test], [!<foo>]])");
+  ]])");
 }
 
 TEST_F(EmitterTest, EmptyFlowMapWithBegunContent) {
@@ -193,13 +181,11 @@ TEST_F(EmitterTest, EmptyFlowMapWithBegunContent) {
   out << BeginSeq;
   out << BeginMap << Comment("comment") << EndMap;
   out << BeginMap << Newline << EndMap;
-  out << BeginMap << Anchor("test") << EndMap;
-  out << BeginMap << VerbatimTag("foo") << EndMap;
   out << EndSeq;
 
   ExpectEmit(R"([{  # comment
   }, {
-  }, {&test}, {!<foo>}])");
+  }])");
 }
 
 TEST_F(EmitterTest, NestedBlockSeq) {
@@ -1572,6 +1558,26 @@ TEST_F(EmitterErrorTest, BadLocalTag) {
   out << LocalTag("e!far") << "bar";
 
   ExpectEmitError("invalid tag");
+}
+
+TEST_F(EmitterErrorTest, BadTagAndTag) {
+  out << VerbatimTag("!far") << VerbatimTag("!foo") << "bar";
+  ExpectEmitError(ErrorMsg::INVALID_TAG);
+}
+
+TEST_F(EmitterErrorTest, BadAnchorAndAnchor) {
+  out << Anchor("far") << Anchor("foo") << "bar";
+  ExpectEmitError(ErrorMsg::INVALID_ANCHOR);
+}
+
+TEST_F(EmitterErrorTest, BadEmptyAnchorOnGroup) {
+  out << BeginSeq << "bar" << Anchor("foo") << EndSeq;
+  ExpectEmitError(ErrorMsg::INVALID_ANCHOR);
+}
+
+TEST_F(EmitterErrorTest, BadEmptyTagOnGroup) {
+  out << BeginSeq << "bar" << VerbatimTag("!foo") << EndSeq;
+  ExpectEmitError(ErrorMsg::INVALID_TAG);
 }
 
 TEST_F(EmitterErrorTest, ExtraEndSeq) {


### PR DESCRIPTION
#743  
* fix bug: emit the correct empty seq/map with` newline`/`comment`/`tag`/`anchor`.
* The detailed output contents are shown in test case. Are they the right ones？ @jbeder  ha-ha, I'm not very sure for these.