### PR TITLE
Update node/impl.h for GCC unused variable warning

### DIFF
--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -42,7 +42,7 @@ inline Node::Node(const detail::iterator_value& rhs)
       m_pMemory(rhs.m_pMemory),
       m_pNode(rhs.m_pNode) {}
 
-inline Node::Node(const Node& rhs) = default;
+inline Node::Node(const Node&) = default;
 
 inline Node::Node(Zombie)
     : m_isValid(false), m_invalidKey{}, m_pMemory{}, m_pNode(nullptr) {}


### PR DESCRIPTION
Removed the variable name in the defaulted function to make GCC happy. Tested on GCC 5.4