### PR TITLE
Conditionally disabled -Weffc++ and -Wshadow for compilers with broken implementations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,12 @@ set(build-shared $<BOOL:${YAML_BUILD_SHARED_LIBS}>)
 set(build-windows-dll $<AND:$<BOOL:${CMAKE_HOST_WIN32}>,${build-shared}>)
 set(not-msvc $<NOT:$<CXX_COMPILER_ID:MSVC>>)
 set(msvc-shared_rt $<BOOL:${YAML_MSVC_SHARED_RT}>)
+set(not-intel $<NOT:$<CXX_COMPILER_ID:Intel>>)
+set(not-gnu $<NOT:$<CXX_COMPILER_ID:GNU>>)
+# -Weffc++ does not work correctly for some compilers 
+set(weffcpp-compatible $<AND:${not-intel},${not-gnu},${not-msvc}>)
+# -Wshadow does not work correctly for some compilers 
+set(wshadow-compatible $<AND:${not-intel},${not-msvc}>)
 
 if (NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
   set(CMAKE_MSVC_RUNTIME_LIBRARY
@@ -93,7 +99,9 @@ endif()
 
 target_compile_options(yaml-cpp
   PRIVATE
-    $<${not-msvc}:-Wall -Wextra -Wshadow -Weffc++ -Wno-long-long>
+    $<${not-msvc}:-Wall -Wextra -Wno-long-long>
+    $<${wshadow-compatible}:-Wshadow >
+    $<${weffcpp-compatible}:-Weffc++>
     $<${not-msvc}:-pedantic -pedantic-errors>
 
     $<$<AND:${backport-msvc-runtime},${msvc-rt-mtd-static}>:-MTd>


### PR DESCRIPTION
Ref. #937 This will turn of these flags which trigger false positives in GNU and Intel compilers.