### PR TITLE
Always quote strings with colons

### DIFF
--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -176,11 +176,11 @@ bool IsValidPlainScalar(const std::string& str, FlowType::value flowType,
   static const RegEx& disallowed_flow =
       Exp::EndScalarInFlow() | (Exp::BlankOrBreak() + Exp::Comment()) |
       Exp::NotPrintable() | Exp::Utf8_ByteOrderMark() | Exp::Break() |
-      Exp::Tab();
+      Exp::Tab() | Exp::Colon();
   static const RegEx& disallowed_block =
       Exp::EndScalar() | (Exp::BlankOrBreak() + Exp::Comment()) |
       Exp::NotPrintable() | Exp::Utf8_ByteOrderMark() | Exp::Break() |
-      Exp::Tab();
+      Exp::Tab() | Exp::Colon();
   const RegEx& disallowed =
       flowType == FlowType::Flow ? disallowed_flow : disallowed_block;
 

--- a/src/exp.h
+++ b/src/exp.h
@@ -32,6 +32,10 @@ inline const RegEx& Tab() {
   static const RegEx e = RegEx('\t');
   return e;
 }
+inline const RegEx& Colon() {
+  static const RegEx e = RegEx(':');
+  return e;
+}
 inline const RegEx& Blank() {
   static const RegEx e = Space() | Tab();
   return e;

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -276,12 +276,12 @@ TEST(NodeTest, SpecialFlow) {
   std::vector<SingleNodeTestCase> tests = {
       {"[:]", NodeType::Sequence, 1, "[{~: ~}]"},
       {"[a:]", NodeType::Sequence, 1, "[{a: ~}]"},
-      {"[:a]", NodeType::Sequence, 1, "[:a]"},
+      {"[:a]", NodeType::Sequence, 1, "[\":a\"]"},
       {"[,]", NodeType::Sequence, 1, "[~]"},
       {"[a:,]", NodeType::Sequence, 1, "[{a: ~}]"},
       {"{:}", NodeType::Map, 1, "{~: ~}"},
       {"{a:}", NodeType::Map, 1, "{a: ~}"},
-      {"{:a}", NodeType::Map, 1, "{:a: ~}"},
+      {"{:a}", NodeType::Map, 1, "{\":a\": ~}"},
       {"{,}", NodeType::Map, 1, "{~: ~}"},
       {"{a:,}", NodeType::Map, 1, "{a: ~}"},
       //testcase for the trailing TAB of scalar

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -663,6 +663,12 @@ class NodeEmitterTest : public ::testing::Test {
   }
 };
 
+TEST_F(NodeEmitterTest, StringWithColons) {
+  Node node{"String:with:colons"};
+
+  ExpectOutput("\"String:with:colons\"", node);
+}
+
 TEST_F(NodeEmitterTest, SimpleFlowSeqNode) {
   Node node;
   node.SetStyle(EmitterStyle::Flow);


### PR DESCRIPTION
Otherwise they may get misinterpreted, or cause a syntax error even.