### PR TITLE
Fix uninitialized variable when copying Node

### DIFF
--- a/include/yaml-cpp/node/detail/node.h
+++ b/include/yaml-cpp/node/detail/node.h
@@ -24,7 +24,7 @@ class node {
   };
 
  public:
-  node() : m_pRef(new node_ref), m_dependencies{} {}
+  node() : m_pRef(new node_ref), m_dependencies{}, m_index{} {}
   node(const node&) = delete;
   node& operator=(const node&) = delete;
 


### PR DESCRIPTION
Running yaml-cpp-tests under valgrind raises following errors because `m_index` variable is not initialized:
```
[ RUN      ] NodeTest.TempMapVariableAlias
==557== Conditional jump or move depends on uninitialised value(s)
==557==    at 0x1E774D: std::pair<std::_Rb_tree_iterator<YAML::detail::node*>, bool> std::_Rb_tree<YAML::detail::node*, YAML::detail::node*, std::_Identity<YAML::detail::node*>, YAML::detail::node::less, std::allocator<YAML::detail::node*> >::_M_insert_unique<YAML::detail::node*>(YAML::detail::node*&&) (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x1EB200: YAML::Node YAML::Node::operator[]<char [6]>(char const (&) [6]) (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x3E1C46: YAML::(anonymous namespace)::NodeTest_TempMapVariableAlias_Test::TestBody() (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x49B539: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x491362: testing::Test::Run() [clone .part.566] (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x4918D9: testing::TestInfo::Run() [clone .part.567] (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x491C2C: testing::TestSuite::Run() [clone .part.568] (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x492EF7: testing::internal::UnitTestImpl::RunAllTests() (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x4930D7: testing::UnitTest::Run() (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x1B223E: main (in yaml-cpp/build/test/yaml-cpp-tests)
==557==
==557== Conditional jump or move depends on uninitialised value(s)
==557==    at 0x1E7766: std::pair<std::_Rb_tree_iterator<YAML::detail::node*>, bool> std::_Rb_tree<YAML::detail::node*, YAML::detail::node*, std::_Identity<YAML::detail::node*>, YAML::detail::node::less, std::allocator<YAML::detail::node*> >::_M_insert_unique<YAML::detail::node*>(YAML::detail::node*&&) (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x1EB200: YAML::Node YAML::Node::operator[]<char [6]>(char const (&) [6]) (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x3E1C46: YAML::(anonymous namespace)::NodeTest_TempMapVariableAlias_Test::TestBody() (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x49B539: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x491362: testing::Test::Run() [clone .part.566] (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x4918D9: testing::TestInfo::Run() [clone .part.567] (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x491C2C: testing::TestSuite::Run() [clone .part.568] (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x492EF7: testing::internal::UnitTestImpl::RunAllTests() (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x4930D7: testing::UnitTest::Run() (in yaml-cpp/build/test/yaml-cpp-tests)
==557==    by 0x1B223E: main (in yaml-cpp/build/test/yaml-cpp-tests)
==557==
```
After this PR, valgrind output is clear.