### PR TITLE
Adds assert to enable compilation with libcxx + gcc

### DIFF
--- a/include/yaml-cpp/node/iterator.h
+++ b/include/yaml-cpp/node/iterator.h
@@ -15,6 +15,8 @@
 #include <utility>
 #include <vector>
 
+static_assert(std::is_constructible<YAML::Node, const YAML::Node&>::value, "Node must be copy constructable");
+
 namespace YAML {
 namespace detail {
 struct iterator_value : public Node, std::pair<Node, Node> {

--- a/include/yaml-cpp/node/iterator.h
+++ b/include/yaml-cpp/node/iterator.h
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+// Assert in place so gcc + libc++ combination properly builds
 static_assert(std::is_constructible<YAML::Node, const YAML::Node&>::value, "Node must be copy constructable");
 
 namespace YAML {


### PR DESCRIPTION
Somehow this instantiates a template properly otherwise the build fails when building using gcc and libc++.

Fixes #742 