### PR TITLE
Fix runtime exceptions in Visual Studio environment.

### DIFF
--- a/src/singledocparser.cpp
+++ b/src/singledocparser.cpp
@@ -48,7 +48,7 @@ void SingleDocParser::HandleDocument(EventHandler& eventHandler) {
 }
 
 void SingleDocParser::HandleNode(EventHandler& eventHandler) {
-  DepthGuard<2000> depthguard(depth, m_scanner.mark(), ErrorMsg::BAD_FILE);
+  DepthGuard<500> depthguard(depth, m_scanner.mark(), ErrorMsg::BAD_FILE);
 
   // an empty node *is* a possibility
   if (m_scanner.empty()) {

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -804,7 +804,7 @@ TEST_F(EmitterTest, OutputCharset) {
   out << "\x24 \xC2\xA2 \xE2\x82\xAC";
   out << EndSeq;
 
-  ExpectEmit("- $ ¢ €\n- \"$ \\xa2 \\u20ac\"");
+  ExpectEmit("- \x24 \xC2\xA2 \xE2\x82\xAC\n- \"\x24 \\xa2 \\u20ac\"");
 }
 
 TEST_F(EmitterTest, EscapedUnicode) {


### PR DESCRIPTION
Fix two runtime errors in VS evironment.
+ When we run the testcase, the VS will throw:
```
...
Exception thrown at 0x0000000077A68676 (ntdll.dll) in yaml-cpp-tests.exe: 0xC00000FD: Stack overflow (parameters: 0x0000000000000001, 0x0000000000173FF8).
unknown file: error: SEH exception with code 0xc00000fd thrown in the test body.
Exception thrown at 0x0000000077A67C0C (ntdll.dll) in yaml-cpp-tests.exe: 0xC0000005: Access violation writing location 0x0000000000170FF8.
```
This error is related to `CVE_2017_5950`. I think this is becase the windows system's stack (1024k) is small and the deep recursion will lead to the stack overflow.  The max nesting depth of node is set as 2000 in yaml-cpp and it is too big for windows system. 

Edit: The error message is shown in [demo in dota17/yaml-cpp](https://ci.appveyor.com/project/dota17/yaml-cpp/builds/34213440/job/funex0hoq445ertb)
+ `ExpectEmit("- $ ¢ €\n- \"$ \\xa2 \\u20ac\"");` will throw an error related with encoding.