### PR TITLE
Allowing partial specialization of the convert struct

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -35,7 +35,7 @@
 namespace YAML {
 class Binary;
 struct _Null;
-template <typename T>
+template <typename T, typename Enable>
 struct convert;
 }  // namespace YAML
 

--- a/include/yaml-cpp/node/node.h
+++ b/include/yaml-cpp/node/node.h
@@ -146,7 +146,7 @@ YAML_CPP_API bool operator==(const Node& lhs, const Node& rhs);
 
 YAML_CPP_API Node Clone(const Node& node);
 
-template <typename T>
+template <typename T, typename Enable = void>
 struct convert;
 }
 

--- a/test/integration/convert_partial_specialization_test.cpp
+++ b/test/integration/convert_partial_specialization_test.cpp
@@ -1,0 +1,92 @@
+#include "yaml-cpp/emitterstyle.h"
+#include "yaml-cpp/eventhandler.h"
+#include "yaml-cpp/yaml.h"  // IWYU pragma: keep
+#include "gtest/gtest.h"
+
+// Base class
+class A {
+ public:
+  A() = default;
+  A(int a) : a{a} {}
+
+  // virtual load/emit methods
+  virtual void load(const YAML::Node &node) { a = node["a"].as<int>(); }
+
+  virtual YAML::Node emit() const {
+    YAML::Node node;
+    node["a"] = a;
+    return node;
+  }
+
+  int a{};
+};
+
+// Derived class
+class B : public A {
+ public:
+  B() = default;
+  B(int a, int b) : A{a}, b{b} {}
+
+  // override virtual load/emit methods
+  virtual void load(const YAML::Node &node) override {
+    A::load(node);
+    b = node["b"].as<int>();
+  }
+
+  virtual YAML::Node emit() const override {
+    YAML::Node node = A::emit();
+    node["b"] = b;
+    return node;
+  }
+
+  int b{};
+};
+
+// Implementation of convert::{encode,decode} for all classes derived from or
+// being A
+namespace YAML {
+template <typename T>
+struct convert<T, typename std::enable_if<std::is_base_of<A, T>::value>::type> {
+  static Node encode(const T &rhs) {
+    Node node = rhs.emit();
+    return node;
+  }
+
+  static bool decode(const Node &node, T &rhs) {
+    rhs.load(node);
+    return true;
+  }
+};
+
+namespace {
+
+TEST(ConvertPartialSpecializationTest, EncodeBaseClass) {
+  Node n(Load("{a: 1}"));
+  A a = n.as<A>();
+  EXPECT_EQ(a.a, 1);
+}
+
+TEST(ConvertPartialSpecializationTest, EncodeDerivedClass) {
+  Node n(Load("{a: 1, b: 2}"));
+  B b = n.as<B>();
+  EXPECT_EQ(b.a, 1);
+  EXPECT_EQ(b.b, 2);
+}
+
+TEST(ConvertPartialSpecializationTest, DecodeBaseClass) {
+  A a(1);
+  Node n;
+  n = a;
+  EXPECT_EQ(a.a, n["a"].as<int>());
+}
+
+TEST(ConvertPartialSpecializationTest, DecodeDerivedClass) {
+  B b(1, 2);
+  Node n;
+  n = b;
+  EXPECT_EQ(b.a, n["a"].as<int>());
+  EXPECT_EQ(b.b, n["b"].as<int>());
+}
+
+}  // namespace
+}  // namespace YAML


### PR DESCRIPTION
This is done by adding a second, defaulted, template parameter that can
be used in conjunction of std::enable_if

An example of usage is added to the tutorial

The code and example has been taken from #310 

