### PR TITLE
Reduce std::string copies

### DIFF
--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -100,6 +100,12 @@ inline const std::string KEY_NOT_FOUND_WITH_KEY(const std::string& key) {
   return stream.str();
 }
 
+inline const std::string KEY_NOT_FOUND_WITH_KEY(const char* key) {
+  std::stringstream stream;
+  stream << KEY_NOT_FOUND << ": " << key;
+  return stream.str();
+}
+
 template <typename T>
 inline const std::string KEY_NOT_FOUND_WITH_KEY(
     const T& key, typename enable_if<is_numeric<T>>::type* = 0) {
@@ -115,6 +121,12 @@ inline const std::string BAD_SUBSCRIPT_WITH_KEY(
 }
 
 inline const std::string BAD_SUBSCRIPT_WITH_KEY(const std::string& key) {
+  std::stringstream stream;
+  stream << BAD_SUBSCRIPT << " (key: \"" << key << "\")";
+  return stream.str();
+}
+
+inline const std::string BAD_SUBSCRIPT_WITH_KEY(const char* key) {
   std::stringstream stream;
   stream << BAD_SUBSCRIPT << " (key: \"" << key << "\")";
   return stream.str();

--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -74,12 +74,17 @@ struct convert<std::string> {
 // C-strings can only be encoded
 template <>
 struct convert<const char*> {
-  static Node encode(const char*& rhs) { return Node(rhs); }
+  static Node encode(const char* rhs) { return Node(rhs); }
+};
+
+template <>
+struct convert<char*> {
+  static Node encode(const char* rhs) { return Node(rhs); }
 };
 
 template <std::size_t N>
-struct convert<const char[N]> {
-  static Node encode(const char(&rhs)[N]) { return Node(rhs); }
+struct convert<char[N]> {
+  static Node encode(const char* rhs) { return Node(rhs); }
 };
 
 template <>

--- a/include/yaml-cpp/node/detail/impl.h
+++ b/include/yaml-cpp/node/detail/impl.h
@@ -106,7 +106,11 @@ inline bool node::equals(const T& rhs, shared_memory_holder pMemory) {
 }
 
 inline bool node::equals(const char* rhs, shared_memory_holder pMemory) {
-  return equals<std::string>(rhs, pMemory);
+  std::string lhs;
+  if (convert<std::string>::decode(Node(*this, std::move(pMemory)), lhs)) {
+    return lhs == rhs;
+  }
+  return false;
 }
 
 // indexing


### PR DESCRIPTION
When indexing (using `Node::operator[]` and friends) with a `Key` which is defined as a template type we early convert it to `std::string` - even when the Key is already a `std::string`. This is not really needed as Node's implementation does work with a templated key type - both `const char*` and `std::string`.