### PR TITLE
Make EMITTER_MANIP an enum class

### DIFF
--- a/include/yaml-cpp/emittermanip.h
+++ b/include/yaml-cpp/emittermanip.h
@@ -10,7 +10,7 @@
 #include <string>
 
 namespace YAML {
-enum EMITTER_MANIP {
+enum class EMITTER_MANIP {
   // general manipulators
   Auto,
   TagByKind,

--- a/include/yaml-cpp/stlemitter.h
+++ b/include/yaml-cpp/stlemitter.h
@@ -15,10 +15,10 @@
 namespace YAML {
 template <typename Seq>
 inline Emitter& EmitSeq(Emitter& emitter, const Seq& seq) {
-  emitter << BeginSeq;
+  emitter << EMITTER_MANIP::BeginSeq;
   for (const auto& v : seq)
     emitter << v;
-  emitter << EndSeq;
+  emitter << EMITTER_MANIP::EndSeq;
   return emitter;
 }
 
@@ -39,10 +39,10 @@ inline Emitter& operator<<(Emitter& emitter, const std::set<T>& v) {
 
 template <typename K, typename V>
 inline Emitter& operator<<(Emitter& emitter, const std::map<K, V>& m) {
-  emitter << BeginMap;
+  emitter << EMITTER_MANIP::BeginMap;
   for (const auto& v : m)
-    emitter << Key << v.first << Value << v.second;
-  emitter << EndMap;
+    emitter << EMITTER_MANIP::Key << v.first << EMITTER_MANIP::Value << v.second;
+  emitter << EMITTER_MANIP::EndMap;
   return emitter;
 }
 }

--- a/src/emitfromevents.cpp
+++ b/src/emitfromevents.cpp
@@ -51,22 +51,22 @@ void EmitFromEvents::OnSequenceStart(const Mark&, const std::string& tag,
   EmitProps(tag, anchor);
   switch (style) {
     case EmitterStyle::Block:
-      m_emitter << Block;
+      m_emitter << EMITTER_MANIP::Block;
       break;
     case EmitterStyle::Flow:
-      m_emitter << Flow;
+      m_emitter << EMITTER_MANIP::Flow;
       break;
     default:
       break;
   }
   // Restore the global settings to eliminate the override from node style
   m_emitter.RestoreGlobalModifiedSettings();
-  m_emitter << BeginSeq;
+  m_emitter << EMITTER_MANIP::BeginSeq;
   m_stateStack.push(State::WaitingForSequenceEntry);
 }
 
 void EmitFromEvents::OnSequenceEnd() {
-  m_emitter << EndSeq;
+  m_emitter << EMITTER_MANIP::EndSeq;
   assert(m_stateStack.top() == State::WaitingForSequenceEntry);
   m_stateStack.pop();
 }
@@ -77,22 +77,22 @@ void EmitFromEvents::OnMapStart(const Mark&, const std::string& tag,
   EmitProps(tag, anchor);
   switch (style) {
     case EmitterStyle::Block:
-      m_emitter << Block;
+      m_emitter << EMITTER_MANIP::Block;
       break;
     case EmitterStyle::Flow:
-      m_emitter << Flow;
+      m_emitter << EMITTER_MANIP::Flow;
       break;
     default:
       break;
   }
   // Restore the global settings to eliminate the override from node style
   m_emitter.RestoreGlobalModifiedSettings();
-  m_emitter << BeginMap;
+  m_emitter << EMITTER_MANIP::BeginMap;
   m_stateStack.push(State::WaitingForKey);
 }
 
 void EmitFromEvents::OnMapEnd() {
-  m_emitter << EndMap;
+  m_emitter << EMITTER_MANIP::EndMap;
   assert(m_stateStack.top() == State::WaitingForKey);
   m_stateStack.pop();
 }
@@ -103,11 +103,11 @@ void EmitFromEvents::BeginNode() {
 
   switch (m_stateStack.top()) {
     case State::WaitingForKey:
-      m_emitter << Key;
+      m_emitter << EMITTER_MANIP::Key;
       m_stateStack.top() = State::WaitingForValue;
       break;
     case State::WaitingForValue:
-      m_emitter << Value;
+      m_emitter << EMITTER_MANIP::Value;
       m_stateStack.top() = State::WaitingForKey;
       break;
     default:

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -101,32 +101,32 @@ Emitter& Emitter::SetLocalValue(EMITTER_MANIP value) {
     return *this;
 
   switch (value) {
-    case BeginDoc:
+    case EMITTER_MANIP::BeginDoc:
       EmitBeginDoc();
       break;
-    case EndDoc:
+    case EMITTER_MANIP::EndDoc:
       EmitEndDoc();
       break;
-    case BeginSeq:
+    case EMITTER_MANIP::BeginSeq:
       EmitBeginSeq();
       break;
-    case EndSeq:
+    case EMITTER_MANIP::EndSeq:
       EmitEndSeq();
       break;
-    case BeginMap:
+    case EMITTER_MANIP::BeginMap:
       EmitBeginMap();
       break;
-    case EndMap:
+    case EMITTER_MANIP::EndMap:
       EmitEndMap();
       break;
-    case Key:
-    case Value:
+    case EMITTER_MANIP::Key:
+    case EMITTER_MANIP::Value:
       // deprecated (these can be deduced by the parity of nodes in a map)
       break;
-    case TagByKind:
+    case EMITTER_MANIP::TagByKind:
       EmitKindTag();
       break;
-    case Newline:
+    case EMITTER_MANIP::Newline:
       EmitNewline();
       break;
     default:
@@ -392,7 +392,7 @@ void Emitter::BlockSeqPrepareNode(EmitterNodeType::value child) {
 
 void Emitter::FlowMapPrepareNode(EmitterNodeType::value child) {
   if (m_pState->CurGroupChildCount() % 2 == 0) {
-    if (m_pState->GetMapKeyFormat() == LongKey)
+    if (m_pState->GetMapKeyFormat() == EMITTER_MANIP::LongKey)
       m_pState->SetLongKey();
 
     if (m_pState->CurGroupLongKey())
@@ -530,7 +530,7 @@ void Emitter::FlowMapPrepareSimpleKeyValue(EmitterNodeType::value child) {
 
 void Emitter::BlockMapPrepareNode(EmitterNodeType::value child) {
   if (m_pState->CurGroupChildCount() % 2 == 0) {
-    if (m_pState->GetMapKeyFormat() == LongKey)
+    if (m_pState->GetMapKeyFormat() == EMITTER_MANIP::LongKey)
       m_pState->SetLongKey();
     if (child == EmitterNodeType::BlockSeq ||
         child == EmitterNodeType::BlockMap)
@@ -681,14 +681,14 @@ void Emitter::SpaceOrIndentTo(bool requireSpace, std::size_t indent) {
 void Emitter::PrepareIntegralStream(std::stringstream& stream) const {
 
   switch (m_pState->GetIntFormat()) {
-    case Dec:
+    case EMITTER_MANIP::Dec:
       stream << std::dec;
       break;
-    case Hex:
+    case EMITTER_MANIP::Hex:
       stream << "0x";
       stream << std::hex;
       break;
-    case Oct:
+    case EMITTER_MANIP::Oct:
       stream << "0";
       stream << std::oct;
       break;
@@ -704,9 +704,9 @@ void Emitter::StartedScalar() { m_pState->StartedScalar(); }
 
 StringEscaping::value GetStringEscapingStyle(const EMITTER_MANIP emitterManip) {
   switch (emitterManip) {
-    case EscapeNonAscii:
+    case EMITTER_MANIP::EscapeNonAscii:
       return StringEscaping::NonAscii;
-    case EscapeAsJson:
+    case EMITTER_MANIP::EscapeAsJson:
       return StringEscaping::JSON;
     default:
       return StringEscaping::None;
@@ -725,7 +725,7 @@ Emitter& Emitter::Write(const std::string& str) {
                                  m_pState->CurGroupFlowType(), stringEscaping == StringEscaping::NonAscii);
 
   if (strFormat == StringFormat::Literal || str.size() > 1024)
-    m_pState->SetMapKeyFormat(YAML::LongKey, FmtScope::Local);
+    m_pState->SetMapKeyFormat(YAML::EMITTER_MANIP::LongKey, FmtScope::Local);
 
   PrepareNode(EmitterNodeType::Scalar);
 
@@ -759,42 +759,42 @@ std::size_t Emitter::GetDoublePrecision() const {
 }
 
 const char* Emitter::ComputeFullBoolName(bool b) const {
-  const EMITTER_MANIP mainFmt = (m_pState->GetBoolLengthFormat() == ShortBool
-                                     ? YesNoBool
+  const EMITTER_MANIP mainFmt = (m_pState->GetBoolLengthFormat() == EMITTER_MANIP::ShortBool
+                                     ? EMITTER_MANIP::YesNoBool
                                      : m_pState->GetBoolFormat());
   const EMITTER_MANIP caseFmt = m_pState->GetBoolCaseFormat();
   switch (mainFmt) {
-    case YesNoBool:
+    case EMITTER_MANIP::YesNoBool:
       switch (caseFmt) {
-        case UpperCase:
+        case EMITTER_MANIP::UpperCase:
           return b ? "YES" : "NO";
-        case CamelCase:
+        case EMITTER_MANIP::CamelCase:
           return b ? "Yes" : "No";
-        case LowerCase:
+        case EMITTER_MANIP::LowerCase:
           return b ? "yes" : "no";
         default:
           break;
       }
       break;
-    case OnOffBool:
+    case EMITTER_MANIP::OnOffBool:
       switch (caseFmt) {
-        case UpperCase:
+        case EMITTER_MANIP::UpperCase:
           return b ? "ON" : "OFF";
-        case CamelCase:
+        case EMITTER_MANIP::CamelCase:
           return b ? "On" : "Off";
-        case LowerCase:
+        case EMITTER_MANIP::LowerCase:
           return b ? "on" : "off";
         default:
           break;
       }
       break;
-    case TrueFalseBool:
+    case EMITTER_MANIP::TrueFalseBool:
       switch (caseFmt) {
-        case UpperCase:
+        case EMITTER_MANIP::UpperCase:
           return b ? "TRUE" : "FALSE";
-        case CamelCase:
+        case EMITTER_MANIP::CamelCase:
           return b ? "True" : "False";
-        case LowerCase:
+        case EMITTER_MANIP::LowerCase:
           return b ? "true" : "false";
         default:
           break;
@@ -809,13 +809,13 @@ const char* Emitter::ComputeFullBoolName(bool b) const {
 
 const char* Emitter::ComputeNullName() const {
   switch (m_pState->GetNullFormat()) {
-    case LowerNull:
+    case EMITTER_MANIP::LowerNull:
       return "null";
-    case UpperNull:
+    case EMITTER_MANIP::UpperNull:
       return "NULL";
-    case CamelNull:
+    case EMITTER_MANIP::CamelNull:
       return "Null";
-    case TildeNull:
+    case EMITTER_MANIP::TildeNull:
       // fallthrough
     default:
       return "~";
@@ -829,7 +829,7 @@ Emitter& Emitter::Write(bool b) {
   PrepareNode(EmitterNodeType::Scalar);
 
   const char* name = ComputeFullBoolName(b);
-  if (m_pState->GetBoolLengthFormat() == ShortBool)
+  if (m_pState->GetBoolLengthFormat() == EMITTER_MANIP::ShortBool)
     m_stream << name[0];
   else
     m_stream << name;

--- a/src/emitterstate.cpp
+++ b/src/emitterstate.cpp
@@ -8,19 +8,19 @@ EmitterState::EmitterState()
     : m_isGood(true),
       m_lastError{},
       // default global manipulators
-      m_charset(EmitNonAscii),
-      m_strFmt(Auto),
-      m_boolFmt(TrueFalseBool),
-      m_boolLengthFmt(LongBool),
-      m_boolCaseFmt(LowerCase),
-      m_nullFmt(TildeNull),
-      m_intFmt(Dec),
+      m_charset(EMITTER_MANIP::EmitNonAscii),
+      m_strFmt(EMITTER_MANIP::Auto),
+      m_boolFmt(EMITTER_MANIP::TrueFalseBool),
+      m_boolLengthFmt(EMITTER_MANIP::LongBool),
+      m_boolCaseFmt(EMITTER_MANIP::LowerCase),
+      m_nullFmt(EMITTER_MANIP::TildeNull),
+      m_intFmt(EMITTER_MANIP::Dec),
       m_indent(2),
       m_preCommentIndent(2),
       m_postCommentIndent(1),
-      m_seqFmt(Block),
-      m_mapFmt(Block),
-      m_mapKeyFmt(Auto),
+      m_seqFmt(EMITTER_MANIP::Block),
+      m_mapFmt(EMITTER_MANIP::Block),
+      m_mapKeyFmt(EMITTER_MANIP::Auto),
       m_floatPrecision(std::numeric_limits<float>::max_digits10),
       m_doublePrecision(std::numeric_limits<double>::max_digits10),
       //
@@ -98,12 +98,12 @@ void EmitterState::StartedNode() {
 EmitterNodeType::value EmitterState::NextGroupType(
     GroupType::value type) const {
   if (type == GroupType::Seq) {
-    if (GetFlowType(type) == Block)
+    if (GetFlowType(type) == EMITTER_MANIP::Block)
       return EmitterNodeType::BlockSeq;
     return EmitterNodeType::FlowSeq;
   }
 
-  if (GetFlowType(type) == Block)
+  if (GetFlowType(type) == EMITTER_MANIP::Block)
     return EmitterNodeType::BlockMap;
   return EmitterNodeType::FlowMap;
 
@@ -146,7 +146,7 @@ void EmitterState::StartedGroup(GroupType::value type) {
   pGroup->modifiedSettings = std::move(m_modifiedSettings);
 
   // set up group
-  if (GetFlowType(type) == Block) {
+  if (GetFlowType(type) == EMITTER_MANIP::Block) {
     pGroup->flowType = FlowType::Block;
   } else {
     pGroup->flowType = FlowType::Flow;
@@ -240,9 +240,9 @@ void EmitterState::RestoreGlobalModifiedSettings() {
 bool EmitterState::SetOutputCharset(EMITTER_MANIP value,
                                     FmtScope::value scope) {
   switch (value) {
-    case EmitNonAscii:
-    case EscapeNonAscii:
-    case EscapeAsJson:
+    case EMITTER_MANIP::EmitNonAscii:
+    case EMITTER_MANIP::EscapeNonAscii:
+    case EMITTER_MANIP::EscapeAsJson:
       _Set(m_charset, value, scope);
       return true;
     default:
@@ -252,10 +252,10 @@ bool EmitterState::SetOutputCharset(EMITTER_MANIP value,
 
 bool EmitterState::SetStringFormat(EMITTER_MANIP value, FmtScope::value scope) {
   switch (value) {
-    case Auto:
-    case SingleQuoted:
-    case DoubleQuoted:
-    case Literal:
+    case EMITTER_MANIP::Auto:
+    case EMITTER_MANIP::SingleQuoted:
+    case EMITTER_MANIP::DoubleQuoted:
+    case EMITTER_MANIP::Literal:
       _Set(m_strFmt, value, scope);
       return true;
     default:
@@ -265,9 +265,9 @@ bool EmitterState::SetStringFormat(EMITTER_MANIP value, FmtScope::value scope) {
 
 bool EmitterState::SetBoolFormat(EMITTER_MANIP value, FmtScope::value scope) {
   switch (value) {
-    case OnOffBool:
-    case TrueFalseBool:
-    case YesNoBool:
+    case EMITTER_MANIP::OnOffBool:
+    case EMITTER_MANIP::TrueFalseBool:
+    case EMITTER_MANIP::YesNoBool:
       _Set(m_boolFmt, value, scope);
       return true;
     default:
@@ -278,8 +278,8 @@ bool EmitterState::SetBoolFormat(EMITTER_MANIP value, FmtScope::value scope) {
 bool EmitterState::SetBoolLengthFormat(EMITTER_MANIP value,
                                        FmtScope::value scope) {
   switch (value) {
-    case LongBool:
-    case ShortBool:
+    case EMITTER_MANIP::LongBool:
+    case EMITTER_MANIP::ShortBool:
       _Set(m_boolLengthFmt, value, scope);
       return true;
     default:
@@ -290,9 +290,9 @@ bool EmitterState::SetBoolLengthFormat(EMITTER_MANIP value,
 bool EmitterState::SetBoolCaseFormat(EMITTER_MANIP value,
                                      FmtScope::value scope) {
   switch (value) {
-    case UpperCase:
-    case LowerCase:
-    case CamelCase:
+    case EMITTER_MANIP::UpperCase:
+    case EMITTER_MANIP::LowerCase:
+    case EMITTER_MANIP::CamelCase:
       _Set(m_boolCaseFmt, value, scope);
       return true;
     default:
@@ -302,10 +302,10 @@ bool EmitterState::SetBoolCaseFormat(EMITTER_MANIP value,
 
 bool EmitterState::SetNullFormat(EMITTER_MANIP value, FmtScope::value scope) {
   switch (value) {
-    case LowerNull:
-    case UpperNull:
-    case CamelNull:
-    case TildeNull:
+    case EMITTER_MANIP::LowerNull:
+    case EMITTER_MANIP::UpperNull:
+    case EMITTER_MANIP::CamelNull:
+    case EMITTER_MANIP::TildeNull:
       _Set(m_nullFmt, value, scope);
       return true;
     default:
@@ -315,9 +315,9 @@ bool EmitterState::SetNullFormat(EMITTER_MANIP value, FmtScope::value scope) {
 
 bool EmitterState::SetIntFormat(EMITTER_MANIP value, FmtScope::value scope) {
   switch (value) {
-    case Dec:
-    case Hex:
-    case Oct:
+    case EMITTER_MANIP::Dec:
+    case EMITTER_MANIP::Hex:
+    case EMITTER_MANIP::Oct:
       _Set(m_intFmt, value, scope);
       return true;
     default:
@@ -354,8 +354,8 @@ bool EmitterState::SetPostCommentIndent(std::size_t value,
 bool EmitterState::SetFlowType(GroupType::value groupType, EMITTER_MANIP value,
                                FmtScope::value scope) {
   switch (value) {
-    case Block:
-    case Flow:
+    case EMITTER_MANIP::Block:
+    case EMITTER_MANIP::Flow:
       _Set(groupType == GroupType::Seq ? m_seqFmt : m_mapFmt, value, scope);
       return true;
     default:
@@ -366,7 +366,7 @@ bool EmitterState::SetFlowType(GroupType::value groupType, EMITTER_MANIP value,
 EMITTER_MANIP EmitterState::GetFlowType(GroupType::value groupType) const {
   // force flow style if we're currently in a flow
   if (CurGroupFlowType() == FlowType::Flow)
-    return Flow;
+    return EMITTER_MANIP::Flow;
 
   // otherwise, go with what's asked of us
   return (groupType == GroupType::Seq ? m_seqFmt.get() : m_mapFmt.get());
@@ -374,8 +374,8 @@ EMITTER_MANIP EmitterState::GetFlowType(GroupType::value groupType) const {
 
 bool EmitterState::SetMapKeyFormat(EMITTER_MANIP value, FmtScope::value scope) {
   switch (value) {
-    case Auto:
-    case LongKey:
+    case EMITTER_MANIP::Auto:
+    case EMITTER_MANIP::LongKey:
       _Set(m_mapKeyFmt, value, scope);
       return true;
     default:

--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -272,19 +272,19 @@ StringFormat::value ComputeStringFormat(const std::string& str,
                                         FlowType::value flowType,
                                         bool escapeNonAscii) {
   switch (strFormat) {
-    case Auto:
+    case EMITTER_MANIP::Auto:
       if (IsValidPlainScalar(str, flowType, escapeNonAscii)) {
         return StringFormat::Plain;
       }
       return StringFormat::DoubleQuoted;
-    case SingleQuoted:
+    case EMITTER_MANIP::SingleQuoted:
       if (IsValidSingleQuotedScalar(str, escapeNonAscii)) {
         return StringFormat::SingleQuoted;
       }
       return StringFormat::DoubleQuoted;
-    case DoubleQuoted:
+    case EMITTER_MANIP::DoubleQuoted:
       return StringFormat::DoubleQuoted;
-    case Literal:
+    case EMITTER_MANIP::Literal:
       if (IsValidLiteralScalar(str, flowType, escapeNonAscii)) {
         return StringFormat::Literal;
       }

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -72,27 +72,27 @@ TEST_F(EmitterTest, AliasScalar) {
 }
 
 TEST_F(EmitterTest, StringFormat) {
-  out << BeginSeq;
-  out.SetStringFormat(SingleQuoted);
+  out << EMITTER_MANIP::BeginSeq;
+  out.SetStringFormat(EMITTER_MANIP::SingleQuoted);
   out << "string";
-  out.SetStringFormat(DoubleQuoted);
+  out.SetStringFormat(EMITTER_MANIP::DoubleQuoted);
   out << "string";
-  out.SetStringFormat(Literal);
+  out.SetStringFormat(EMITTER_MANIP::Literal);
   out << "string";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- 'string'\n- \"string\"\n- |\n  string");
 }
 
 TEST_F(EmitterTest, IntBase) {
-  out << BeginSeq;
-  out.SetIntBase(Dec);
+  out << EMITTER_MANIP::BeginSeq;
+  out.SetIntBase(EMITTER_MANIP::Dec);
   out << 1024;
-  out.SetIntBase(Hex);
+  out.SetIntBase(EMITTER_MANIP::Hex);
   out << 1024;
-  out.SetIntBase(Oct);
+  out.SetIntBase(EMITTER_MANIP::Oct);
   out << 1024;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- 1024\n- 0x400\n- 02000");
 }
@@ -100,49 +100,49 @@ TEST_F(EmitterTest, IntBase) {
 TEST_F(EmitterTest, NumberPrecision) {
   out.SetFloatPrecision(3);
   out.SetDoublePrecision(2);
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << 3.1425926f;
   out << 53.5893;
   out << 2384626.4338;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- 3.14\n- 54\n- 2.4e+06");
 }
 
 TEST_F(EmitterTest, SimpleSeq) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "eggs";
   out << "bread";
   out << "milk";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- eggs\n- bread\n- milk");
 }
 
 TEST_F(EmitterTest, SimpleFlowSeq) {
-  out << Flow;
-  out << BeginSeq;
+  out << EMITTER_MANIP::Flow;
+  out << EMITTER_MANIP::BeginSeq;
   out << "Larry";
   out << "Curly";
   out << "Moe";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("[Larry, Curly, Moe]");
 }
 
 TEST_F(EmitterTest, EmptyFlowSeq) {
-  out << Flow;
-  out << BeginSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::Flow;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("[]");
 }
 
 TEST_F(EmitterTest, EmptyBlockSeqWithBegunContent) {
-  out << BeginSeq;
-  out << BeginSeq << Comment("comment") << EndSeq;
-  out << BeginSeq << Newline << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq << Comment("comment") << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq << EMITTER_MANIP::Newline << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit(R"(-
 # comment
@@ -153,10 +153,10 @@ TEST_F(EmitterTest, EmptyBlockSeqWithBegunContent) {
 }
 
 TEST_F(EmitterTest, EmptyBlockMapWithBegunContent) {
-  out << BeginSeq;
-  out << BeginMap << Comment("comment") << EndMap;
-  out << BeginMap << Newline << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap << Comment("comment") << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Newline << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit(R"(-  # comment
   {}
@@ -165,11 +165,11 @@ TEST_F(EmitterTest, EmptyBlockMapWithBegunContent) {
 }
 
 TEST_F(EmitterTest, EmptyFlowSeqWithBegunContent) {
-  out << Flow;
-  out << BeginSeq;
-  out << BeginSeq << Comment("comment") << EndSeq;
-  out << BeginSeq << Newline << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::Flow;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq << Comment("comment") << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq << EMITTER_MANIP::Newline << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit(R"([[  # comment
   ], [
@@ -177,11 +177,11 @@ TEST_F(EmitterTest, EmptyFlowSeqWithBegunContent) {
 }
 
 TEST_F(EmitterTest, EmptyFlowMapWithBegunContent) {
-  out << Flow;
-  out << BeginSeq;
-  out << BeginMap << Comment("comment") << EndMap;
-  out << BeginMap << Newline << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::Flow;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap << Comment("comment") << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Newline << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit(R"([{  # comment
   }, {
@@ -189,128 +189,128 @@ TEST_F(EmitterTest, EmptyFlowMapWithBegunContent) {
 }
 
 TEST_F(EmitterTest, NestedBlockSeq) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "item 1";
-  out << BeginSeq << "subitem 1"
-      << "subitem 2" << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginSeq << "subitem 1"
+      << "subitem 2" << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- item 1\n-\n  - subitem 1\n  - subitem 2");
 }
 
 TEST_F(EmitterTest, NestedFlowSeq) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "one";
-  out << Flow << BeginSeq << "two"
-      << "three" << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq << "two"
+      << "three" << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- one\n- [two, three]");
 }
 
 TEST_F(EmitterTest, SimpleMap) {
-  out << BeginMap;
-  out << Key << "name";
-  out << Value << "Ryan Braun";
-  out << Key << "position";
-  out << Value << "3B";
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "name";
+  out << EMITTER_MANIP::Value << "Ryan Braun";
+  out << EMITTER_MANIP::Key << "position";
+  out << EMITTER_MANIP::Value << "3B";
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("name: Ryan Braun\nposition: 3B");
 }
 
 TEST_F(EmitterTest, SimpleFlowMap) {
-  out << Flow;
-  out << BeginMap;
-  out << Key << "shape";
-  out << Value << "square";
-  out << Key << "color";
-  out << Value << "blue";
-  out << EndMap;
+  out << EMITTER_MANIP::Flow;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "shape";
+  out << EMITTER_MANIP::Value << "square";
+  out << EMITTER_MANIP::Key << "color";
+  out << EMITTER_MANIP::Value << "blue";
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("{shape: square, color: blue}");
 }
 
 TEST_F(EmitterTest, MapAndList) {
-  out << BeginMap;
-  out << Key << "name";
-  out << Value << "Barack Obama";
-  out << Key << "children";
-  out << Value << BeginSeq << "Sasha"
-      << "Malia" << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "name";
+  out << EMITTER_MANIP::Value << "Barack Obama";
+  out << EMITTER_MANIP::Key << "children";
+  out << EMITTER_MANIP::Value << EMITTER_MANIP::BeginSeq << "Sasha"
+      << "Malia" << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("name: Barack Obama\nchildren:\n  - Sasha\n  - Malia");
 }
 
 TEST_F(EmitterTest, ListAndMap) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "item 1";
-  out << BeginMap;
-  out << Key << "pens" << Value << 8;
-  out << Key << "pencils" << Value << 14;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "pens" << EMITTER_MANIP::Value << 8;
+  out << EMITTER_MANIP::Key << "pencils" << EMITTER_MANIP::Value << 14;
+  out << EMITTER_MANIP::EndMap;
   out << "item 2";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- item 1\n- pens: 8\n  pencils: 14\n- item 2");
 }
 
 TEST_F(EmitterTest, NestedBlockMap) {
-  out << BeginMap;
-  out << Key << "name";
-  out << Value << "Fred";
-  out << Key << "grades";
-  out << Value;
-  out << BeginMap;
-  out << Key << "algebra" << Value << "A";
-  out << Key << "physics" << Value << "C+";
-  out << Key << "literature" << Value << "B";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "name";
+  out << EMITTER_MANIP::Value << "Fred";
+  out << EMITTER_MANIP::Key << "grades";
+  out << EMITTER_MANIP::Value;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "algebra" << EMITTER_MANIP::Value << "A";
+  out << EMITTER_MANIP::Key << "physics" << EMITTER_MANIP::Value << "C+";
+  out << EMITTER_MANIP::Key << "literature" << EMITTER_MANIP::Value << "B";
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(
       "name: Fred\ngrades:\n  algebra: A\n  physics: C+\n  literature: B");
 }
 
 TEST_F(EmitterTest, NestedFlowMap) {
-  out << Flow;
-  out << BeginMap;
-  out << Key << "name";
-  out << Value << "Fred";
-  out << Key << "grades";
-  out << Value;
-  out << BeginMap;
-  out << Key << "algebra" << Value << "A";
-  out << Key << "physics" << Value << "C+";
-  out << Key << "literature" << Value << "B";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::Flow;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "name";
+  out << EMITTER_MANIP::Value << "Fred";
+  out << EMITTER_MANIP::Key << "grades";
+  out << EMITTER_MANIP::Value;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "algebra" << EMITTER_MANIP::Value << "A";
+  out << EMITTER_MANIP::Key << "physics" << EMITTER_MANIP::Value << "C+";
+  out << EMITTER_MANIP::Key << "literature" << EMITTER_MANIP::Value << "B";
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("{name: Fred, grades: {algebra: A, physics: C+, literature: B}}");
 }
 
 TEST_F(EmitterTest, MapListMix) {
-  out << BeginMap;
-  out << Key << "name";
-  out << Value << "Bob";
-  out << Key << "position";
-  out << Value;
-  out << Flow << BeginSeq << 2 << 4 << EndSeq;
-  out << Key << "invincible" << Value << OnOffBool << false;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "name";
+  out << EMITTER_MANIP::Value << "Bob";
+  out << EMITTER_MANIP::Key << "position";
+  out << EMITTER_MANIP::Value;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq << 2 << 4 << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::Key << "invincible" << EMITTER_MANIP::Value << EMITTER_MANIP::OnOffBool << false;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("name: Bob\nposition: [2, 4]\ninvincible: off");
 }
 
 TEST_F(EmitterTest, SimpleLongKey) {
-  out << LongKey;
-  out << BeginMap;
-  out << Key << "height";
-  out << Value << "5'9\"";
-  out << Key << "weight";
-  out << Value << 145;
-  out << EndMap;
+  out << EMITTER_MANIP::LongKey;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "height";
+  out << EMITTER_MANIP::Value << "5'9\"";
+  out << EMITTER_MANIP::Key << "weight";
+  out << EMITTER_MANIP::Value << 145;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("? height\n: 5'9\"\n? weight\n: 145");
 }
@@ -318,59 +318,59 @@ TEST_F(EmitterTest, SimpleLongKey) {
 TEST_F(EmitterTest, SingleLongKey) {
   const std::string shortKey(1024, 'a');
   const std::string longKey(1025, 'a');
-  out << BeginMap;
-  out << Key << "age";
-  out << Value << "24";
-  out << LongKey << Key << "height";
-  out << Value << "5'9\"";
-  out << Key << "weight";
-  out << Value << 145;
-  out << Key << shortKey;
-  out << Value << "1";
-  out << Key << longKey;
-  out << Value << "1";
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "age";
+  out << EMITTER_MANIP::Value << "24";
+  out << EMITTER_MANIP::LongKey << EMITTER_MANIP::Key << "height";
+  out << EMITTER_MANIP::Value << "5'9\"";
+  out << EMITTER_MANIP::Key << "weight";
+  out << EMITTER_MANIP::Value << 145;
+  out << EMITTER_MANIP::Key << shortKey;
+  out << EMITTER_MANIP::Value << "1";
+  out << EMITTER_MANIP::Key << longKey;
+  out << EMITTER_MANIP::Value << "1";
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("age: 24\n? height\n: 5'9\"\nweight: 145\n" + shortKey +
              ": 1\n? " + longKey + "\n: 1");
 }
 
 TEST_F(EmitterTest, ComplexLongKey) {
-  out << LongKey;
-  out << BeginMap;
-  out << Key << BeginSeq << 1 << 3 << EndSeq;
-  out << Value << "monster";
-  out << Key << Flow << BeginSeq << 2 << 0 << EndSeq;
-  out << Value << "demon";
-  out << EndMap;
+  out << EMITTER_MANIP::LongKey;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << EMITTER_MANIP::BeginSeq << 1 << 3 << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::Value << "monster";
+  out << EMITTER_MANIP::Key << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq << 2 << 0 << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::Value << "demon";
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("? - 1\n  - 3\n: monster\n? [2, 0]\n: demon");
 }
 
 TEST_F(EmitterTest, AutoLongKey) {
-  out << BeginMap;
-  out << Key << BeginSeq << 1 << 3 << EndSeq;
-  out << Value << "monster";
-  out << Key << Flow << BeginSeq << 2 << 0 << EndSeq;
-  out << Value << "demon";
-  out << Key << "the origin";
-  out << Value << "angel";
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << EMITTER_MANIP::BeginSeq << 1 << 3 << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::Value << "monster";
+  out << EMITTER_MANIP::Key << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq << 2 << 0 << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::Value << "demon";
+  out << EMITTER_MANIP::Key << "the origin";
+  out << EMITTER_MANIP::Value << "angel";
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("? - 1\n  - 3\n: monster\n[2, 0]: demon\nthe origin: angel");
 }
 
 TEST_F(EmitterTest, ScalarFormat) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "simple scalar";
-  out << SingleQuoted << "explicit single-quoted scalar";
-  out << DoubleQuoted << "explicit double-quoted scalar";
+  out << EMITTER_MANIP::SingleQuoted << "explicit single-quoted scalar";
+  out << EMITTER_MANIP::DoubleQuoted << "explicit double-quoted scalar";
   out << "auto-detected\ndouble-quoted scalar";
   out << "a non-\"auto-detected\" double-quoted scalar";
-  out << Literal
+  out << EMITTER_MANIP::Literal
       << "literal scalar\nthat may span\nmany, many\nlines "
          "and have \"whatever\" crazy\tsymbols that we like";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit(
       "- simple scalar\n- 'explicit single-quoted scalar'\n- \"explicit "
@@ -383,86 +383,86 @@ TEST_F(EmitterTest, ScalarFormat) {
 }
 
 TEST_F(EmitterTest, AutoLongKeyScalar) {
-  out << BeginMap;
-  out << Key << Literal << "multi-line\nscalar";
-  out << Value << "and its value";
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << EMITTER_MANIP::Literal << "multi-line\nscalar";
+  out << EMITTER_MANIP::Value << "and its value";
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("? |\n  multi-line\n  scalar\n: and its value");
 }
 
 TEST_F(EmitterTest, LongKeyFlowMap) {
-  out << Flow;
-  out << BeginMap;
-  out << Key << "simple key";
-  out << Value << "and value";
-  out << LongKey << Key << "long key";
-  out << Value << "and its value";
-  out << EndMap;
+  out << EMITTER_MANIP::Flow;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "simple key";
+  out << EMITTER_MANIP::Value << "and value";
+  out << EMITTER_MANIP::LongKey << EMITTER_MANIP::Key << "long key";
+  out << EMITTER_MANIP::Value << "and its value";
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("{simple key: and value, ? long key: and its value}");
 }
 
 TEST_F(EmitterTest, BlockMapAsKey) {
-  out << BeginMap;
-  out << Key;
-  out << BeginMap;
-  out << Key << "key" << Value << "value";
-  out << Key << "next key" << Value << "next value";
-  out << EndMap;
-  out << Value;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "key" << EMITTER_MANIP::Value << "value";
+  out << EMITTER_MANIP::Key << "next key" << EMITTER_MANIP::Value << "next value";
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::Value;
   out << "total value";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("? key: value\n  next key: next value\n: total value");
 }
 
 TEST_F(EmitterTest, AliasAndAnchor) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("fred");
-  out << BeginMap;
-  out << Key << "name" << Value << "Fred";
-  out << Key << "age" << Value << 42;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "name" << EMITTER_MANIP::Value << "Fred";
+  out << EMITTER_MANIP::Key << "age" << EMITTER_MANIP::Value << 42;
+  out << EMITTER_MANIP::EndMap;
   out << Alias("fred");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- &fred\n  name: Fred\n  age: 42\n- *fred");
 }
 
 TEST_F(EmitterTest, AliasOnKey) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("name") << "Name";
-  out << BeginMap;
-  out << Key << Alias("name") << Value << "Fred";
-  out << EndMap;
-  out << Flow << BeginMap;
-  out << Key << Alias("name") << Value << "Mike";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << Alias("name") << EMITTER_MANIP::Value << "Fred";
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << Alias("name") << EMITTER_MANIP::Value << "Mike";
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
   ExpectEmit(R"(- &name Name
 - *name : Fred
 - {*name : Mike})");
 }
 
 TEST_F(EmitterTest, AliasAndAnchorWithNull) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("fred") << Null;
   out << Alias("fred");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- &fred ~\n- *fred");
 }
 
 TEST_F(EmitterTest, AliasAndAnchorInFlow) {
-  out << Flow << BeginSeq;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
   out << Anchor("fred");
-  out << BeginMap;
-  out << Key << "name" << Value << "Fred";
-  out << Key << "age" << Value << 42;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "name" << EMITTER_MANIP::Value << "Fred";
+  out << EMITTER_MANIP::Key << "age" << EMITTER_MANIP::Value << 42;
+  out << EMITTER_MANIP::EndMap;
   out << Alias("fred");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("[&fred {name: Fred, age: 42}, *fred]");
 }
@@ -474,86 +474,86 @@ TEST_F(EmitterTest, SimpleVerbatimTag) {
 }
 
 TEST_F(EmitterTest, VerbatimTagInBlockSeq) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("!foo") << "bar";
   out << "baz";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- !<!foo> bar\n- baz");
 }
 
 TEST_F(EmitterTest, VerbatimTagInFlowSeq) {
-  out << Flow << BeginSeq;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("!foo") << "bar";
   out << "baz";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("[!<!foo> bar, baz]");
 }
 
 TEST_F(EmitterTest, VerbatimTagInFlowSeqWithNull) {
-  out << Flow << BeginSeq;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("!foo") << Null;
   out << "baz";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("[!<!foo> ~, baz]");
 }
 
 TEST_F(EmitterTest, VerbatimTagInBlockMap) {
-  out << BeginMap;
-  out << Key << VerbatimTag("!foo") << "bar";
-  out << Value << VerbatimTag("!waz") << "baz";
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << VerbatimTag("!foo") << "bar";
+  out << EMITTER_MANIP::Value << VerbatimTag("!waz") << "baz";
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("!<!foo> bar: !<!waz> baz");
 }
 
 TEST_F(EmitterTest, VerbatimTagInFlowMap) {
-  out << Flow << BeginMap;
-  out << Key << VerbatimTag("!foo") << "bar";
-  out << Value << "baz";
-  out << EndMap;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << VerbatimTag("!foo") << "bar";
+  out << EMITTER_MANIP::Value << "baz";
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("{!<!foo> bar: baz}");
 }
 
 TEST_F(EmitterTest, VerbatimTagInFlowMapWithNull) {
-  out << Flow << BeginMap;
-  out << Key << VerbatimTag("!foo") << Null;
-  out << Value << "baz";
-  out << EndMap;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << VerbatimTag("!foo") << Null;
+  out << EMITTER_MANIP::Value << "baz";
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("{!<!foo> ~: baz}");
 }
 
 TEST_F(EmitterTest, VerbatimTagWithEmptySeq) {
-  out << VerbatimTag("!foo") << BeginSeq << EndSeq;
+  out << VerbatimTag("!foo") << EMITTER_MANIP::BeginSeq << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("!<!foo>\n[]");
 }
 
 TEST_F(EmitterTest, VerbatimTagWithEmptyMap) {
-  out << VerbatimTag("!bar") << BeginMap << EndMap;
+  out << VerbatimTag("!bar") << EMITTER_MANIP::BeginMap << EMITTER_MANIP::EndMap;
 
   ExpectEmit("!<!bar>\n{}");
 }
 
 TEST_F(EmitterTest, VerbatimTagWithEmptySeqAndMap) {
-  out << BeginSeq;
-  out << VerbatimTag("!foo") << BeginSeq << EndSeq;
-  out << VerbatimTag("!bar") << BeginMap << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << VerbatimTag("!foo") << EMITTER_MANIP::BeginSeq << EMITTER_MANIP::EndSeq;
+  out << VerbatimTag("!bar") << EMITTER_MANIP::BeginMap << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- !<!foo>\n  []\n- !<!bar>\n  {}");
 }
 
 TEST_F(EmitterTest, ByKindTagWithScalar) {
-  out << BeginSeq;
-  out << DoubleQuoted << "12";
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::DoubleQuoted << "12";
   out << "12";
-  out << TagByKind << "12";
-  out << EndSeq;
+  out << EMITTER_MANIP::TagByKind << "12";
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- \"12\"\n- 12\n- ! 12");
 }
@@ -571,56 +571,56 @@ TEST_F(EmitterTest, LocalTagWithScalar) {
 }
 
 TEST_F(EmitterTest, ComplexDoc) {
-  out << BeginMap;
-  out << Key << "receipt";
-  out << Value << "Oz-Ware Purchase Invoice";
-  out << Key << "date";
-  out << Value << "2007-08-06";
-  out << Key << "customer";
-  out << Value;
-  out << BeginMap;
-  out << Key << "given";
-  out << Value << "Dorothy";
-  out << Key << "family";
-  out << Value << "Gale";
-  out << EndMap;
-  out << Key << "items";
-  out << Value;
-  out << BeginSeq;
-  out << BeginMap;
-  out << Key << "part_no";
-  out << Value << "A4786";
-  out << Key << "descrip";
-  out << Value << "Water Bucket (Filled)";
-  out << Key << "price";
-  out << Value << 1.47;
-  out << Key << "quantity";
-  out << Value << 4;
-  out << EndMap;
-  out << BeginMap;
-  out << Key << "part_no";
-  out << Value << "E1628";
-  out << Key << "descrip";
-  out << Value << "High Heeled \"Ruby\" Slippers";
-  out << Key << "price";
-  out << Value << 100.27;
-  out << Key << "quantity";
-  out << Value << 1;
-  out << EndMap;
-  out << EndSeq;
-  out << Key << "bill-to";
-  out << Value << Anchor("id001");
-  out << BeginMap;
-  out << Key << "street";
-  out << Value << Literal << "123 Tornado Alley\nSuite 16";
-  out << Key << "city";
-  out << Value << "East Westville";
-  out << Key << "state";
-  out << Value << "KS";
-  out << EndMap;
-  out << Key << "ship-to";
-  out << Value << Alias("id001");
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "receipt";
+  out << EMITTER_MANIP::Value << "Oz-Ware Purchase Invoice";
+  out << EMITTER_MANIP::Key << "date";
+  out << EMITTER_MANIP::Value << "2007-08-06";
+  out << EMITTER_MANIP::Key << "customer";
+  out << EMITTER_MANIP::Value;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "given";
+  out << EMITTER_MANIP::Value << "Dorothy";
+  out << EMITTER_MANIP::Key << "family";
+  out << EMITTER_MANIP::Value << "Gale";
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::Key << "items";
+  out << EMITTER_MANIP::Value;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "part_no";
+  out << EMITTER_MANIP::Value << "A4786";
+  out << EMITTER_MANIP::Key << "descrip";
+  out << EMITTER_MANIP::Value << "Water Bucket (Filled)";
+  out << EMITTER_MANIP::Key << "price";
+  out << EMITTER_MANIP::Value << 1.47;
+  out << EMITTER_MANIP::Key << "quantity";
+  out << EMITTER_MANIP::Value << 4;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "part_no";
+  out << EMITTER_MANIP::Value << "E1628";
+  out << EMITTER_MANIP::Key << "descrip";
+  out << EMITTER_MANIP::Value << "High Heeled \"Ruby\" Slippers";
+  out << EMITTER_MANIP::Key << "price";
+  out << EMITTER_MANIP::Value << 100.27;
+  out << EMITTER_MANIP::Key << "quantity";
+  out << EMITTER_MANIP::Value << 1;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::Key << "bill-to";
+  out << EMITTER_MANIP::Value << Anchor("id001");
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "street";
+  out << EMITTER_MANIP::Value << EMITTER_MANIP::Literal << "123 Tornado Alley\nSuite 16";
+  out << EMITTER_MANIP::Key << "city";
+  out << EMITTER_MANIP::Value << "East Westville";
+  out << EMITTER_MANIP::Key << "state";
+  out << EMITTER_MANIP::Value << "KS";
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::Key << "ship-to";
+  out << EMITTER_MANIP::Value << Alias("id001");
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(
       "receipt: Oz-Ware Purchase Invoice\ndate: 2007-08-06\ncustomer:\n  "
@@ -633,7 +633,7 @@ TEST_F(EmitterTest, ComplexDoc) {
 }
 
 TEST_F(EmitterTest, STLContainers) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   std::vector<int> primes;
   primes.push_back(2);
   primes.push_back(3);
@@ -641,12 +641,12 @@ TEST_F(EmitterTest, STLContainers) {
   primes.push_back(7);
   primes.push_back(11);
   primes.push_back(13);
-  out << Flow << primes;
+  out << EMITTER_MANIP::Flow << primes;
   std::map<std::string, int> ages;
   ages["Daniel"] = 26;
   ages["Jesse"] = 24;
   out << ages;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- [2, 3, 5, 7, 11, 13]\n- Daniel: 26\n  Jesse: 24");
 }
@@ -654,31 +654,31 @@ TEST_F(EmitterTest, STLContainers) {
 TEST_F(EmitterTest, CommentStyle) {
   out.SetPreCommentIndent(1);
   out.SetPostCommentIndent(2);
-  out << BeginMap;
-  out << Key << "method";
-  out << Value << "least squares" << Comment("should we change this method?");
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "method";
+  out << EMITTER_MANIP::Value << "least squares" << Comment("should we change this method?");
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("method: least squares #  should we change this method?");
 }
 
 TEST_F(EmitterTest, SimpleComment) {
-  out << BeginMap;
-  out << Key << "method";
-  out << Value << "least squares" << Comment("should we change this method?");
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "method";
+  out << EMITTER_MANIP::Value << "least squares" << Comment("should we change this method?");
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("method: least squares  # should we change this method?");
 }
 
 TEST_F(EmitterTest, MultiLineComment) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "item 1"
       << Comment(
              "really really long\ncomment that couldn't "
              "possibly\nfit on one line");
   out << "item 2";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit(
       "- item 1  # really really long\n          # comment that couldn't "
@@ -686,41 +686,41 @@ TEST_F(EmitterTest, MultiLineComment) {
 }
 
 TEST_F(EmitterTest, ComplexComments) {
-  out << BeginMap;
-  out << LongKey << Key << "long key" << Comment("long key");
-  out << Value << "value";
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::LongKey << EMITTER_MANIP::Key << "long key" << Comment("long key");
+  out << EMITTER_MANIP::Value << "value";
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("? long key  # long key\n: value");
 }
 
 TEST_F(EmitterTest, InitialComment) {
   out << Comment("A comment describing the purpose of the file.");
-  out << BeginMap << Key << "key" << Value << "value" << EndMap;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "key" << EMITTER_MANIP::Value << "value" << EMITTER_MANIP::EndMap;
 
   ExpectEmit("# A comment describing the purpose of the file.\nkey: value");
 }
 
 TEST_F(EmitterTest, InitialCommentWithDocIndicator) {
-  out << BeginDoc << Comment("A comment describing the purpose of the file.");
-  out << BeginMap << Key << "key" << Value << "value" << EndMap;
+  out << EMITTER_MANIP::BeginDoc << Comment("A comment describing the purpose of the file.");
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "key" << EMITTER_MANIP::Value << "value" << EMITTER_MANIP::EndMap;
 
   ExpectEmit(
       "---\n# A comment describing the purpose of the file.\nkey: value");
 }
 
 TEST_F(EmitterTest, CommentInFlowSeq) {
-  out << Flow << BeginSeq << "foo" << Comment("foo!") << "bar" << EndSeq;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq << "foo" << Comment("foo!") << "bar" << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("[foo,  # foo!\nbar]");
 }
 
 TEST_F(EmitterTest, CommentInFlowMap) {
-  out << Flow << BeginMap;
-  out << Key << "foo" << Value << "foo value";
-  out << Key << "bar" << Value << "bar value" << Comment("bar!");
-  out << Key << "baz" << Value << "baz value" << Comment("baz!");
-  out << EndMap;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "foo" << EMITTER_MANIP::Value << "foo value";
+  out << EMITTER_MANIP::Key << "bar" << EMITTER_MANIP::Value << "bar value" << Comment("bar!");
+  out << EMITTER_MANIP::Key << "baz" << EMITTER_MANIP::Value << "baz value" << Comment("baz!");
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(
       "{foo: foo value, bar: bar value,  # bar!\nbaz: baz value,  # baz!\n}");
@@ -728,14 +728,14 @@ TEST_F(EmitterTest, CommentInFlowMap) {
 
 TEST_F(EmitterTest, Indentation) {
   out << Indent(4);
-  out << BeginSeq;
-  out << BeginMap;
-  out << Key << "key 1" << Value << "value 1";
-  out << Key << "key 2" << Value << BeginSeq << "a"
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "key 1" << EMITTER_MANIP::Value << "value 1";
+  out << EMITTER_MANIP::Key << "key 2" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginSeq << "a"
       << "b"
-      << "c" << EndSeq;
-  out << EndMap;
-  out << EndSeq;
+      << "c" << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit(
       "-   key 1: value 1\n    key 2:\n        -   a\n        -   b\n        - "
@@ -744,32 +744,32 @@ TEST_F(EmitterTest, Indentation) {
 
 TEST_F(EmitterTest, SimpleGlobalSettings) {
   out.SetIndent(4);
-  out.SetMapFormat(LongKey);
+  out.SetMapFormat(EMITTER_MANIP::LongKey);
 
-  out << BeginSeq;
-  out << BeginMap;
-  out << Key << "key 1" << Value << "value 1";
-  out << Key << "key 2" << Value << Flow << BeginSeq << "a"
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "key 1" << EMITTER_MANIP::Value << "value 1";
+  out << EMITTER_MANIP::Key << "key 2" << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq << "a"
       << "b"
-      << "c" << EndSeq;
-  out << EndMap;
-  out << EndSeq;
+      << "c" << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("-   ? key 1\n    : value 1\n    ? key 2\n    : [a, b, c]");
 }
 
 TEST_F(EmitterTest, GlobalLongKeyOnSeq) {
-  out.SetMapFormat(LongKey);
+  out.SetMapFormat(EMITTER_MANIP::LongKey);
 
-  out << BeginMap;
-  out << Key << Anchor("key");
-  out << BeginSeq << "a"
-      << "b" << EndSeq;
-  out << Value << Anchor("value");
-  out << BeginSeq << "c"
-      << "d" << EndSeq;
-  out << Key << Alias("key") << Value << Alias("value");
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << Anchor("key");
+  out << EMITTER_MANIP::BeginSeq << "a"
+      << "b" << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::Value << Anchor("value");
+  out << EMITTER_MANIP::BeginSeq << "c"
+      << "d" << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::Key << Alias("key") << EMITTER_MANIP::Value << Alias("value");
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(R"(? &key
   - a
@@ -782,17 +782,17 @@ TEST_F(EmitterTest, GlobalLongKeyOnSeq) {
 }
 
 TEST_F(EmitterTest, GlobalLongKeyOnMap) {
-  out.SetMapFormat(LongKey);
+  out.SetMapFormat(EMITTER_MANIP::LongKey);
 
-  out << BeginMap;
-  out << Key << Anchor("key");
-  out << BeginMap << "a"
-      << "b" << EndMap;
-  out << Value << Anchor("value");
-  out << BeginMap << "c"
-      << "d" << EndMap;
-  out << Key << Alias("key") << Value << Alias("value");
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << Anchor("key");
+  out << EMITTER_MANIP::BeginMap << "a"
+      << "b" << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::Value << Anchor("value");
+  out << EMITTER_MANIP::BeginMap << "c"
+      << "d" << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::Key << Alias("key") << EMITTER_MANIP::Value << Alias("value");
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(R"(? &key
   ? a
@@ -810,7 +810,7 @@ TEST_F(EmitterTest, GlobalSettingStyleOnSeqNode) {
   - 2
   - 3
 bar: aa)"));
-  out.SetSeqFormat(YAML::Flow);
+  out.SetSeqFormat(EMITTER_MANIP::Flow);
   out << n;
   ExpectEmit(R"(foo: [1, 2, 3]
 bar: aa)");
@@ -822,7 +822,7 @@ TEST_F(EmitterTest, GlobalSettingStyleOnMapNode) {
   bar: b
 - 2
 - 3)"));
-  out.SetMapFormat(YAML::Flow);
+  out.SetMapFormat(EMITTER_MANIP::Flow);
   out << n;
   ExpectEmit(R"(- {foo: a, bar: b}
 - 2
@@ -830,50 +830,50 @@ TEST_F(EmitterTest, GlobalSettingStyleOnMapNode) {
 }
 
 TEST_F(EmitterTest, ComplexGlobalSettings) {
-  out << BeginSeq;
-  out << Block;
-  out << BeginMap;
-  out << Key << "key 1" << Value << "value 1";
-  out << Key << "key 2" << Value;
-  out.SetSeqFormat(Flow);
-  out << BeginSeq << "a"
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::Block;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "key 1" << EMITTER_MANIP::Value << "value 1";
+  out << EMITTER_MANIP::Key << "key 2" << EMITTER_MANIP::Value;
+  out.SetSeqFormat(EMITTER_MANIP::Flow);
+  out << EMITTER_MANIP::BeginSeq << "a"
       << "b"
-      << "c" << EndSeq;
-  out << EndMap;
-  out << BeginMap;
-  out << Key << BeginSeq << 1 << 2 << EndSeq;
-  out << Value << BeginMap << Key << "a" << Value << "b" << EndMap;
-  out << EndMap;
-  out << EndSeq;
+      << "c" << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << EMITTER_MANIP::BeginSeq << 1 << 2 << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "a" << EMITTER_MANIP::Value << "b" << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- key 1: value 1\n  key 2: [a, b, c]\n- [1, 2]:\n    a: b");
 }
 
 TEST_F(EmitterTest, Null) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Null;
-  out << BeginMap;
-  out << Key << "null value" << Value << Null;
-  out << Key << Null << Value << "null key";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "null value" << EMITTER_MANIP::Value << Null;
+  out << EMITTER_MANIP::Key << Null << EMITTER_MANIP::Value << "null key";
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- ~\n- null value: ~\n  ~: null key");
 }
 
 TEST_F(EmitterTest, OutputCharset) {
-  out << BeginSeq;
-  out.SetOutputCharset(EmitNonAscii);
+  out << EMITTER_MANIP::BeginSeq;
+  out.SetOutputCharset(EMITTER_MANIP::EmitNonAscii);
   out << "\x24 \xC2\xA2 \xE2\x82\xAC";
-  out.SetOutputCharset(EscapeNonAscii);
+  out.SetOutputCharset(EMITTER_MANIP::EscapeNonAscii);
   out << "\x24 \xC2\xA2 \xE2\x82\xAC";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- \x24 \xC2\xA2 \xE2\x82\xAC\n- \"\x24 \\xa2 \\u20ac\"");
 }
 
 TEST_F(EmitterTest, EscapedUnicode) {
-  out << EscapeNonAscii << "\x24 \xC2\xA2 \xE2\x82\xAC \xF0\xA4\xAD\xA2";
+  out << EMITTER_MANIP::EscapeNonAscii << "\x24 \xC2\xA2 \xE2\x82\xAC \xF0\xA4\xAD\xA2";
 
   ExpectEmit("\"$ \\xa2 \\u20ac \\U00024b62\"");
 }
@@ -884,13 +884,13 @@ TEST_F(EmitterTest, Unicode) {
 }
 
 TEST_F(EmitterTest, DoubleQuotedUnicode) {
-  out << DoubleQuoted << "\x24 \xC2\xA2 \xE2\x82\xAC \xF0\xA4\xAD\xA2";
+  out << EMITTER_MANIP::DoubleQuoted << "\x24 \xC2\xA2 \xE2\x82\xAC \xF0\xA4\xAD\xA2";
   ExpectEmit("\"\x24 \xC2\xA2 \xE2\x82\xAC \xF0\xA4\xAD\xA2\""); 
 }
 
 TEST_F(EmitterTest, EscapedJsonString) {
-  out.SetStringFormat(DoubleQuoted);
-  out.SetOutputCharset(EscapeAsJson);
+  out.SetStringFormat(EMITTER_MANIP::DoubleQuoted);
+  out.SetOutputCharset(EMITTER_MANIP::EscapeAsJson);
   out << "\" \\ "
     "\x01 \x02 \x03 \x04 \x05 \x06 \x07 \x08 \x09 \x0A \x0B \x0C \x0D \x0E \x0F "
     "\x10 \x11 \x12 \x13 \x14 \x15 \x16 \x17 \x18 \x19 \x1A \x1B \x1C \x1D \x1E \x1F "
@@ -904,28 +904,28 @@ TEST_F(EmitterTest, EscapedJsonString) {
 }
 
 TEST_F(EmitterTest, EscapedCharacters) {
-  out << BeginSeq 
+  out << EMITTER_MANIP::BeginSeq 
     << '\x00'
     << '\x0C'
     << '\x0D'
-    << EndSeq;
+    << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- \"\\x00\"\n- \"\\f\"\n- \"\\r\"");
 }
 
 TEST_F(EmitterTest, CharactersEscapedAsJson) {
-  out.SetOutputCharset(EscapeAsJson);
-  out << BeginSeq
+  out.SetOutputCharset(EMITTER_MANIP::EscapeAsJson);
+  out << EMITTER_MANIP::BeginSeq
     << '\x00'
     << '\x0C'
     << '\x0D'
-    << EndSeq;
+    << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- \"\\u0000\"\n- \"\\f\"\n- \"\\r\"");
 }
 
 TEST_F(EmitterTest, DoubleQuotedString) {
-  out << DoubleQuoted << "\" \\ \n \t \r \b \x15 \xEF\xBB\xBF \x24";
+  out << EMITTER_MANIP::DoubleQuoted << "\" \\ \n \t \r \b \x15 \xEF\xBB\xBF \x24";
   ExpectEmit("\"\\\" \\\\ \\n \\t \\r \\b \\x15 \\ufeff $\"");
 }
 
@@ -938,18 +938,18 @@ struct Foo {
 };
 
 Emitter& operator<<(Emitter& out, const Foo& foo) {
-  out << BeginMap;
-  out << Key << "x" << Value << foo.x;
-  out << Key << "bar" << Value << foo.bar;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "x" << EMITTER_MANIP::Value << foo.x;
+  out << EMITTER_MANIP::Key << "bar" << EMITTER_MANIP::Value << foo.bar;
+  out << EMITTER_MANIP::EndMap;
   return out;
 }
 
 TEST_F(EmitterTest, UserType) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Foo(5, "hello");
   out << Foo(3, "goodbye");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- x: 5\n  bar: hello\n- x: 3\n  bar: goodbye");
 }
@@ -976,9 +976,9 @@ TEST_F(EmitterTest, PointerToInt) {
   int foo = 5;
   int* bar = &foo;
   int* baz = 0;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << bar << baz;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- 5\n- ~");
 }
@@ -987,64 +987,64 @@ TEST_F(EmitterTest, PointerToUserType) {
   Foo foo(5, "hello");
   Foo* bar = &foo;
   Foo* baz = 0;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << bar << baz;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit("- x: 5\n  bar: hello\n- ~");
 }
 
 TEST_F(EmitterTest, NewlineAtEnd) {
-  out << "Hello" << Newline << Newline;
+  out << "Hello" << EMITTER_MANIP::Newline << EMITTER_MANIP::Newline;
   ExpectEmit("Hello\n\n");
 }
 
 TEST_F(EmitterTest, NewlineInBlockSequence) {
-  out << BeginSeq;
-  out << "a" << Newline << "b"
-      << "c" << Newline << "d";
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << "a" << EMITTER_MANIP::Newline << "b"
+      << "c" << EMITTER_MANIP::Newline << "d";
+  out << EMITTER_MANIP::EndSeq;
   ExpectEmit("- a\n\n- b\n- c\n\n- d");
 }
 
 TEST_F(EmitterTest, NewlineInFlowSequence) {
-  out << Flow << BeginSeq;
-  out << "a" << Newline << "b"
-      << "c" << Newline << "d";
-  out << EndSeq;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out << "a" << EMITTER_MANIP::Newline << "b"
+      << "c" << EMITTER_MANIP::Newline << "d";
+  out << EMITTER_MANIP::EndSeq;
   ExpectEmit("[a,\nb, c,\nd]");
 }
 
 TEST_F(EmitterTest, NewlineInBlockMap) {
-  out << BeginMap;
-  out << Key << "a" << Value << "foo" << Newline;
-  out << Key << "b" << Newline << Value << "bar";
-  out << LongKey << Key << "c" << Newline << Value << "car";
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "a" << EMITTER_MANIP::Value << "foo" << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::Key << "b" << EMITTER_MANIP::Newline << EMITTER_MANIP::Value << "bar";
+  out << EMITTER_MANIP::LongKey << EMITTER_MANIP::Key << "c" << EMITTER_MANIP::Newline << EMITTER_MANIP::Value << "car";
+  out << EMITTER_MANIP::EndMap;
   ExpectEmit("a: foo\nb:\n  bar\n? c\n\n: car");
 }
 
 TEST_F(EmitterTest, NewlineInFlowMap) {
-  out << Flow << BeginMap;
-  out << Key << "a" << Value << "foo" << Newline;
-  out << Key << "b" << Value << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "a" << EMITTER_MANIP::Value << "foo" << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::Key << "b" << EMITTER_MANIP::Value << "bar";
+  out << EMITTER_MANIP::EndMap;
   ExpectEmit("{a: foo,\nb: bar}");
 }
 
 TEST_F(EmitterTest, LotsOfNewlines) {
-  out << BeginSeq;
-  out << "a" << Newline;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << "a" << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::BeginSeq;
   out << "b"
-      << "c" << Newline;
-  out << EndSeq;
-  out << Newline;
-  out << BeginMap;
-  out << Newline << Key << "d" << Value << Newline << "e";
-  out << LongKey << Key << "f" << Newline << Value << "foo";
-  out << EndMap;
-  out << EndSeq;
+      << "c" << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Newline << EMITTER_MANIP::Key << "d" << EMITTER_MANIP::Value << EMITTER_MANIP::Newline << "e";
+  out << EMITTER_MANIP::LongKey << EMITTER_MANIP::Key << "f" << EMITTER_MANIP::Newline << EMITTER_MANIP::Value << "foo";
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
   ExpectEmit("- a\n\n-\n  - b\n  - c\n\n\n-\n  d:\n    e\n  ? f\n\n  : foo");
 }
 
@@ -1083,62 +1083,62 @@ TEST_F(EmitterTest, ColonAtEndOfScalar) {
 }
 
 TEST_F(EmitterTest, ColonAsScalar) {
-  out << BeginMap;
-  out << Key << "apple" << Value << ":";
-  out << Key << "banana" << Value << ":";
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "apple" << EMITTER_MANIP::Value << ":";
+  out << EMITTER_MANIP::Key << "banana" << EMITTER_MANIP::Value << ":";
+  out << EMITTER_MANIP::EndMap;
   ExpectEmit("apple: \":\"\nbanana: \":\"");
 }
 
 TEST_F(EmitterTest, ColonAtEndOfScalarInFlow) {
-  out << Flow << BeginMap << Key << "C:" << Value << "C:" << EndMap;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "C:" << EMITTER_MANIP::Value << "C:" << EMITTER_MANIP::EndMap;
   ExpectEmit("{\"C:\": \"C:\"}");
 }
 
 TEST_F(EmitterTest, GlobalBoolFormatting) {
-  out << BeginSeq;
-  out.SetBoolFormat(UpperCase);
-  out.SetBoolFormat(YesNoBool);
+  out << EMITTER_MANIP::BeginSeq;
+  out.SetBoolFormat(EMITTER_MANIP::UpperCase);
+  out.SetBoolFormat(EMITTER_MANIP::YesNoBool);
   out << true;
   out << false;
-  out.SetBoolFormat(TrueFalseBool);
+  out.SetBoolFormat(EMITTER_MANIP::TrueFalseBool);
   out << true;
   out << false;
-  out.SetBoolFormat(OnOffBool);
+  out.SetBoolFormat(EMITTER_MANIP::OnOffBool);
   out << true;
   out << false;
-  out.SetBoolFormat(LowerCase);
-  out.SetBoolFormat(YesNoBool);
+  out.SetBoolFormat(EMITTER_MANIP::LowerCase);
+  out.SetBoolFormat(EMITTER_MANIP::YesNoBool);
   out << true;
   out << false;
-  out.SetBoolFormat(TrueFalseBool);
+  out.SetBoolFormat(EMITTER_MANIP::TrueFalseBool);
   out << true;
   out << false;
-  out.SetBoolFormat(OnOffBool);
+  out.SetBoolFormat(EMITTER_MANIP::OnOffBool);
   out << true;
   out << false;
-  out.SetBoolFormat(CamelCase);
-  out.SetBoolFormat(YesNoBool);
+  out.SetBoolFormat(EMITTER_MANIP::CamelCase);
+  out.SetBoolFormat(EMITTER_MANIP::YesNoBool);
   out << true;
   out << false;
-  out.SetBoolFormat(TrueFalseBool);
+  out.SetBoolFormat(EMITTER_MANIP::TrueFalseBool);
   out << true;
   out << false;
-  out.SetBoolFormat(OnOffBool);
+  out.SetBoolFormat(EMITTER_MANIP::OnOffBool);
   out << true;
   out << false;
-  out.SetBoolFormat(ShortBool);
-  out.SetBoolFormat(UpperCase);
-  out.SetBoolFormat(YesNoBool);
+  out.SetBoolFormat(EMITTER_MANIP::ShortBool);
+  out.SetBoolFormat(EMITTER_MANIP::UpperCase);
+  out.SetBoolFormat(EMITTER_MANIP::YesNoBool);
   out << true;
   out << false;
-  out.SetBoolFormat(TrueFalseBool);
+  out.SetBoolFormat(EMITTER_MANIP::TrueFalseBool);
   out << true;
   out << false;
-  out.SetBoolFormat(OnOffBool);
+  out.SetBoolFormat(EMITTER_MANIP::OnOffBool);
   out << true;
   out << false;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   ExpectEmit(
       "- YES\n- NO\n- TRUE\n- FALSE\n- ON\n- OFF\n"
       "- yes\n- no\n- true\n- false\n- on\n- off\n"
@@ -1147,32 +1147,32 @@ TEST_F(EmitterTest, GlobalBoolFormatting) {
 }
 
 TEST_F(EmitterTest, BoolFormatting) {
-  out << BeginSeq;
-  out << TrueFalseBool << UpperCase << true;
-  out << TrueFalseBool << CamelCase << true;
-  out << TrueFalseBool << LowerCase << true;
-  out << TrueFalseBool << UpperCase << false;
-  out << TrueFalseBool << CamelCase << false;
-  out << TrueFalseBool << LowerCase << false;
-  out << YesNoBool << UpperCase << true;
-  out << YesNoBool << CamelCase << true;
-  out << YesNoBool << LowerCase << true;
-  out << YesNoBool << UpperCase << false;
-  out << YesNoBool << CamelCase << false;
-  out << YesNoBool << LowerCase << false;
-  out << OnOffBool << UpperCase << true;
-  out << OnOffBool << CamelCase << true;
-  out << OnOffBool << LowerCase << true;
-  out << OnOffBool << UpperCase << false;
-  out << OnOffBool << CamelCase << false;
-  out << OnOffBool << LowerCase << false;
-  out << ShortBool << UpperCase << true;
-  out << ShortBool << CamelCase << true;
-  out << ShortBool << LowerCase << true;
-  out << ShortBool << UpperCase << false;
-  out << ShortBool << CamelCase << false;
-  out << ShortBool << LowerCase << false;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::TrueFalseBool << EMITTER_MANIP::UpperCase << true;
+  out << EMITTER_MANIP::TrueFalseBool << EMITTER_MANIP::CamelCase << true;
+  out << EMITTER_MANIP::TrueFalseBool << EMITTER_MANIP::LowerCase << true;
+  out << EMITTER_MANIP::TrueFalseBool << EMITTER_MANIP::UpperCase << false;
+  out << EMITTER_MANIP::TrueFalseBool << EMITTER_MANIP::CamelCase << false;
+  out << EMITTER_MANIP::TrueFalseBool << EMITTER_MANIP::LowerCase << false;
+  out << EMITTER_MANIP::YesNoBool << EMITTER_MANIP::UpperCase << true;
+  out << EMITTER_MANIP::YesNoBool << EMITTER_MANIP::CamelCase << true;
+  out << EMITTER_MANIP::YesNoBool << EMITTER_MANIP::LowerCase << true;
+  out << EMITTER_MANIP::YesNoBool << EMITTER_MANIP::UpperCase << false;
+  out << EMITTER_MANIP::YesNoBool << EMITTER_MANIP::CamelCase << false;
+  out << EMITTER_MANIP::YesNoBool << EMITTER_MANIP::LowerCase << false;
+  out << EMITTER_MANIP::OnOffBool << EMITTER_MANIP::UpperCase << true;
+  out << EMITTER_MANIP::OnOffBool << EMITTER_MANIP::CamelCase << true;
+  out << EMITTER_MANIP::OnOffBool << EMITTER_MANIP::LowerCase << true;
+  out << EMITTER_MANIP::OnOffBool << EMITTER_MANIP::UpperCase << false;
+  out << EMITTER_MANIP::OnOffBool << EMITTER_MANIP::CamelCase << false;
+  out << EMITTER_MANIP::OnOffBool << EMITTER_MANIP::LowerCase << false;
+  out << EMITTER_MANIP::ShortBool << EMITTER_MANIP::UpperCase << true;
+  out << EMITTER_MANIP::ShortBool << EMITTER_MANIP::CamelCase << true;
+  out << EMITTER_MANIP::ShortBool << EMITTER_MANIP::LowerCase << true;
+  out << EMITTER_MANIP::ShortBool << EMITTER_MANIP::UpperCase << false;
+  out << EMITTER_MANIP::ShortBool << EMITTER_MANIP::CamelCase << false;
+  out << EMITTER_MANIP::ShortBool << EMITTER_MANIP::LowerCase << false;
+  out << EMITTER_MANIP::EndSeq;
   ExpectEmit(
       "- TRUE\n- True\n- true\n- FALSE\n- False\n- false\n"
       "- YES\n- Yes\n- yes\n- NO\n- No\n- no\n"
@@ -1181,54 +1181,54 @@ TEST_F(EmitterTest, BoolFormatting) {
 }
 
 TEST_F(EmitterTest, GlobalNullFormatting) {
-  out << Flow << BeginSeq;
-  out.SetNullFormat(LowerNull);
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out.SetNullFormat(EMITTER_MANIP::LowerNull);
   out << Null;
-  out.SetNullFormat(UpperNull);
+  out.SetNullFormat(EMITTER_MANIP::UpperNull);
   out << Null;
-  out.SetNullFormat(CamelNull);
+  out.SetNullFormat(EMITTER_MANIP::CamelNull);
   out << Null;
-  out.SetNullFormat(TildeNull);
+  out.SetNullFormat(EMITTER_MANIP::TildeNull);
   out << Null;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   ExpectEmit("[null, NULL, Null, ~]");
 }
 
 TEST_F(EmitterTest, NullFormatting) {
-  out << Flow << BeginSeq;
-  out << LowerNull << Null;
-  out << UpperNull << Null;
-  out << CamelNull << Null;
-  out << TildeNull << Null;
-  out << EndSeq;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::LowerNull << Null;
+  out << EMITTER_MANIP::UpperNull << Null;
+  out << EMITTER_MANIP::CamelNull << Null;
+  out << EMITTER_MANIP::TildeNull << Null;
+  out << EMITTER_MANIP::EndSeq;
   ExpectEmit("[null, NULL, Null, ~]");
 }
 
 TEST_F(EmitterTest, NullFormattingOnNode) {
   Node n(Load("null"));
-  out << Flow << BeginSeq;
-  out.SetNullFormat(LowerNull);
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out.SetNullFormat(EMITTER_MANIP::LowerNull);
   out << n;
-  out.SetNullFormat(UpperNull);
+  out.SetNullFormat(EMITTER_MANIP::UpperNull);
   out << n;
-  out.SetNullFormat(CamelNull);
+  out.SetNullFormat(EMITTER_MANIP::CamelNull);
   out << n;
-  out.SetNullFormat(TildeNull);
+  out.SetNullFormat(EMITTER_MANIP::TildeNull);
   out << n;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   ExpectEmit("[null, NULL, Null, ~]");
 }
 
 // TODO: Fix this test.
 // TEST_F(EmitterTest, DocStartAndEnd) {
-//  out << BeginDoc;
-//  out << BeginSeq << 1 << 2 << 3 << EndSeq;
-//  out << BeginDoc;
+//  out << EMITTER_MANIP::BeginDoc;
+//  out << EMITTER_MANIP::BeginSeq << 1 << 2 << 3 << EMITTER_MANIP::EndSeq;
+//  out << EMITTER_MANIP::BeginDoc;
 //  out << "Hi there!";
-//  out << EndDoc;
-//  out << EndDoc;
-//  out << EndDoc;
-//  out << BeginDoc;
+//  out << EMITTER_MANIP::EndDoc;
+//  out << EMITTER_MANIP::EndDoc;
+//  out << EMITTER_MANIP::EndDoc;
+//  out << EMITTER_MANIP::BeginDoc;
 //  out << VerbatimTag("foo") << "bar";
 //  ExpectEmit(
 //      "---\n- 1\n- 2\n- 3\n---\nHi there!\n...\n...\n...\n---\n!<foo> bar");
@@ -1242,70 +1242,70 @@ TEST_F(EmitterTest, ImplicitDocStart) {
 }
 
 TEST_F(EmitterTest, EmptyString) {
-  out << BeginMap;
-  out << Key << "key" << Value << "";
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "key" << EMITTER_MANIP::Value << "";
+  out << EMITTER_MANIP::EndMap;
   ExpectEmit("key: \"\"");
 }
 
 TEST_F(EmitterTest, SingleChar) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << 'a';
   out << ':';
   out << (char)0x10;
   out << '\n';
   out << ' ';
   out << '\t';
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   ExpectEmit("- a\n- \":\"\n- \"\\x10\"\n- \"\\n\"\n- \" \"\n- \"\\t\"");
 }
 
 TEST_F(EmitterTest, DefaultPrecision) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << 1.3125f;
   out << 1.23455810546875;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   ExpectEmit("- 1.3125\n- 1.23455810546875");
 }
 
 TEST_F(EmitterTest, SetPrecision) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << FloatPrecision(3) << 1.3125f;
   out << DoublePrecision(6) << 1.23455810546875;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   ExpectEmit("- 1.31\n- 1.23456");
 }
 
 TEST_F(EmitterTest, DashInBlockContext) {
-  out << BeginMap;
-  out << Key << "key" << Value << "-";
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "key" << EMITTER_MANIP::Value << "-";
+  out << EMITTER_MANIP::EndMap;
   ExpectEmit("key: \"-\"");
 }
 
 TEST_F(EmitterTest, HexAndOct) {
-  out << Flow << BeginSeq;
+  out << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
   out << 31;
-  out << Hex << 31;
-  out << Oct << 31;
-  out << EndSeq;
+  out << EMITTER_MANIP::Hex << 31;
+  out << EMITTER_MANIP::Oct << 31;
+  out << EMITTER_MANIP::EndSeq;
   ExpectEmit("[31, 0x1f, 037]");
 }
 
 TEST_F(EmitterTest, CompactMapWithNewline) {
   out << Comment("Characteristics");
-  out << BeginSeq;
-  out << BeginMap;
-  out << Key << "color" << Value << "blue";
-  out << Key << "height" << Value << 120;
-  out << EndMap;
-  out << Newline << Newline;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "color" << EMITTER_MANIP::Value << "blue";
+  out << EMITTER_MANIP::Key << "height" << EMITTER_MANIP::Value << 120;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::Newline << EMITTER_MANIP::Newline;
   out << Comment("Skills");
-  out << BeginMap;
-  out << Key << "attack" << Value << 23;
-  out << Key << "intelligence" << Value << 56;
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "attack" << EMITTER_MANIP::Value << 23;
+  out << EMITTER_MANIP::Key << "intelligence" << EMITTER_MANIP::Value << 56;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmit(
       "# Characteristics\n"
@@ -1318,7 +1318,7 @@ TEST_F(EmitterTest, CompactMapWithNewline) {
 }
 
 TEST_F(EmitterTest, ForceSingleQuotedToDouble) {
-  out << SingleQuoted << "Hello\nWorld";
+  out << EMITTER_MANIP::SingleQuoted << "Hello\nWorld";
 
   ExpectEmit("\"Hello\\nWorld\"");
 }
@@ -1330,28 +1330,28 @@ TEST_F(EmitterTest, QuoteNull) {
 }
 
 TEST_F(EmitterTest, ValueOfDoubleQuote) {
-  out << YAML::BeginMap;
-  out << YAML::Key << "foo" << YAML::Value << '"';
-  out << YAML::EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "foo" << EMITTER_MANIP::Value << '"';
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("foo: \"\\\"\"");
 }
 
 TEST_F(EmitterTest, ValueOfBackslash) {
-  out << YAML::BeginMap;
-  out << YAML::Key << "foo" << YAML::Value << '\\';
-  out << YAML::EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "foo" << EMITTER_MANIP::Value << '\\';
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit("foo: \"\\\\\"");
 }
 
 TEST_F(EmitterTest, Infinity) {
-  out << YAML::BeginMap;
-  out << YAML::Key << "foo" << YAML::Value
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "foo" << EMITTER_MANIP::Value
       << std::numeric_limits<float>::infinity();
-  out << YAML::Key << "bar" << YAML::Value
+  out << EMITTER_MANIP::Key << "bar" << EMITTER_MANIP::Value
       << std::numeric_limits<double>::infinity();
-  out << YAML::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(
 	  "foo: .inf\n"
@@ -1359,12 +1359,12 @@ TEST_F(EmitterTest, Infinity) {
 }
 
 TEST_F(EmitterTest, NegInfinity) {
-  out << YAML::BeginMap;
-  out << YAML::Key << "foo" << YAML::Value
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "foo" << EMITTER_MANIP::Value
       << -std::numeric_limits<float>::infinity();
-  out << YAML::Key << "bar" << YAML::Value
+  out << EMITTER_MANIP::Key << "bar" << EMITTER_MANIP::Value
       << -std::numeric_limits<double>::infinity();
-  out << YAML::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(
 	  "foo: -.inf\n"
@@ -1372,12 +1372,12 @@ TEST_F(EmitterTest, NegInfinity) {
 }
 
 TEST_F(EmitterTest, NaN) {
-  out << YAML::BeginMap;
-  out << YAML::Key << "foo" << YAML::Value
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "foo" << EMITTER_MANIP::Value
       << std::numeric_limits<float>::quiet_NaN();
-  out << YAML::Key << "bar" << YAML::Value
+  out << EMITTER_MANIP::Key << "bar" << EMITTER_MANIP::Value
       << std::numeric_limits<double>::quiet_NaN();
-  out << YAML::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(
 	  "foo: .nan\n"
@@ -1385,27 +1385,27 @@ TEST_F(EmitterTest, NaN) {
 }
 
 TEST_F(EmitterTest, ComplexFlowSeqEmbeddingAMapWithNewLine) { 
-  out << YAML::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
 
-  out << YAML::Key << "NodeA" << YAML::Value << YAML::BeginMap;
-  out << YAML::Key << "k" << YAML::Value << YAML::Flow << YAML::BeginSeq;
-  out << YAML::BeginMap << YAML::Key << "i" << YAML::Value << 0 << YAML::EndMap
-      << YAML::Newline;
-  out << YAML::BeginMap << YAML::Key << "i" << YAML::Value << 1 << YAML::EndMap
-      << YAML::Newline;
-  out << YAML::EndSeq;
-  out << YAML::EndMap;
+  out << EMITTER_MANIP::Key << "NodeA" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 0 << EMITTER_MANIP::EndMap
+      << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 1 << EMITTER_MANIP::EndMap
+      << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
-  out << YAML::Key << "NodeB" << YAML::Value << YAML::BeginMap;
-  out << YAML::Key << "k" << YAML::Value << YAML::Flow << YAML::BeginSeq;
-  out << YAML::BeginMap << YAML::Key << "i" << YAML::Value << 0 << YAML::EndMap
-      << YAML::Newline;
-  out << YAML::BeginMap << YAML::Key << "i" << YAML::Value << 1 << YAML::EndMap
-      << YAML::Newline;
-  out << YAML::EndSeq;
-  out << YAML::EndMap;
+  out << EMITTER_MANIP::Key << "NodeB" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 0 << EMITTER_MANIP::EndMap
+      << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 1 << EMITTER_MANIP::EndMap
+      << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
-  out << YAML::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(R"(NodeA:
   k: [{i: 0},
@@ -1418,20 +1418,20 @@ NodeB:
 }
 
 TEST_F(EmitterTest, ComplexFlowSeqEmbeddingAMapWithNewLineUsingAliases) {
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
 
-  out << Key << "Node" << Anchor("Node") << Value << BeginMap;
-  out << Key << "k" << Value << Flow << BeginSeq;
-  out << BeginMap << Key << "i" << Value << 0 << EndMap;
-  out << YAML::Newline;
-  out << BeginMap << Key << "i" << Value << 1 << EndMap;
-  out << YAML::Newline;
-  out << EndSeq << EndMap;
+  out << EMITTER_MANIP::Key << "Node" << Anchor("Node") << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 0 << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 1 << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::EndSeq << EMITTER_MANIP::EndMap;
 
-  out << Key << "NodeA" << Alias("Node");
-  out << Key << "NodeB" << Alias("Node");
+  out << EMITTER_MANIP::Key << "NodeA" << Alias("Node");
+  out << EMITTER_MANIP::Key << "NodeB" << Alias("Node");
 
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(R"(Node: &Node
   k: [{i: 0},
@@ -1442,18 +1442,18 @@ NodeB: *Node)");
 }
 
 TEST_F(EmitterTest, ComplexFlowSeqEmbeddingAMapUsingAliases) {
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
 
-  out << Key << "Node" << Anchor("Node") << Value << BeginMap;
-  out << Key << "k" << Value << Flow << BeginSeq;
-  out << BeginMap << Key << "i" << Value << 0 << EndMap;
-  out << BeginMap << Key << "i" << Value << 1 << EndMap;
-  out << EndSeq << EndMap;
+  out << EMITTER_MANIP::Key << "Node" << Anchor("Node") << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 0 << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 1 << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq << EMITTER_MANIP::EndMap;
 
-  out << Key << "NodeA" << Alias("Node");
-  out << Key << "NodeB" << Alias("Node");
+  out << EMITTER_MANIP::Key << "NodeA" << Alias("Node");
+  out << EMITTER_MANIP::Key << "NodeB" << Alias("Node");
 
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(R"(Node: &Node
   k: [{i: 0}, {i: 1}]
@@ -1462,21 +1462,21 @@ NodeB: *Node)");
 }
 
 TEST_F(EmitterTest, ComplexFlowSeqEmbeddingAMapWithNewLineUsingAliases2) {
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
 
-  out << Key << "Seq" << Anchor("Seq") << Flow << BeginSeq;
-  out << BeginMap << Key << "i" << Value << 0 << EndMap;
-  out << YAML::Newline;
-  out << BeginMap << Key << "i" << Value << 1 << EndMap;
-  out << YAML::Newline;
-  out << EndSeq;
+  out << EMITTER_MANIP::Key << "Seq" << Anchor("Seq") << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 0 << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 1 << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::EndSeq;
 
-  out << Key << "NodeA" << Value << BeginMap;
-  out << Key << "k" << Value << Alias("Seq") << EndMap;
-  out << Key << "NodeB" << Value << BeginMap;
-  out << Key << "k" << Value << Alias("Seq") << EndMap;
+  out << EMITTER_MANIP::Key << "NodeA" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << Alias("Seq") << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::Key << "NodeB" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << Alias("Seq") << EMITTER_MANIP::EndMap;
 
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(R"(Seq: &Seq [{i: 0},
   {i: 1},
@@ -1488,19 +1488,19 @@ NodeB:
 }
 
 TEST_F(EmitterTest, ComplexFlowSeqEmbeddingAMapUsingAliases2) {
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
 
-  out << Key << "Seq" << Anchor("Seq") << Value << Flow << BeginSeq;
-  out << BeginMap << Key << "i" << Value << 0 << EndMap;
-  out << BeginMap << Key << "i" << Value << 1 << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::Key << "Seq" << Anchor("Seq") << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 0 << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 1 << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
-  out << Key << "NodeA" << Value << BeginMap;
-  out << Key << "k" << Value << Alias("Seq") << EndMap;
-  out << Key << "NodeB" << Value << BeginMap;
-  out << Key << "k" << Value << Alias("Seq") << EndMap;
+  out << EMITTER_MANIP::Key << "NodeA" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << Alias("Seq") << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::Key << "NodeB" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << Alias("Seq") << EMITTER_MANIP::EndMap;
 
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(R"(Seq: &Seq [{i: 0}, {i: 1}]
 NodeA:
@@ -1510,26 +1510,26 @@ NodeB:
 }
 
 TEST_F(EmitterTest, ComplexFlowSeqEmbeddingAMapWithNewLineUsingAliases3) {
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
 
-  out << Key << "Keys" << Value << Flow << BeginSeq;
-  out << Anchor("k0") << BeginMap << Key << "i" << Value << 0 << EndMap
-      << Newline;
-  out << Anchor("k1") << BeginMap << Key << "i" << Value << 1 << EndMap
-      << Newline;
-  out << EndSeq;
+  out << EMITTER_MANIP::Key << "Keys" << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out << Anchor("k0") << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 0 << EMITTER_MANIP::EndMap
+      << EMITTER_MANIP::Newline;
+  out << Anchor("k1") << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 1 << EMITTER_MANIP::EndMap
+      << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::EndSeq;
 
-  out << Key << "NodeA" << Value << BeginMap;
-  out << Key << "k" << Value << Flow << BeginSeq;
-  out << Alias("k0") << Newline << Alias("k1") << Newline;
-  out << EndSeq << EndMap;
+  out << EMITTER_MANIP::Key << "NodeA" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out << Alias("k0") << EMITTER_MANIP::Newline << Alias("k1") << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::EndSeq << EMITTER_MANIP::EndMap;
 
-  out << Key << "NodeB" << Value << BeginMap;
-  out << Key << "k" << Value << Flow << BeginSeq;
-  out << Alias("k0") << Newline << Alias("k1") << Newline;
-  out << EndSeq << EndMap;
+  out << EMITTER_MANIP::Key << "NodeB" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out << Alias("k0") << EMITTER_MANIP::Newline << Alias("k1") << EMITTER_MANIP::Newline;
+  out << EMITTER_MANIP::EndSeq << EMITTER_MANIP::EndMap;
 
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(R"(Keys: [&k0 {i: 0},
 &k1 {i: 1},
@@ -1545,24 +1545,24 @@ NodeB:
 }
 
 TEST_F(EmitterTest, ComplexFlowSeqEmbeddingAMapUsingAliases3a) {
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
 
-  out << Key << "Keys" << Value << BeginSeq;
-  out << Anchor("k0") << BeginMap << Key << "i" << Value << 0 << EndMap;
-  out << Anchor("k1") << BeginMap << Key << "i" << Value << 1 << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::Key << "Keys" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginSeq;
+  out << Anchor("k0") << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 0 << EMITTER_MANIP::EndMap;
+  out << Anchor("k1") << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 1 << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
-  out << Key << "NodeA" << Value << BeginMap;
-  out << Key << "k" << Value << Flow << BeginSeq;
+  out << EMITTER_MANIP::Key << "NodeA" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
   out << Alias("k0") << Alias("k1");
-  out << EndSeq << EndMap;
+  out << EMITTER_MANIP::EndSeq << EMITTER_MANIP::EndMap;
 
-  out << Key << "NodeB" << Value << BeginMap;
-  out << Key << "k" << Value << Flow << BeginSeq;
+  out << EMITTER_MANIP::Key << "NodeB" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
   out << Alias("k0") << Alias("k1");
-  out << EndSeq << EndMap;
+  out << EMITTER_MANIP::EndSeq << EMITTER_MANIP::EndMap;
 
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(R"(Keys:
   - &k0
@@ -1576,24 +1576,24 @@ NodeB:
 }
 
 TEST_F(EmitterTest, ComplexFlowSeqEmbeddingAMapUsingAliases3b) {
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
 
-  out << Key << "Keys" << Value << Flow << BeginSeq;
-  out << Anchor("k0") << BeginMap << Key << "i" << Value << 0 << EndMap;
-  out << Anchor("k1") << BeginMap << Key << "i" << Value << 1 << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::Key << "Keys" << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
+  out << Anchor("k0") << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 0 << EMITTER_MANIP::EndMap;
+  out << Anchor("k1") << EMITTER_MANIP::BeginMap << EMITTER_MANIP::Key << "i" << EMITTER_MANIP::Value << 1 << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
-  out << Key << "NodeA" << Value << BeginMap;
-  out << Key << "k" << Value << Flow << BeginSeq;
+  out << EMITTER_MANIP::Key << "NodeA" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
   out << Alias("k0") << Alias("k1");
-  out << EndSeq << EndMap;
+  out << EMITTER_MANIP::EndSeq << EMITTER_MANIP::EndMap;
 
-  out << Key << "NodeB" << Value << BeginMap;
-  out << Key << "k" << Value << Flow << BeginSeq;
+  out << EMITTER_MANIP::Key << "NodeB" << EMITTER_MANIP::Value << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "k" << EMITTER_MANIP::Value << EMITTER_MANIP::Flow << EMITTER_MANIP::BeginSeq;
   out << Alias("k0") << Alias("k1");
-  out << EndSeq << EndMap;
+  out << EMITTER_MANIP::EndSeq << EMITTER_MANIP::EndMap;
 
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmit(R"(Keys: [&k0 {i: 0}, &k1 {i: 1}]
 NodeA:
@@ -1629,46 +1629,46 @@ TEST_F(EmitterErrorTest, BadAnchorAndAnchor) {
 }
 
 TEST_F(EmitterErrorTest, BadEmptyAnchorOnGroup) {
-  out << BeginSeq << "bar" << Anchor("foo") << EndSeq;
+  out << EMITTER_MANIP::BeginSeq << "bar" << Anchor("foo") << EMITTER_MANIP::EndSeq;
   ExpectEmitError(ErrorMsg::INVALID_ANCHOR);
 }
 
 TEST_F(EmitterErrorTest, BadEmptyTagOnGroup) {
-  out << BeginSeq << "bar" << VerbatimTag("!foo") << EndSeq;
+  out << EMITTER_MANIP::BeginSeq << "bar" << VerbatimTag("!foo") << EMITTER_MANIP::EndSeq;
   ExpectEmitError(ErrorMsg::INVALID_TAG);
 }
 
 TEST_F(EmitterErrorTest, ExtraEndSeq) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "Hello";
   out << "World";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmitError(ErrorMsg::UNEXPECTED_END_SEQ);
 }
 
 TEST_F(EmitterErrorTest, ExtraEndMap) {
-  out << BeginMap;
-  out << Key << "Hello" << Value << "World";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::Key << "Hello" << EMITTER_MANIP::Value << "World";
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   ExpectEmitError(ErrorMsg::UNEXPECTED_END_MAP);
 }
 
 TEST_F(EmitterErrorTest, InvalidAnchor) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("new\nline") << "Test";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmitError(ErrorMsg::INVALID_ANCHOR);
 }
 
 TEST_F(EmitterErrorTest, InvalidAlias) {
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Alias("new\nline");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   ExpectEmitError(ErrorMsg::INVALID_ALIAS);
 }

--- a/test/integration/gen_emitter_test.cpp
+++ b/test/integration/gen_emitter_test.cpp
@@ -13,9 +13,9 @@ typedef HandlerTest GenEmitterTest;
 TEST_F(GenEmitterTest, testf2a8b6e6359fb2c30830) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "?", 0, "foo"));
@@ -25,10 +25,10 @@ TEST_F(GenEmitterTest, testf2a8b6e6359fb2c30830) {
 
 TEST_F(GenEmitterTest, testa2c9c04eab06a05bf1a3) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "?", 0, "foo"));
@@ -38,10 +38,10 @@ TEST_F(GenEmitterTest, testa2c9c04eab06a05bf1a3) {
 
 TEST_F(GenEmitterTest, testc5fae995bf84b2f62627) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << "foo";
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "?", 0, "foo"));
@@ -51,9 +51,9 @@ TEST_F(GenEmitterTest, testc5fae995bf84b2f62627) {
 
 TEST_F(GenEmitterTest, test208b4fb7399a936fce93) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -65,7 +65,7 @@ TEST_F(GenEmitterTest, test208b4fb7399a936fce93) {
 TEST_F(GenEmitterTest, test402085442ada9788bc4e) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << "foo";
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -76,7 +76,7 @@ TEST_F(GenEmitterTest, test402085442ada9788bc4e) {
 
 TEST_F(GenEmitterTest, test279346c761f7d9a10aec) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
   out << "foo";
 
@@ -88,7 +88,7 @@ TEST_F(GenEmitterTest, test279346c761f7d9a10aec) {
 
 TEST_F(GenEmitterTest, test386f6766d57a48ccb316) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << "foo";
   out << Comment("comment");
 
@@ -100,7 +100,7 @@ TEST_F(GenEmitterTest, test386f6766d57a48ccb316) {
 
 TEST_F(GenEmitterTest, test989baa41ede860374193) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << "foo";
   out << Comment("comment");
 
@@ -113,9 +113,9 @@ TEST_F(GenEmitterTest, test989baa41ede860374193) {
 TEST_F(GenEmitterTest, test718fa11b9bfa9dfc6632) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << "foo\n";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "!", 0, "foo\n"));
@@ -125,10 +125,10 @@ TEST_F(GenEmitterTest, test718fa11b9bfa9dfc6632) {
 
 TEST_F(GenEmitterTest, test7986c74c7cab2ff062e7) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
   out << "foo\n";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "!", 0, "foo\n"));
@@ -138,10 +138,10 @@ TEST_F(GenEmitterTest, test7986c74c7cab2ff062e7) {
 
 TEST_F(GenEmitterTest, test1a432be0760ebcf72dde) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << "foo\n";
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "!", 0, "foo\n"));
@@ -151,9 +151,9 @@ TEST_F(GenEmitterTest, test1a432be0760ebcf72dde) {
 
 TEST_F(GenEmitterTest, test9b4714c8c6dd71f963f1) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << "foo\n";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -165,7 +165,7 @@ TEST_F(GenEmitterTest, test9b4714c8c6dd71f963f1) {
 TEST_F(GenEmitterTest, test59d039102f43b05233b2) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << "foo\n";
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -176,7 +176,7 @@ TEST_F(GenEmitterTest, test59d039102f43b05233b2) {
 
 TEST_F(GenEmitterTest, test15371be5fc126b3601ee) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
   out << "foo\n";
 
@@ -188,7 +188,7 @@ TEST_F(GenEmitterTest, test15371be5fc126b3601ee) {
 
 TEST_F(GenEmitterTest, test5a2a5702a41d71567a10) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << "foo\n";
   out << Comment("comment");
 
@@ -200,7 +200,7 @@ TEST_F(GenEmitterTest, test5a2a5702a41d71567a10) {
 
 TEST_F(GenEmitterTest, test7975acd31f55f66c21a9) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << "foo\n";
   out << Comment("comment");
 
@@ -213,10 +213,10 @@ TEST_F(GenEmitterTest, test7975acd31f55f66c21a9) {
 TEST_F(GenEmitterTest, test9ab358e41e3af0e1852c) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "tag", 0, "foo"));
@@ -226,11 +226,11 @@ TEST_F(GenEmitterTest, test9ab358e41e3af0e1852c) {
 
 TEST_F(GenEmitterTest, test6571b17e1089f3f34d41) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "tag", 0, "foo"));
@@ -240,11 +240,11 @@ TEST_F(GenEmitterTest, test6571b17e1089f3f34d41) {
 
 TEST_F(GenEmitterTest, test7c8476d0a02eeab3326f) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << VerbatimTag("tag");
   out << "foo";
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "tag", 0, "foo"));
@@ -254,10 +254,10 @@ TEST_F(GenEmitterTest, test7c8476d0a02eeab3326f) {
 
 TEST_F(GenEmitterTest, test0883fa5d170d96324325) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -269,7 +269,7 @@ TEST_F(GenEmitterTest, test0883fa5d170d96324325) {
 TEST_F(GenEmitterTest, test7f44d870f57878e83749) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << VerbatimTag("tag");
   out << "foo";
 
@@ -281,7 +281,7 @@ TEST_F(GenEmitterTest, test7f44d870f57878e83749) {
 
 TEST_F(GenEmitterTest, testc7b8d9af2a71da438220) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << "foo";
@@ -294,7 +294,7 @@ TEST_F(GenEmitterTest, testc7b8d9af2a71da438220) {
 
 TEST_F(GenEmitterTest, testa27a4f0174aee7622160) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << VerbatimTag("tag");
   out << "foo";
   out << Comment("comment");
@@ -307,7 +307,7 @@ TEST_F(GenEmitterTest, testa27a4f0174aee7622160) {
 
 TEST_F(GenEmitterTest, testf06e77dc66bc51682e57) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << VerbatimTag("tag");
   out << "foo";
   out << Comment("comment");
@@ -321,10 +321,10 @@ TEST_F(GenEmitterTest, testf06e77dc66bc51682e57) {
 TEST_F(GenEmitterTest, test28c636f42558c217d90b) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Anchor("anchor");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnAnchor(_, "anchor"));
@@ -335,11 +335,11 @@ TEST_F(GenEmitterTest, test28c636f42558c217d90b) {
 
 TEST_F(GenEmitterTest, testa8e930c2f4f761519825) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
   out << Anchor("anchor");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnAnchor(_, "anchor"));
@@ -350,11 +350,11 @@ TEST_F(GenEmitterTest, testa8e930c2f4f761519825) {
 
 TEST_F(GenEmitterTest, testc73b721f492b45035034) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Anchor("anchor");
   out << "foo";
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnAnchor(_, "anchor"));
@@ -365,10 +365,10 @@ TEST_F(GenEmitterTest, testc73b721f492b45035034) {
 
 TEST_F(GenEmitterTest, testb401b54145c71ea07848) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Anchor("anchor");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -381,7 +381,7 @@ TEST_F(GenEmitterTest, testb401b54145c71ea07848) {
 TEST_F(GenEmitterTest, test380d9af0ae2e27279526) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Anchor("anchor");
   out << "foo";
 
@@ -394,7 +394,7 @@ TEST_F(GenEmitterTest, test380d9af0ae2e27279526) {
 
 TEST_F(GenEmitterTest, test6969308096c6106d1f55) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
   out << Anchor("anchor");
   out << "foo";
@@ -408,7 +408,7 @@ TEST_F(GenEmitterTest, test6969308096c6106d1f55) {
 
 TEST_F(GenEmitterTest, testa8afc0036fffa3b2d185) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Anchor("anchor");
   out << "foo";
   out << Comment("comment");
@@ -422,7 +422,7 @@ TEST_F(GenEmitterTest, testa8afc0036fffa3b2d185) {
 
 TEST_F(GenEmitterTest, test7b41f0a32b90bf5f138d) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Anchor("anchor");
   out << "foo";
   out << Comment("comment");
@@ -438,7 +438,7 @@ TEST_F(GenEmitterTest, test99b1e0027d74c641f4fc) {
   Emitter out;
   out << Comment("comment");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "?", 0, "foo"));
@@ -450,7 +450,7 @@ TEST_F(GenEmitterTest, test8e45fdb3ff3c00d56f27) {
   Emitter out;
   out << Comment("comment");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "?", 0, "foo"));
@@ -462,7 +462,7 @@ TEST_F(GenEmitterTest, testf898ade0c92d48d498cf) {
   Emitter out;
   out << "foo";
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "?", 0, "foo"));
@@ -473,7 +473,7 @@ TEST_F(GenEmitterTest, testf898ade0c92d48d498cf) {
 TEST_F(GenEmitterTest, test3eb11fe6897b9638b90c) {
   Emitter out;
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -530,7 +530,7 @@ TEST_F(GenEmitterTest, testdccc5288dfb2f680dd82) {
   Emitter out;
   out << Comment("comment");
   out << "foo\n";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "!", 0, "foo\n"));
@@ -542,7 +542,7 @@ TEST_F(GenEmitterTest, test0a928620b149d5644a3b) {
   Emitter out;
   out << Comment("comment");
   out << "foo\n";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "!", 0, "foo\n"));
@@ -554,7 +554,7 @@ TEST_F(GenEmitterTest, test72bf9f8ba5207fb041c3) {
   Emitter out;
   out << "foo\n";
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "!", 0, "foo\n"));
@@ -565,7 +565,7 @@ TEST_F(GenEmitterTest, test72bf9f8ba5207fb041c3) {
 TEST_F(GenEmitterTest, test39ba33ec287e431e70d0) {
   Emitter out;
   out << "foo\n";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -623,7 +623,7 @@ TEST_F(GenEmitterTest, testc15cdbdbf9661c853def) {
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "tag", 0, "foo"));
@@ -636,7 +636,7 @@ TEST_F(GenEmitterTest, testa349878c464f03fa6d4e) {
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "tag", 0, "foo"));
@@ -649,7 +649,7 @@ TEST_F(GenEmitterTest, testc063a846f87b1e20e4e9) {
   out << VerbatimTag("tag");
   out << "foo";
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "tag", 0, "foo"));
@@ -661,7 +661,7 @@ TEST_F(GenEmitterTest, testdfb3a9ec6da3b792f392) {
   Emitter out;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -723,7 +723,7 @@ TEST_F(GenEmitterTest, testd10a9c9671992acd494d) {
   out << Comment("comment");
   out << Anchor("anchor");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnAnchor(_, "anchor"));
@@ -737,7 +737,7 @@ TEST_F(GenEmitterTest, testd5ee8a3bdb42c8639ad4) {
   out << Comment("comment");
   out << Anchor("anchor");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnAnchor(_, "anchor"));
@@ -751,7 +751,7 @@ TEST_F(GenEmitterTest, test24914f6c2b7f7d5843c4) {
   out << Anchor("anchor");
   out << "foo";
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnAnchor(_, "anchor"));
@@ -764,7 +764,7 @@ TEST_F(GenEmitterTest, test9af19fe8c77aa18cd462) {
   Emitter out;
   out << Anchor("anchor");
   out << "foo";
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -829,10 +829,10 @@ TEST_F(GenEmitterTest, testa594204f0724101d4931) {
 TEST_F(GenEmitterTest, test87638f2fba55c5235720) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -843,11 +843,11 @@ TEST_F(GenEmitterTest, test87638f2fba55c5235720) {
 
 TEST_F(GenEmitterTest, test786f027ec8e380bdeb45) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -858,11 +858,11 @@ TEST_F(GenEmitterTest, test786f027ec8e380bdeb45) {
 
 TEST_F(GenEmitterTest, test9d9ca2fc29536ef5d392) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -873,11 +873,11 @@ TEST_F(GenEmitterTest, test9d9ca2fc29536ef5d392) {
 
 TEST_F(GenEmitterTest, testde9c33927d8f706e5191) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -888,10 +888,10 @@ TEST_F(GenEmitterTest, testde9c33927d8f706e5191) {
 
 TEST_F(GenEmitterTest, testa03392eb1d9af2180eb2) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -904,9 +904,9 @@ TEST_F(GenEmitterTest, testa03392eb1d9af2180eb2) {
 TEST_F(GenEmitterTest, test8826ba8a4954e2775441) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -917,10 +917,10 @@ TEST_F(GenEmitterTest, test8826ba8a4954e2775441) {
 
 TEST_F(GenEmitterTest, testf116d1ab8a1646bb4295) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -931,10 +931,10 @@ TEST_F(GenEmitterTest, testf116d1ab8a1646bb4295) {
 
 TEST_F(GenEmitterTest, test1d4afe394248c5d6f190) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -945,9 +945,9 @@ TEST_F(GenEmitterTest, test1d4afe394248c5d6f190) {
 
 TEST_F(GenEmitterTest, test4cc7b190d6dd08368f08) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -959,9 +959,9 @@ TEST_F(GenEmitterTest, test4cc7b190d6dd08368f08) {
 
 TEST_F(GenEmitterTest, testc623063380afa67c57c4) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -974,11 +974,11 @@ TEST_F(GenEmitterTest, testc623063380afa67c57c4) {
 TEST_F(GenEmitterTest, teste24ef3f378c4c33107b2) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -990,12 +990,12 @@ TEST_F(GenEmitterTest, teste24ef3f378c4c33107b2) {
 
 TEST_F(GenEmitterTest, test2aa8f68b872fd07fde8c) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1007,12 +1007,12 @@ TEST_F(GenEmitterTest, test2aa8f68b872fd07fde8c) {
 
 TEST_F(GenEmitterTest, test940bf9330572d48b476f) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1024,12 +1024,12 @@ TEST_F(GenEmitterTest, test940bf9330572d48b476f) {
 
 TEST_F(GenEmitterTest, testd710bce67052a991abfa) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1041,12 +1041,12 @@ TEST_F(GenEmitterTest, testd710bce67052a991abfa) {
 
 TEST_F(GenEmitterTest, testd2ac557dae648cd1ba66) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1058,11 +1058,11 @@ TEST_F(GenEmitterTest, testd2ac557dae648cd1ba66) {
 
 TEST_F(GenEmitterTest, testb394f0e282404d1235d3) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -1076,10 +1076,10 @@ TEST_F(GenEmitterTest, testb394f0e282404d1235d3) {
 TEST_F(GenEmitterTest, testaf620080909b118a715d) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1091,11 +1091,11 @@ TEST_F(GenEmitterTest, testaf620080909b118a715d) {
 
 TEST_F(GenEmitterTest, testfc23fc6f424006e5907f) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1107,11 +1107,11 @@ TEST_F(GenEmitterTest, testfc23fc6f424006e5907f) {
 
 TEST_F(GenEmitterTest, testbc5517fe466dd4988ce2) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1123,11 +1123,11 @@ TEST_F(GenEmitterTest, testbc5517fe466dd4988ce2) {
 
 TEST_F(GenEmitterTest, testc0db52f1be33ddf93852) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1139,10 +1139,10 @@ TEST_F(GenEmitterTest, testc0db52f1be33ddf93852) {
 
 TEST_F(GenEmitterTest, test279a9eef5b2d2cf98ecf) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -1155,10 +1155,10 @@ TEST_F(GenEmitterTest, test279a9eef5b2d2cf98ecf) {
 
 TEST_F(GenEmitterTest, test7f55b2f00c1090e43af5) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -1172,12 +1172,12 @@ TEST_F(GenEmitterTest, test7f55b2f00c1090e43af5) {
 TEST_F(GenEmitterTest, test1be996b4b790d9bd565d) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1189,13 +1189,13 @@ TEST_F(GenEmitterTest, test1be996b4b790d9bd565d) {
 
 TEST_F(GenEmitterTest, testa5dea69e968ea27412cc) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1207,13 +1207,13 @@ TEST_F(GenEmitterTest, testa5dea69e968ea27412cc) {
 
 TEST_F(GenEmitterTest, test77fe0d4370db4aa8af1a) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1225,13 +1225,13 @@ TEST_F(GenEmitterTest, test77fe0d4370db4aa8af1a) {
 
 TEST_F(GenEmitterTest, test6d0319a28dd1a931f211) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1243,13 +1243,13 @@ TEST_F(GenEmitterTest, test6d0319a28dd1a931f211) {
 
 TEST_F(GenEmitterTest, test0031c4cd5331366162a6) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1261,12 +1261,12 @@ TEST_F(GenEmitterTest, test0031c4cd5331366162a6) {
 
 TEST_F(GenEmitterTest, testc0c74d483811e3322ed2) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -1280,11 +1280,11 @@ TEST_F(GenEmitterTest, testc0c74d483811e3322ed2) {
 TEST_F(GenEmitterTest, test0d0938c9dca1e78401d6) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1296,12 +1296,12 @@ TEST_F(GenEmitterTest, test0d0938c9dca1e78401d6) {
 
 TEST_F(GenEmitterTest, test0c83b8f0404e62673099) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1313,12 +1313,12 @@ TEST_F(GenEmitterTest, test0c83b8f0404e62673099) {
 
 TEST_F(GenEmitterTest, test733fd2f94ae082ea6076) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1330,12 +1330,12 @@ TEST_F(GenEmitterTest, test733fd2f94ae082ea6076) {
 
 TEST_F(GenEmitterTest, test04b57f98a492b0f2c1ad) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1347,11 +1347,11 @@ TEST_F(GenEmitterTest, test04b57f98a492b0f2c1ad) {
 
 TEST_F(GenEmitterTest, test80d83a80f235341f1bff) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -1364,11 +1364,11 @@ TEST_F(GenEmitterTest, test80d83a80f235341f1bff) {
 
 TEST_F(GenEmitterTest, testecbe137bf7436ccd7976) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -1382,12 +1382,12 @@ TEST_F(GenEmitterTest, testecbe137bf7436ccd7976) {
 TEST_F(GenEmitterTest, testf14f2e8202cacdf9252d) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1400,13 +1400,13 @@ TEST_F(GenEmitterTest, testf14f2e8202cacdf9252d) {
 
 TEST_F(GenEmitterTest, test9c029f7cf565580a56fd) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1419,13 +1419,13 @@ TEST_F(GenEmitterTest, test9c029f7cf565580a56fd) {
 
 TEST_F(GenEmitterTest, test129cd28cda34c7b97a89) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1438,13 +1438,13 @@ TEST_F(GenEmitterTest, test129cd28cda34c7b97a89) {
 
 TEST_F(GenEmitterTest, test1c55ee081412be96e00f) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1457,13 +1457,13 @@ TEST_F(GenEmitterTest, test1c55ee081412be96e00f) {
 
 TEST_F(GenEmitterTest, testf9e9d15d9e09a8e98681) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1476,12 +1476,12 @@ TEST_F(GenEmitterTest, testf9e9d15d9e09a8e98681) {
 
 TEST_F(GenEmitterTest, test03dd7104722840fe7fee) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -1496,11 +1496,11 @@ TEST_F(GenEmitterTest, test03dd7104722840fe7fee) {
 TEST_F(GenEmitterTest, teste6c856a08270255404b6) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1513,12 +1513,12 @@ TEST_F(GenEmitterTest, teste6c856a08270255404b6) {
 
 TEST_F(GenEmitterTest, testf285ed8797058c0e4e2f) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1531,12 +1531,12 @@ TEST_F(GenEmitterTest, testf285ed8797058c0e4e2f) {
 
 TEST_F(GenEmitterTest, test906076647b894281787e) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1549,12 +1549,12 @@ TEST_F(GenEmitterTest, test906076647b894281787e) {
 
 TEST_F(GenEmitterTest, test8a836336041c56130c5c) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1567,11 +1567,11 @@ TEST_F(GenEmitterTest, test8a836336041c56130c5c) {
 
 TEST_F(GenEmitterTest, testc7f61ada097fb34f24ce) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -1585,11 +1585,11 @@ TEST_F(GenEmitterTest, testc7f61ada097fb34f24ce) {
 
 TEST_F(GenEmitterTest, testec075d926fd1f95a1bae) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -1604,13 +1604,13 @@ TEST_F(GenEmitterTest, testec075d926fd1f95a1bae) {
 TEST_F(GenEmitterTest, testa79ce9edc0c3593faa31) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1623,14 +1623,14 @@ TEST_F(GenEmitterTest, testa79ce9edc0c3593faa31) {
 
 TEST_F(GenEmitterTest, test525c133ebf8f46a1962f) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1643,14 +1643,14 @@ TEST_F(GenEmitterTest, test525c133ebf8f46a1962f) {
 
 TEST_F(GenEmitterTest, testb06604d03a8c9cfbe7c2) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1663,14 +1663,14 @@ TEST_F(GenEmitterTest, testb06604d03a8c9cfbe7c2) {
 
 TEST_F(GenEmitterTest, teste268ba5f2d54120eb665) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1683,14 +1683,14 @@ TEST_F(GenEmitterTest, teste268ba5f2d54120eb665) {
 
 TEST_F(GenEmitterTest, test7a646350a81bba70e44a) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1703,13 +1703,13 @@ TEST_F(GenEmitterTest, test7a646350a81bba70e44a) {
 
 TEST_F(GenEmitterTest, test025df570e0d8a1f818da) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -1724,12 +1724,12 @@ TEST_F(GenEmitterTest, test025df570e0d8a1f818da) {
 TEST_F(GenEmitterTest, test897087b9aba1d5773870) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1742,13 +1742,13 @@ TEST_F(GenEmitterTest, test897087b9aba1d5773870) {
 
 TEST_F(GenEmitterTest, testa45ee0501da4a4e5da54) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1761,13 +1761,13 @@ TEST_F(GenEmitterTest, testa45ee0501da4a4e5da54) {
 
 TEST_F(GenEmitterTest, teste751c06ea558ccca1821) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1780,13 +1780,13 @@ TEST_F(GenEmitterTest, teste751c06ea558ccca1821) {
 
 TEST_F(GenEmitterTest, test8526d26e85cc930eecec) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1799,12 +1799,12 @@ TEST_F(GenEmitterTest, test8526d26e85cc930eecec) {
 
 TEST_F(GenEmitterTest, teste9a5a4a0f0e44311d01a) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -1818,12 +1818,12 @@ TEST_F(GenEmitterTest, teste9a5a4a0f0e44311d01a) {
 
 TEST_F(GenEmitterTest, testac8a091ab93b65aee893) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -1838,12 +1838,12 @@ TEST_F(GenEmitterTest, testac8a091ab93b65aee893) {
 TEST_F(GenEmitterTest, testee014788f524623b5075) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1856,13 +1856,13 @@ TEST_F(GenEmitterTest, testee014788f524623b5075) {
 
 TEST_F(GenEmitterTest, test57a067545c01c42a7b4e) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1875,13 +1875,13 @@ TEST_F(GenEmitterTest, test57a067545c01c42a7b4e) {
 
 TEST_F(GenEmitterTest, test948ac02da8825214c869) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1894,13 +1894,13 @@ TEST_F(GenEmitterTest, test948ac02da8825214c869) {
 
 TEST_F(GenEmitterTest, testa3d6c5e8a1658c1dd726) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1913,13 +1913,13 @@ TEST_F(GenEmitterTest, testa3d6c5e8a1658c1dd726) {
 
 TEST_F(GenEmitterTest, test548d71006d7cafde91da) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1932,13 +1932,13 @@ TEST_F(GenEmitterTest, test548d71006d7cafde91da) {
 
 TEST_F(GenEmitterTest, test35e08ea7459dbee9eab8) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1951,12 +1951,12 @@ TEST_F(GenEmitterTest, test35e08ea7459dbee9eab8) {
 
 TEST_F(GenEmitterTest, test87e79665a4339434d781) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -1971,11 +1971,11 @@ TEST_F(GenEmitterTest, test87e79665a4339434d781) {
 TEST_F(GenEmitterTest, test4928d09bc979129c05ca) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -1988,12 +1988,12 @@ TEST_F(GenEmitterTest, test4928d09bc979129c05ca) {
 
 TEST_F(GenEmitterTest, test1d2f73011af6b4486504) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2006,12 +2006,12 @@ TEST_F(GenEmitterTest, test1d2f73011af6b4486504) {
 
 TEST_F(GenEmitterTest, test2460718f7277d5f42306) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2024,12 +2024,12 @@ TEST_F(GenEmitterTest, test2460718f7277d5f42306) {
 
 TEST_F(GenEmitterTest, test52309e87b3f0185f982b) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2042,12 +2042,12 @@ TEST_F(GenEmitterTest, test52309e87b3f0185f982b) {
 
 TEST_F(GenEmitterTest, testa51d8f1cedfead1de5ab) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2060,11 +2060,11 @@ TEST_F(GenEmitterTest, testa51d8f1cedfead1de5ab) {
 
 TEST_F(GenEmitterTest, test537bf14b4d578f212f4d) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2078,11 +2078,11 @@ TEST_F(GenEmitterTest, test537bf14b4d578f212f4d) {
 
 TEST_F(GenEmitterTest, teste19e3fd4d5cd52bf6754) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2097,16 +2097,16 @@ TEST_F(GenEmitterTest, teste19e3fd4d5cd52bf6754) {
 TEST_F(GenEmitterTest, testf27e53142f2ca0e96a99) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2121,17 +2121,17 @@ TEST_F(GenEmitterTest, testf27e53142f2ca0e96a99) {
 
 TEST_F(GenEmitterTest, test8ce13fdbb0e53e131cbe) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2146,8 +2146,8 @@ TEST_F(GenEmitterTest, test8ce13fdbb0e53e131cbe) {
 
 TEST_F(GenEmitterTest, test9fa693277f014353aa34) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << Anchor("anchor");
@@ -2155,8 +2155,8 @@ TEST_F(GenEmitterTest, test9fa693277f014353aa34) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2171,8 +2171,8 @@ TEST_F(GenEmitterTest, test9fa693277f014353aa34) {
 
 TEST_F(GenEmitterTest, testc3e4849fb38bc3556f45) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -2180,8 +2180,8 @@ TEST_F(GenEmitterTest, testc3e4849fb38bc3556f45) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2196,8 +2196,8 @@ TEST_F(GenEmitterTest, testc3e4849fb38bc3556f45) {
 
 TEST_F(GenEmitterTest, test34049495795f40da2d52) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -2205,8 +2205,8 @@ TEST_F(GenEmitterTest, test34049495795f40da2d52) {
   out << Anchor("other");
   out << "bar";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2221,17 +2221,17 @@ TEST_F(GenEmitterTest, test34049495795f40da2d52) {
 
 TEST_F(GenEmitterTest, test14353701fc865919ab50) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2246,16 +2246,16 @@ TEST_F(GenEmitterTest, test14353701fc865919ab50) {
 
 TEST_F(GenEmitterTest, test74547fc0ba8d387c5423) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2272,15 +2272,15 @@ TEST_F(GenEmitterTest, test74547fc0ba8d387c5423) {
 TEST_F(GenEmitterTest, test52d2b69b185f6ccfff4c) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2295,16 +2295,16 @@ TEST_F(GenEmitterTest, test52d2b69b185f6ccfff4c) {
 
 TEST_F(GenEmitterTest, test44d442585e5bc9a7644a) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2319,8 +2319,8 @@ TEST_F(GenEmitterTest, test44d442585e5bc9a7644a) {
 
 TEST_F(GenEmitterTest, test3dc263684801dec471c9) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << Anchor("anchor");
@@ -2328,7 +2328,7 @@ TEST_F(GenEmitterTest, test3dc263684801dec471c9) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2343,8 +2343,8 @@ TEST_F(GenEmitterTest, test3dc263684801dec471c9) {
 
 TEST_F(GenEmitterTest, testa04cde3245ad9b929b9a) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -2352,7 +2352,7 @@ TEST_F(GenEmitterTest, testa04cde3245ad9b929b9a) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2367,8 +2367,8 @@ TEST_F(GenEmitterTest, testa04cde3245ad9b929b9a) {
 
 TEST_F(GenEmitterTest, testd911e740ca36e0509dfa) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -2376,7 +2376,7 @@ TEST_F(GenEmitterTest, testd911e740ca36e0509dfa) {
   out << Anchor("other");
   out << "bar";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2391,15 +2391,15 @@ TEST_F(GenEmitterTest, testd911e740ca36e0509dfa) {
 
 TEST_F(GenEmitterTest, testde44215fe9b2e87846ba) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2415,15 +2415,15 @@ TEST_F(GenEmitterTest, testde44215fe9b2e87846ba) {
 
 TEST_F(GenEmitterTest, test6390021323a4889f19d2) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2440,9 +2440,9 @@ TEST_F(GenEmitterTest, test6390021323a4889f19d2) {
 TEST_F(GenEmitterTest, test1db2fcb7347f6cb37dd4) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2454,9 +2454,9 @@ TEST_F(GenEmitterTest, test1db2fcb7347f6cb37dd4) {
 TEST_F(GenEmitterTest, test06b32e9d75498ee291d2) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2467,10 +2467,10 @@ TEST_F(GenEmitterTest, test06b32e9d75498ee291d2) {
 
 TEST_F(GenEmitterTest, test86654989004963952b15) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2481,10 +2481,10 @@ TEST_F(GenEmitterTest, test86654989004963952b15) {
 
 TEST_F(GenEmitterTest, test53d875fc5058faa44a4e) {
   Emitter out;
-  out << BeginSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2495,9 +2495,9 @@ TEST_F(GenEmitterTest, test53d875fc5058faa44a4e) {
 
 TEST_F(GenEmitterTest, test3f4b49a82b6e07eb11fd) {
   Emitter out;
-  out << BeginSeq;
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2510,8 +2510,8 @@ TEST_F(GenEmitterTest, test3f4b49a82b6e07eb11fd) {
 TEST_F(GenEmitterTest, testae4e2fa09d6a34077b6e) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2523,8 +2523,8 @@ TEST_F(GenEmitterTest, testae4e2fa09d6a34077b6e) {
 TEST_F(GenEmitterTest, testb181b63559d96d5f848c) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2535,9 +2535,9 @@ TEST_F(GenEmitterTest, testb181b63559d96d5f848c) {
 
 TEST_F(GenEmitterTest, test817661fec7d3730f4fa6) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2548,8 +2548,8 @@ TEST_F(GenEmitterTest, test817661fec7d3730f4fa6) {
 
 TEST_F(GenEmitterTest, test34bb2700e9688718fa5a) {
   Emitter out;
-  out << BeginSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2561,8 +2561,8 @@ TEST_F(GenEmitterTest, test34bb2700e9688718fa5a) {
 
 TEST_F(GenEmitterTest, test84e3c1999b6888d2e897) {
   Emitter out;
-  out << BeginSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2575,10 +2575,10 @@ TEST_F(GenEmitterTest, test84e3c1999b6888d2e897) {
 TEST_F(GenEmitterTest, testa9d113656780031a99f5) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2591,10 +2591,10 @@ TEST_F(GenEmitterTest, testa9d113656780031a99f5) {
 TEST_F(GenEmitterTest, test1cd1ead50aaa7b827068) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2606,11 +2606,11 @@ TEST_F(GenEmitterTest, test1cd1ead50aaa7b827068) {
 
 TEST_F(GenEmitterTest, test1389f95066b07eac89ef) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2622,11 +2622,11 @@ TEST_F(GenEmitterTest, test1389f95066b07eac89ef) {
 
 TEST_F(GenEmitterTest, test709f3a5c294f47f62c1e) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2638,11 +2638,11 @@ TEST_F(GenEmitterTest, test709f3a5c294f47f62c1e) {
 
 TEST_F(GenEmitterTest, test8a238d7fdee02a368203) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2654,10 +2654,10 @@ TEST_F(GenEmitterTest, test8a238d7fdee02a368203) {
 
 TEST_F(GenEmitterTest, test0d13534e2949ea35ca96) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2671,9 +2671,9 @@ TEST_F(GenEmitterTest, test0d13534e2949ea35ca96) {
 TEST_F(GenEmitterTest, test10fe6827ed46e0e063a7) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2686,9 +2686,9 @@ TEST_F(GenEmitterTest, test10fe6827ed46e0e063a7) {
 TEST_F(GenEmitterTest, testc7eb6d9da57005534c1c) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2700,10 +2700,10 @@ TEST_F(GenEmitterTest, testc7eb6d9da57005534c1c) {
 
 TEST_F(GenEmitterTest, test3f424efd76e1d32727eb) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2715,10 +2715,10 @@ TEST_F(GenEmitterTest, test3f424efd76e1d32727eb) {
 
 TEST_F(GenEmitterTest, test2bdc361bc6b056f02465) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2730,9 +2730,9 @@ TEST_F(GenEmitterTest, test2bdc361bc6b056f02465) {
 
 TEST_F(GenEmitterTest, test0cc1936afe5637ba1376) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2745,9 +2745,9 @@ TEST_F(GenEmitterTest, test0cc1936afe5637ba1376) {
 
 TEST_F(GenEmitterTest, test7d3e2f793963d3480545) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2761,11 +2761,11 @@ TEST_F(GenEmitterTest, test7d3e2f793963d3480545) {
 TEST_F(GenEmitterTest, testf3f50e76d7ef6e2b2bff) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2778,11 +2778,11 @@ TEST_F(GenEmitterTest, testf3f50e76d7ef6e2b2bff) {
 TEST_F(GenEmitterTest, testcbf1cff67fec9148df1c) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2794,12 +2794,12 @@ TEST_F(GenEmitterTest, testcbf1cff67fec9148df1c) {
 
 TEST_F(GenEmitterTest, test168bd4b8dc78b4d524ee) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2811,12 +2811,12 @@ TEST_F(GenEmitterTest, test168bd4b8dc78b4d524ee) {
 
 TEST_F(GenEmitterTest, testb616ef26030304bca6ef) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2828,12 +2828,12 @@ TEST_F(GenEmitterTest, testb616ef26030304bca6ef) {
 
 TEST_F(GenEmitterTest, test9fda976f36ddb23b38ee) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2845,11 +2845,11 @@ TEST_F(GenEmitterTest, test9fda976f36ddb23b38ee) {
 
 TEST_F(GenEmitterTest, test48e8c45c081edc86deb2) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2863,10 +2863,10 @@ TEST_F(GenEmitterTest, test48e8c45c081edc86deb2) {
 TEST_F(GenEmitterTest, test30f5136e817ddd8158de) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2879,10 +2879,10 @@ TEST_F(GenEmitterTest, test30f5136e817ddd8158de) {
 TEST_F(GenEmitterTest, testeb51d66281f593566172) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2894,11 +2894,11 @@ TEST_F(GenEmitterTest, testeb51d66281f593566172) {
 
 TEST_F(GenEmitterTest, testef6ffa5fa4658785ef00) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2910,11 +2910,11 @@ TEST_F(GenEmitterTest, testef6ffa5fa4658785ef00) {
 
 TEST_F(GenEmitterTest, test6db34efc6b59e8a7ba18) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2926,10 +2926,10 @@ TEST_F(GenEmitterTest, test6db34efc6b59e8a7ba18) {
 
 TEST_F(GenEmitterTest, test537b9ecc9d9a5b546a9c) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2942,10 +2942,10 @@ TEST_F(GenEmitterTest, test537b9ecc9d9a5b546a9c) {
 
 TEST_F(GenEmitterTest, testfadd6ee259c13382f5ce) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -2959,11 +2959,11 @@ TEST_F(GenEmitterTest, testfadd6ee259c13382f5ce) {
 TEST_F(GenEmitterTest, test974ae82483391d01787b) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2977,11 +2977,11 @@ TEST_F(GenEmitterTest, test974ae82483391d01787b) {
 TEST_F(GenEmitterTest, test7fc68b49cfe198b30eeb) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -2994,12 +2994,12 @@ TEST_F(GenEmitterTest, test7fc68b49cfe198b30eeb) {
 
 TEST_F(GenEmitterTest, test41644c59ff95f8ec5ec2) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3012,12 +3012,12 @@ TEST_F(GenEmitterTest, test41644c59ff95f8ec5ec2) {
 
 TEST_F(GenEmitterTest, testa3a24413b537aece4834) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3030,12 +3030,12 @@ TEST_F(GenEmitterTest, testa3a24413b537aece4834) {
 
 TEST_F(GenEmitterTest, testc4516128af938868b120) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3048,11 +3048,11 @@ TEST_F(GenEmitterTest, testc4516128af938868b120) {
 
 TEST_F(GenEmitterTest, testef3c20a56c8a3993cc2d) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -3067,10 +3067,10 @@ TEST_F(GenEmitterTest, testef3c20a56c8a3993cc2d) {
 TEST_F(GenEmitterTest, test83aceee2ee6446347fba) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3084,10 +3084,10 @@ TEST_F(GenEmitterTest, test83aceee2ee6446347fba) {
 TEST_F(GenEmitterTest, test5a054d76c67b6de340e2) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3100,11 +3100,11 @@ TEST_F(GenEmitterTest, test5a054d76c67b6de340e2) {
 
 TEST_F(GenEmitterTest, testc6706e6b6fc94d1e4752) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3117,11 +3117,11 @@ TEST_F(GenEmitterTest, testc6706e6b6fc94d1e4752) {
 
 TEST_F(GenEmitterTest, test72f3ded341d6b5d21803) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3134,10 +3134,10 @@ TEST_F(GenEmitterTest, test72f3ded341d6b5d21803) {
 
 TEST_F(GenEmitterTest, test7dc830828b604b5d1839) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -3151,10 +3151,10 @@ TEST_F(GenEmitterTest, test7dc830828b604b5d1839) {
 
 TEST_F(GenEmitterTest, test3a5baef0d6a62e5880ef) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -3169,12 +3169,12 @@ TEST_F(GenEmitterTest, test3a5baef0d6a62e5880ef) {
 TEST_F(GenEmitterTest, testfe7bf25b7a5525cab12a) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3188,12 +3188,12 @@ TEST_F(GenEmitterTest, testfe7bf25b7a5525cab12a) {
 TEST_F(GenEmitterTest, test817bf3d583230e503f8e) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3206,13 +3206,13 @@ TEST_F(GenEmitterTest, test817bf3d583230e503f8e) {
 
 TEST_F(GenEmitterTest, testab122e386b3e30ea59e2) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3225,13 +3225,13 @@ TEST_F(GenEmitterTest, testab122e386b3e30ea59e2) {
 
 TEST_F(GenEmitterTest, test466c3e0dbec8e9660837) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3244,13 +3244,13 @@ TEST_F(GenEmitterTest, test466c3e0dbec8e9660837) {
 
 TEST_F(GenEmitterTest, test9fc49f92e554cd85e349) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3263,12 +3263,12 @@ TEST_F(GenEmitterTest, test9fc49f92e554cd85e349) {
 
 TEST_F(GenEmitterTest, testf9d2f39bdbd217d70868) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -3283,11 +3283,11 @@ TEST_F(GenEmitterTest, testf9d2f39bdbd217d70868) {
 TEST_F(GenEmitterTest, test1ce3d77707f18ec48a19) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3301,11 +3301,11 @@ TEST_F(GenEmitterTest, test1ce3d77707f18ec48a19) {
 TEST_F(GenEmitterTest, test71df6ecc32e49ea961d4) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3318,12 +3318,12 @@ TEST_F(GenEmitterTest, test71df6ecc32e49ea961d4) {
 
 TEST_F(GenEmitterTest, test8f37b0a6cc287f8c922f) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3336,12 +3336,12 @@ TEST_F(GenEmitterTest, test8f37b0a6cc287f8c922f) {
 
 TEST_F(GenEmitterTest, testf992e2a1f7d737647506) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3354,11 +3354,11 @@ TEST_F(GenEmitterTest, testf992e2a1f7d737647506) {
 
 TEST_F(GenEmitterTest, testd79381f97cdd0af81ae4) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -3372,11 +3372,11 @@ TEST_F(GenEmitterTest, testd79381f97cdd0af81ae4) {
 
 TEST_F(GenEmitterTest, test74ca1feb5f0c520a8518) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -3391,11 +3391,11 @@ TEST_F(GenEmitterTest, test74ca1feb5f0c520a8518) {
 TEST_F(GenEmitterTest, teste86e6fd56707272c091b) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3409,11 +3409,11 @@ TEST_F(GenEmitterTest, teste86e6fd56707272c091b) {
 TEST_F(GenEmitterTest, test1e6f73bc378c184c786b) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3426,12 +3426,12 @@ TEST_F(GenEmitterTest, test1e6f73bc378c184c786b) {
 
 TEST_F(GenEmitterTest, test3fbac5e1aef66dc40bf7) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3444,12 +3444,12 @@ TEST_F(GenEmitterTest, test3fbac5e1aef66dc40bf7) {
 
 TEST_F(GenEmitterTest, test558c4bf1c9c6e4e81e98) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3462,12 +3462,12 @@ TEST_F(GenEmitterTest, test558c4bf1c9c6e4e81e98) {
 
 TEST_F(GenEmitterTest, testfa6d88b26c0072cddb26) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3480,12 +3480,12 @@ TEST_F(GenEmitterTest, testfa6d88b26c0072cddb26) {
 
 TEST_F(GenEmitterTest, test40a5af3360fb3d9e79f1) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3498,11 +3498,11 @@ TEST_F(GenEmitterTest, test40a5af3360fb3d9e79f1) {
 
 TEST_F(GenEmitterTest, test451dd95b95b7e958bb03) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -3517,10 +3517,10 @@ TEST_F(GenEmitterTest, test451dd95b95b7e958bb03) {
 TEST_F(GenEmitterTest, test1717ad2d772bafb9b573) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3534,10 +3534,10 @@ TEST_F(GenEmitterTest, test1717ad2d772bafb9b573) {
 TEST_F(GenEmitterTest, testedc6737e8b2f5b23b42e) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3550,11 +3550,11 @@ TEST_F(GenEmitterTest, testedc6737e8b2f5b23b42e) {
 
 TEST_F(GenEmitterTest, test771c7d28c0b8c184e2c7) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3567,11 +3567,11 @@ TEST_F(GenEmitterTest, test771c7d28c0b8c184e2c7) {
 
 TEST_F(GenEmitterTest, test469a446f0b22e9b6d269) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3584,11 +3584,11 @@ TEST_F(GenEmitterTest, test469a446f0b22e9b6d269) {
 
 TEST_F(GenEmitterTest, testec45b0503f312be47336) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3601,10 +3601,10 @@ TEST_F(GenEmitterTest, testec45b0503f312be47336) {
 
 TEST_F(GenEmitterTest, test1bfc4f39d6730acb6a12) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -3618,10 +3618,10 @@ TEST_F(GenEmitterTest, test1bfc4f39d6730acb6a12) {
 
 TEST_F(GenEmitterTest, test9bc9a72ad06084dc8cf8) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -3636,15 +3636,15 @@ TEST_F(GenEmitterTest, test9bc9a72ad06084dc8cf8) {
 TEST_F(GenEmitterTest, test62c996cdfc1d3b77b7ec) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3660,15 +3660,15 @@ TEST_F(GenEmitterTest, test62c996cdfc1d3b77b7ec) {
 TEST_F(GenEmitterTest, test1d038936a340d5bef490) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3683,7 +3683,7 @@ TEST_F(GenEmitterTest, test1d038936a340d5bef490) {
 
 TEST_F(GenEmitterTest, test7057f64ac570dbe3c1ca) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << Anchor("anchor");
@@ -3691,8 +3691,8 @@ TEST_F(GenEmitterTest, test7057f64ac570dbe3c1ca) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3707,7 +3707,7 @@ TEST_F(GenEmitterTest, test7057f64ac570dbe3c1ca) {
 
 TEST_F(GenEmitterTest, testbfe0890de3ffc73f0f9d) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -3715,8 +3715,8 @@ TEST_F(GenEmitterTest, testbfe0890de3ffc73f0f9d) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3731,7 +3731,7 @@ TEST_F(GenEmitterTest, testbfe0890de3ffc73f0f9d) {
 
 TEST_F(GenEmitterTest, test5faa7320a493247b4f8b) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -3739,8 +3739,8 @@ TEST_F(GenEmitterTest, test5faa7320a493247b4f8b) {
   out << Anchor("other");
   out << "bar";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3755,16 +3755,16 @@ TEST_F(GenEmitterTest, test5faa7320a493247b4f8b) {
 
 TEST_F(GenEmitterTest, test929fbc93b3d6d98b1f0a) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3779,15 +3779,15 @@ TEST_F(GenEmitterTest, test929fbc93b3d6d98b1f0a) {
 
 TEST_F(GenEmitterTest, testcc7d1ad7797581b37549) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -3804,14 +3804,14 @@ TEST_F(GenEmitterTest, testcc7d1ad7797581b37549) {
 TEST_F(GenEmitterTest, test1115ba981ba8f739ddf2) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3827,14 +3827,14 @@ TEST_F(GenEmitterTest, test1115ba981ba8f739ddf2) {
 TEST_F(GenEmitterTest, testf7ca743a82040e1313a8) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3849,7 +3849,7 @@ TEST_F(GenEmitterTest, testf7ca743a82040e1313a8) {
 
 TEST_F(GenEmitterTest, testa4e0257ad6c987178ca4) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << Anchor("anchor");
@@ -3857,7 +3857,7 @@ TEST_F(GenEmitterTest, testa4e0257ad6c987178ca4) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3872,7 +3872,7 @@ TEST_F(GenEmitterTest, testa4e0257ad6c987178ca4) {
 
 TEST_F(GenEmitterTest, testb65ceea0d4080b44180e) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -3880,7 +3880,7 @@ TEST_F(GenEmitterTest, testb65ceea0d4080b44180e) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3895,7 +3895,7 @@ TEST_F(GenEmitterTest, testb65ceea0d4080b44180e) {
 
 TEST_F(GenEmitterTest, test4fcd60d48dbd7b07e289) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -3903,7 +3903,7 @@ TEST_F(GenEmitterTest, test4fcd60d48dbd7b07e289) {
   out << Anchor("other");
   out << "bar";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -3918,14 +3918,14 @@ TEST_F(GenEmitterTest, test4fcd60d48dbd7b07e289) {
 
 TEST_F(GenEmitterTest, test92704937d4e130b43390) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -3941,14 +3941,14 @@ TEST_F(GenEmitterTest, test92704937d4e130b43390) {
 
 TEST_F(GenEmitterTest, test029a31902f93dfa9ea7b) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -3965,10 +3965,10 @@ TEST_F(GenEmitterTest, test029a31902f93dfa9ea7b) {
 TEST_F(GenEmitterTest, test40b4e7494e5b850d26f4) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginMap;
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -3979,11 +3979,11 @@ TEST_F(GenEmitterTest, test40b4e7494e5b850d26f4) {
 
 TEST_F(GenEmitterTest, test64d2ab5993b67281212b) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginMap;
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -3994,11 +3994,11 @@ TEST_F(GenEmitterTest, test64d2ab5993b67281212b) {
 
 TEST_F(GenEmitterTest, teste71b9b975d71c18a2897) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4009,11 +4009,11 @@ TEST_F(GenEmitterTest, teste71b9b975d71c18a2897) {
 
 TEST_F(GenEmitterTest, test138039761e432a5ba11e) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4024,10 +4024,10 @@ TEST_F(GenEmitterTest, test138039761e432a5ba11e) {
 
 TEST_F(GenEmitterTest, test6684d2eacb3f094bfc84) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -4040,9 +4040,9 @@ TEST_F(GenEmitterTest, test6684d2eacb3f094bfc84) {
 TEST_F(GenEmitterTest, test8624a705f2167d4db358) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginMap;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4053,10 +4053,10 @@ TEST_F(GenEmitterTest, test8624a705f2167d4db358) {
 
 TEST_F(GenEmitterTest, test90877a1ec609edb69bce) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginMap;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4067,10 +4067,10 @@ TEST_F(GenEmitterTest, test90877a1ec609edb69bce) {
 
 TEST_F(GenEmitterTest, test5f925d3c910a7e32bb99) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4081,9 +4081,9 @@ TEST_F(GenEmitterTest, test5f925d3c910a7e32bb99) {
 
 TEST_F(GenEmitterTest, testffeb4955bf4ee9510a88) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -4095,9 +4095,9 @@ TEST_F(GenEmitterTest, testffeb4955bf4ee9510a88) {
 
 TEST_F(GenEmitterTest, test769ee82c3bfc52d7a85d) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -4110,12 +4110,12 @@ TEST_F(GenEmitterTest, test769ee82c3bfc52d7a85d) {
 TEST_F(GenEmitterTest, testdc4e16b5a48fe16102b4) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4128,13 +4128,13 @@ TEST_F(GenEmitterTest, testdc4e16b5a48fe16102b4) {
 
 TEST_F(GenEmitterTest, testd3c578e5b5a6813a73c7) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4147,13 +4147,13 @@ TEST_F(GenEmitterTest, testd3c578e5b5a6813a73c7) {
 
 TEST_F(GenEmitterTest, test0034b2c9905b34f7f22e) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4166,13 +4166,13 @@ TEST_F(GenEmitterTest, test0034b2c9905b34f7f22e) {
 
 TEST_F(GenEmitterTest, teste911e620becf080a4d96) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4185,13 +4185,13 @@ TEST_F(GenEmitterTest, teste911e620becf080a4d96) {
 
 TEST_F(GenEmitterTest, test7f8bbf619609651a2e55) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4204,13 +4204,13 @@ TEST_F(GenEmitterTest, test7f8bbf619609651a2e55) {
 
 TEST_F(GenEmitterTest, test2974bda177bed72619f4) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4223,12 +4223,12 @@ TEST_F(GenEmitterTest, test2974bda177bed72619f4) {
 
 TEST_F(GenEmitterTest, testbc7a1599883ed8c27262) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -4243,11 +4243,11 @@ TEST_F(GenEmitterTest, testbc7a1599883ed8c27262) {
 TEST_F(GenEmitterTest, test323e14a02e02b94939fb) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4260,12 +4260,12 @@ TEST_F(GenEmitterTest, test323e14a02e02b94939fb) {
 
 TEST_F(GenEmitterTest, test705ff113324bf0b4897c) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4278,12 +4278,12 @@ TEST_F(GenEmitterTest, test705ff113324bf0b4897c) {
 
 TEST_F(GenEmitterTest, test587f5739ba58f0e21e0e) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4296,12 +4296,12 @@ TEST_F(GenEmitterTest, test587f5739ba58f0e21e0e) {
 
 TEST_F(GenEmitterTest, test31a8c7da96ebe3da3f6e) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4314,12 +4314,12 @@ TEST_F(GenEmitterTest, test31a8c7da96ebe3da3f6e) {
 
 TEST_F(GenEmitterTest, test0b6fe270e4cf9fc21181) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4332,11 +4332,11 @@ TEST_F(GenEmitterTest, test0b6fe270e4cf9fc21181) {
 
 TEST_F(GenEmitterTest, testaf5869c722ea0dfb3394) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -4350,11 +4350,11 @@ TEST_F(GenEmitterTest, testaf5869c722ea0dfb3394) {
 
 TEST_F(GenEmitterTest, testc348837f92793a778246) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -4369,16 +4369,16 @@ TEST_F(GenEmitterTest, testc348837f92793a778246) {
 TEST_F(GenEmitterTest, test9d26ae9ec8db76a06a6f) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4393,17 +4393,17 @@ TEST_F(GenEmitterTest, test9d26ae9ec8db76a06a6f) {
 
 TEST_F(GenEmitterTest, test28691969bbaa41191640) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4418,8 +4418,8 @@ TEST_F(GenEmitterTest, test28691969bbaa41191640) {
 
 TEST_F(GenEmitterTest, testb38c27cd2556a14bb479) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << Anchor("anchor");
@@ -4427,8 +4427,8 @@ TEST_F(GenEmitterTest, testb38c27cd2556a14bb479) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4443,8 +4443,8 @@ TEST_F(GenEmitterTest, testb38c27cd2556a14bb479) {
 
 TEST_F(GenEmitterTest, test1103d3c99e3525075da6) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -4452,8 +4452,8 @@ TEST_F(GenEmitterTest, test1103d3c99e3525075da6) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4468,8 +4468,8 @@ TEST_F(GenEmitterTest, test1103d3c99e3525075da6) {
 
 TEST_F(GenEmitterTest, testeb7edb5d1dfd039c72c3) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -4477,8 +4477,8 @@ TEST_F(GenEmitterTest, testeb7edb5d1dfd039c72c3) {
   out << Anchor("other");
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4493,17 +4493,17 @@ TEST_F(GenEmitterTest, testeb7edb5d1dfd039c72c3) {
 
 TEST_F(GenEmitterTest, testa9862d708fcb755db479) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4518,16 +4518,16 @@ TEST_F(GenEmitterTest, testa9862d708fcb755db479) {
 
 TEST_F(GenEmitterTest, testae3e98286336f0c5d2af) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -4544,15 +4544,15 @@ TEST_F(GenEmitterTest, testae3e98286336f0c5d2af) {
 TEST_F(GenEmitterTest, test8bd970000ae21619e864) {
   Emitter out;
   out << Comment("comment");
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4567,16 +4567,16 @@ TEST_F(GenEmitterTest, test8bd970000ae21619e864) {
 
 TEST_F(GenEmitterTest, test0a960fe3efeeb1b4fafe) {
   Emitter out;
-  out << BeginDoc;
+  out << EMITTER_MANIP::BeginDoc;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4591,8 +4591,8 @@ TEST_F(GenEmitterTest, test0a960fe3efeeb1b4fafe) {
 
 TEST_F(GenEmitterTest, testffec1dcba9a2622b57a3) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << Anchor("anchor");
@@ -4600,7 +4600,7 @@ TEST_F(GenEmitterTest, testffec1dcba9a2622b57a3) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4615,8 +4615,8 @@ TEST_F(GenEmitterTest, testffec1dcba9a2622b57a3) {
 
 TEST_F(GenEmitterTest, test9a181b6042027e7977bf) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -4624,7 +4624,7 @@ TEST_F(GenEmitterTest, test9a181b6042027e7977bf) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4639,8 +4639,8 @@ TEST_F(GenEmitterTest, test9a181b6042027e7977bf) {
 
 TEST_F(GenEmitterTest, test5b42728bff7e0dd63ae8) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -4648,7 +4648,7 @@ TEST_F(GenEmitterTest, test5b42728bff7e0dd63ae8) {
   out << Anchor("other");
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4663,15 +4663,15 @@ TEST_F(GenEmitterTest, test5b42728bff7e0dd63ae8) {
 
 TEST_F(GenEmitterTest, testa17514c4db3a70fe5084) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -4687,15 +4687,15 @@ TEST_F(GenEmitterTest, testa17514c4db3a70fe5084) {
 
 TEST_F(GenEmitterTest, test2ac903a52c526db4b34b) {
   Emitter out;
-  out << BeginDoc;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginDoc;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -4712,9 +4712,9 @@ TEST_F(GenEmitterTest, test2ac903a52c526db4b34b) {
 TEST_F(GenEmitterTest, testbebc6bc66d04a91bfa9c) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4726,9 +4726,9 @@ TEST_F(GenEmitterTest, testbebc6bc66d04a91bfa9c) {
 TEST_F(GenEmitterTest, test0918e247384bfc94d831) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4739,10 +4739,10 @@ TEST_F(GenEmitterTest, test0918e247384bfc94d831) {
 
 TEST_F(GenEmitterTest, testf8512b2ebdaad8ae4cae) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4753,10 +4753,10 @@ TEST_F(GenEmitterTest, testf8512b2ebdaad8ae4cae) {
 
 TEST_F(GenEmitterTest, test01a1d249079c380030ca) {
   Emitter out;
-  out << BeginMap;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4767,9 +4767,9 @@ TEST_F(GenEmitterTest, test01a1d249079c380030ca) {
 
 TEST_F(GenEmitterTest, testcb48737e9c352108dc56) {
   Emitter out;
-  out << BeginMap;
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -4782,8 +4782,8 @@ TEST_F(GenEmitterTest, testcb48737e9c352108dc56) {
 TEST_F(GenEmitterTest, testdea8106f3dce46929197) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4795,8 +4795,8 @@ TEST_F(GenEmitterTest, testdea8106f3dce46929197) {
 TEST_F(GenEmitterTest, test2b91aa87abdaa0fc0b20) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4807,9 +4807,9 @@ TEST_F(GenEmitterTest, test2b91aa87abdaa0fc0b20) {
 
 TEST_F(GenEmitterTest, test9c8b1fe0c5bbbf6a787e) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4820,8 +4820,8 @@ TEST_F(GenEmitterTest, test9c8b1fe0c5bbbf6a787e) {
 
 TEST_F(GenEmitterTest, test8808d4be9571f365f79a) {
   Emitter out;
-  out << BeginMap;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -4833,8 +4833,8 @@ TEST_F(GenEmitterTest, test8808d4be9571f365f79a) {
 
 TEST_F(GenEmitterTest, teste77c95c5163513fa25c5) {
   Emitter out;
-  out << BeginMap;
-  out << EndMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -4847,11 +4847,11 @@ TEST_F(GenEmitterTest, teste77c95c5163513fa25c5) {
 TEST_F(GenEmitterTest, testa3ed6e26dac366240579) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4865,11 +4865,11 @@ TEST_F(GenEmitterTest, testa3ed6e26dac366240579) {
 TEST_F(GenEmitterTest, test136adbd0ad47d74cfa22) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4882,12 +4882,12 @@ TEST_F(GenEmitterTest, test136adbd0ad47d74cfa22) {
 
 TEST_F(GenEmitterTest, test77f384e8387e39b54691) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4900,12 +4900,12 @@ TEST_F(GenEmitterTest, test77f384e8387e39b54691) {
 
 TEST_F(GenEmitterTest, testf8f016177cf9e428fcd4) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4918,12 +4918,12 @@ TEST_F(GenEmitterTest, testf8f016177cf9e428fcd4) {
 
 TEST_F(GenEmitterTest, test1cec69d3c95937f4137a) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4936,12 +4936,12 @@ TEST_F(GenEmitterTest, test1cec69d3c95937f4137a) {
 
 TEST_F(GenEmitterTest, testb1fe1a5c5c064bdfe505) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4954,11 +4954,11 @@ TEST_F(GenEmitterTest, testb1fe1a5c5c064bdfe505) {
 
 TEST_F(GenEmitterTest, test14200fdf4de8797d8dfb) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -4973,10 +4973,10 @@ TEST_F(GenEmitterTest, test14200fdf4de8797d8dfb) {
 TEST_F(GenEmitterTest, testde7595a96199f66d7ac0) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -4990,10 +4990,10 @@ TEST_F(GenEmitterTest, testde7595a96199f66d7ac0) {
 TEST_F(GenEmitterTest, testb1434e1f508509c0ade4) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5006,11 +5006,11 @@ TEST_F(GenEmitterTest, testb1434e1f508509c0ade4) {
 
 TEST_F(GenEmitterTest, test0d3bd788298201abbe67) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5023,11 +5023,11 @@ TEST_F(GenEmitterTest, test0d3bd788298201abbe67) {
 
 TEST_F(GenEmitterTest, test3c716f5c232001f04805) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5040,11 +5040,11 @@ TEST_F(GenEmitterTest, test3c716f5c232001f04805) {
 
 TEST_F(GenEmitterTest, testa55ef29eecbda5bc5b69) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5057,10 +5057,10 @@ TEST_F(GenEmitterTest, testa55ef29eecbda5bc5b69) {
 
 TEST_F(GenEmitterTest, test55ddd593defa5ee8da90) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -5074,10 +5074,10 @@ TEST_F(GenEmitterTest, test55ddd593defa5ee8da90) {
 
 TEST_F(GenEmitterTest, test7326f87fd5c3adff317b) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -5092,15 +5092,15 @@ TEST_F(GenEmitterTest, test7326f87fd5c3adff317b) {
 TEST_F(GenEmitterTest, test5ebc413d376f3b965879) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5116,15 +5116,15 @@ TEST_F(GenEmitterTest, test5ebc413d376f3b965879) {
 TEST_F(GenEmitterTest, test4c7159334e528e2cfff8) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5139,7 +5139,7 @@ TEST_F(GenEmitterTest, test4c7159334e528e2cfff8) {
 
 TEST_F(GenEmitterTest, test6a6bc06cdfee9f58a094) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << Anchor("anchor");
@@ -5147,8 +5147,8 @@ TEST_F(GenEmitterTest, test6a6bc06cdfee9f58a094) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5163,7 +5163,7 @@ TEST_F(GenEmitterTest, test6a6bc06cdfee9f58a094) {
 
 TEST_F(GenEmitterTest, test0beedfaace1b1e71d0c6) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -5171,8 +5171,8 @@ TEST_F(GenEmitterTest, test0beedfaace1b1e71d0c6) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5187,7 +5187,7 @@ TEST_F(GenEmitterTest, test0beedfaace1b1e71d0c6) {
 
 TEST_F(GenEmitterTest, test9f65fafc369193908b7b) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -5195,8 +5195,8 @@ TEST_F(GenEmitterTest, test9f65fafc369193908b7b) {
   out << Anchor("other");
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5211,16 +5211,16 @@ TEST_F(GenEmitterTest, test9f65fafc369193908b7b) {
 
 TEST_F(GenEmitterTest, test3a5c3ac504d7a58a08ca) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << EndDoc;
+  out << EMITTER_MANIP::EndDoc;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5235,15 +5235,15 @@ TEST_F(GenEmitterTest, test3a5c3ac504d7a58a08ca) {
 
 TEST_F(GenEmitterTest, testc007513c868038dd3a68) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
-  out << EndDoc;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndDoc;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -5260,14 +5260,14 @@ TEST_F(GenEmitterTest, testc007513c868038dd3a68) {
 TEST_F(GenEmitterTest, test89f3ba065cbd341381ec) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5283,14 +5283,14 @@ TEST_F(GenEmitterTest, test89f3ba065cbd341381ec) {
 TEST_F(GenEmitterTest, test692c2652cee84e90c096) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5305,7 +5305,7 @@ TEST_F(GenEmitterTest, test692c2652cee84e90c096) {
 
 TEST_F(GenEmitterTest, test761fba62f7617a03fbf0) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << VerbatimTag("tag");
   out << Anchor("anchor");
@@ -5313,7 +5313,7 @@ TEST_F(GenEmitterTest, test761fba62f7617a03fbf0) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5328,7 +5328,7 @@ TEST_F(GenEmitterTest, test761fba62f7617a03fbf0) {
 
 TEST_F(GenEmitterTest, teste960a69bc06912eb8c76) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -5336,7 +5336,7 @@ TEST_F(GenEmitterTest, teste960a69bc06912eb8c76) {
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5351,7 +5351,7 @@ TEST_F(GenEmitterTest, teste960a69bc06912eb8c76) {
 
 TEST_F(GenEmitterTest, test8f6187c6c2419dbf1770) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
@@ -5359,7 +5359,7 @@ TEST_F(GenEmitterTest, test8f6187c6c2419dbf1770) {
   out << Anchor("other");
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5374,14 +5374,14 @@ TEST_F(GenEmitterTest, test8f6187c6c2419dbf1770) {
 
 TEST_F(GenEmitterTest, testba6cb3810a074fabc55e) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -5397,14 +5397,14 @@ TEST_F(GenEmitterTest, testba6cb3810a074fabc55e) {
 
 TEST_F(GenEmitterTest, testac695c3621ec3f104672) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << VerbatimTag("tag");
   out << Anchor("anchor");
   out << "foo";
   out << VerbatimTag("tag");
   out << Anchor("other");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -5421,10 +5421,10 @@ TEST_F(GenEmitterTest, testac695c3621ec3f104672) {
 TEST_F(GenEmitterTest, test86494a6bcb6a65e7029e) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5438,10 +5438,10 @@ TEST_F(GenEmitterTest, test86494a6bcb6a65e7029e) {
 TEST_F(GenEmitterTest, testb406fb13323c199d709c) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5454,11 +5454,11 @@ TEST_F(GenEmitterTest, testb406fb13323c199d709c) {
 
 TEST_F(GenEmitterTest, test4409f685a3e80b9ab415) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5471,11 +5471,11 @@ TEST_F(GenEmitterTest, test4409f685a3e80b9ab415) {
 
 TEST_F(GenEmitterTest, testa74ace9c1f5e18cf3f2a) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5488,11 +5488,11 @@ TEST_F(GenEmitterTest, testa74ace9c1f5e18cf3f2a) {
 
 TEST_F(GenEmitterTest, testabfc8ce2ca4c3dafa013) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "foo";
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5505,10 +5505,10 @@ TEST_F(GenEmitterTest, testabfc8ce2ca4c3dafa013) {
 
 TEST_F(GenEmitterTest, test07ff4bbae6104c4e30c1) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -5522,10 +5522,10 @@ TEST_F(GenEmitterTest, test07ff4bbae6104c4e30c1) {
 
 TEST_F(GenEmitterTest, test1e3559cacab6d46c98fe) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -5540,12 +5540,12 @@ TEST_F(GenEmitterTest, test1e3559cacab6d46c98fe) {
 TEST_F(GenEmitterTest, test795830e12e5a20213a7e) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5561,12 +5561,12 @@ TEST_F(GenEmitterTest, test795830e12e5a20213a7e) {
 TEST_F(GenEmitterTest, test849f2c88c71734fcf3f3) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5581,13 +5581,13 @@ TEST_F(GenEmitterTest, test849f2c88c71734fcf3f3) {
 
 TEST_F(GenEmitterTest, test7bb139ac1f14e8ae04e2) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5602,13 +5602,13 @@ TEST_F(GenEmitterTest, test7bb139ac1f14e8ae04e2) {
 
 TEST_F(GenEmitterTest, test58655e359c60bf73986f) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5623,13 +5623,13 @@ TEST_F(GenEmitterTest, test58655e359c60bf73986f) {
 
 TEST_F(GenEmitterTest, testde9f70648448cbd37245) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5644,13 +5644,13 @@ TEST_F(GenEmitterTest, testde9f70648448cbd37245) {
 
 TEST_F(GenEmitterTest, testfff25037c90a64db8771) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5665,13 +5665,13 @@ TEST_F(GenEmitterTest, testfff25037c90a64db8771) {
 
 TEST_F(GenEmitterTest, test94b24a286074cac9b881) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5686,12 +5686,12 @@ TEST_F(GenEmitterTest, test94b24a286074cac9b881) {
 
 TEST_F(GenEmitterTest, test0c678fe6c6dbd3ccf4eb) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -5707,12 +5707,12 @@ TEST_F(GenEmitterTest, test0c678fe6c6dbd3ccf4eb) {
 
 TEST_F(GenEmitterTest, test15f6ce577f139b9f1b61) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -5729,13 +5729,13 @@ TEST_F(GenEmitterTest, test15f6ce577f139b9f1b61) {
 TEST_F(GenEmitterTest, test5e927c8865f44b5c1abe) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5752,13 +5752,13 @@ TEST_F(GenEmitterTest, test5e927c8865f44b5c1abe) {
 TEST_F(GenEmitterTest, test235aebc60786962899f1) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5774,14 +5774,14 @@ TEST_F(GenEmitterTest, test235aebc60786962899f1) {
 
 TEST_F(GenEmitterTest, test45e109e1bc3ca312091d) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5797,14 +5797,14 @@ TEST_F(GenEmitterTest, test45e109e1bc3ca312091d) {
 
 TEST_F(GenEmitterTest, test9a58086d44719b21c6b3) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5820,14 +5820,14 @@ TEST_F(GenEmitterTest, test9a58086d44719b21c6b3) {
 
 TEST_F(GenEmitterTest, testa3ac3fa06ae69e9f5c9d) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5843,14 +5843,14 @@ TEST_F(GenEmitterTest, testa3ac3fa06ae69e9f5c9d) {
 
 TEST_F(GenEmitterTest, test9ccaf628d78cc8f27857) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5866,14 +5866,14 @@ TEST_F(GenEmitterTest, test9ccaf628d78cc8f27857) {
 
 TEST_F(GenEmitterTest, test6b8483101720027fd945) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5889,14 +5889,14 @@ TEST_F(GenEmitterTest, test6b8483101720027fd945) {
 
 TEST_F(GenEmitterTest, test1549a08694b053f8a2cb) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5912,13 +5912,13 @@ TEST_F(GenEmitterTest, test1549a08694b053f8a2cb) {
 
 TEST_F(GenEmitterTest, test0417f66daae22676ad66) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -5935,13 +5935,13 @@ TEST_F(GenEmitterTest, test0417f66daae22676ad66) {
 
 TEST_F(GenEmitterTest, test6b3d4384d27d0ac90b01) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -5959,12 +5959,12 @@ TEST_F(GenEmitterTest, test6b3d4384d27d0ac90b01) {
 TEST_F(GenEmitterTest, testbf166fa245c204799ea8) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -5980,12 +5980,12 @@ TEST_F(GenEmitterTest, testbf166fa245c204799ea8) {
 TEST_F(GenEmitterTest, testdf279b50896e8f084ed3) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6000,13 +6000,13 @@ TEST_F(GenEmitterTest, testdf279b50896e8f084ed3) {
 
 TEST_F(GenEmitterTest, test7d9b55fe33dfdc6cf930) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6021,13 +6021,13 @@ TEST_F(GenEmitterTest, test7d9b55fe33dfdc6cf930) {
 
 TEST_F(GenEmitterTest, test2b0f0825ac5d9ac3baf7) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6042,13 +6042,13 @@ TEST_F(GenEmitterTest, test2b0f0825ac5d9ac3baf7) {
 
 TEST_F(GenEmitterTest, teste4865b227f48a727aafe) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6063,13 +6063,13 @@ TEST_F(GenEmitterTest, teste4865b227f48a727aafe) {
 
 TEST_F(GenEmitterTest, testb02fb812ae14499cc30e) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6084,13 +6084,13 @@ TEST_F(GenEmitterTest, testb02fb812ae14499cc30e) {
 
 TEST_F(GenEmitterTest, testa395515c1bce39e737b7) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6105,12 +6105,12 @@ TEST_F(GenEmitterTest, testa395515c1bce39e737b7) {
 
 TEST_F(GenEmitterTest, test813be458848be1ba3bf1) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -6126,12 +6126,12 @@ TEST_F(GenEmitterTest, test813be458848be1ba3bf1) {
 
 TEST_F(GenEmitterTest, test23ab6af7b3fc7957a03d) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -6148,14 +6148,14 @@ TEST_F(GenEmitterTest, test23ab6af7b3fc7957a03d) {
 TEST_F(GenEmitterTest, testc5fb40e239029d9efa58) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6173,14 +6173,14 @@ TEST_F(GenEmitterTest, testc5fb40e239029d9efa58) {
 TEST_F(GenEmitterTest, test88b5c599a4f9ac52f951) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6197,15 +6197,15 @@ TEST_F(GenEmitterTest, test88b5c599a4f9ac52f951) {
 
 TEST_F(GenEmitterTest, test3995578993108fa25f88) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6222,15 +6222,15 @@ TEST_F(GenEmitterTest, test3995578993108fa25f88) {
 
 TEST_F(GenEmitterTest, test61a24036be6f8cd49a28) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6247,15 +6247,15 @@ TEST_F(GenEmitterTest, test61a24036be6f8cd49a28) {
 
 TEST_F(GenEmitterTest, testc13e02ab3c1bd1db6e55) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6272,15 +6272,15 @@ TEST_F(GenEmitterTest, testc13e02ab3c1bd1db6e55) {
 
 TEST_F(GenEmitterTest, testb3ca69f6d7a888644064) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6297,15 +6297,15 @@ TEST_F(GenEmitterTest, testb3ca69f6d7a888644064) {
 
 TEST_F(GenEmitterTest, test4e6337821c858c2f7cfa) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6322,15 +6322,15 @@ TEST_F(GenEmitterTest, test4e6337821c858c2f7cfa) {
 
 TEST_F(GenEmitterTest, test8dc4a01d956c779dd8b0) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6347,15 +6347,15 @@ TEST_F(GenEmitterTest, test8dc4a01d956c779dd8b0) {
 
 TEST_F(GenEmitterTest, test1dae9c6350559f6b9f89) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6372,14 +6372,14 @@ TEST_F(GenEmitterTest, test1dae9c6350559f6b9f89) {
 
 TEST_F(GenEmitterTest, test9f891b1cdde286863956) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -6397,14 +6397,14 @@ TEST_F(GenEmitterTest, test9f891b1cdde286863956) {
 
 TEST_F(GenEmitterTest, test0704315052c50c54b17a) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -6423,15 +6423,15 @@ TEST_F(GenEmitterTest, test0704315052c50c54b17a) {
 TEST_F(GenEmitterTest, test7f5b47cf1d2571afc033) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6450,15 +6450,15 @@ TEST_F(GenEmitterTest, test7f5b47cf1d2571afc033) {
 TEST_F(GenEmitterTest, test5040c19e850e3046d32d) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6476,16 +6476,16 @@ TEST_F(GenEmitterTest, test5040c19e850e3046d32d) {
 
 TEST_F(GenEmitterTest, test110665e2f3409ef307ff) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6503,16 +6503,16 @@ TEST_F(GenEmitterTest, test110665e2f3409ef307ff) {
 
 TEST_F(GenEmitterTest, teste9e1549f96267f93651c) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6530,16 +6530,16 @@ TEST_F(GenEmitterTest, teste9e1549f96267f93651c) {
 
 TEST_F(GenEmitterTest, test6a5b6a20fdb6f7c3279e) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6557,16 +6557,16 @@ TEST_F(GenEmitterTest, test6a5b6a20fdb6f7c3279e) {
 
 TEST_F(GenEmitterTest, test7c568c68f77e34d5c714) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6584,16 +6584,16 @@ TEST_F(GenEmitterTest, test7c568c68f77e34d5c714) {
 
 TEST_F(GenEmitterTest, testfd8fe783b5297c92d17f) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6611,16 +6611,16 @@ TEST_F(GenEmitterTest, testfd8fe783b5297c92d17f) {
 
 TEST_F(GenEmitterTest, test418b1426e630825a7c85) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6638,16 +6638,16 @@ TEST_F(GenEmitterTest, test418b1426e630825a7c85) {
 
 TEST_F(GenEmitterTest, test8161c5e486d317e7864e) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6665,16 +6665,16 @@ TEST_F(GenEmitterTest, test8161c5e486d317e7864e) {
 
 TEST_F(GenEmitterTest, testa48e1915ca7c919db445) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6692,15 +6692,15 @@ TEST_F(GenEmitterTest, testa48e1915ca7c919db445) {
 
 TEST_F(GenEmitterTest, test27124815aea27c053aab) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -6719,15 +6719,15 @@ TEST_F(GenEmitterTest, test27124815aea27c053aab) {
 
 TEST_F(GenEmitterTest, teste751377e4a74306bc555) {
   Emitter out;
-  out << BeginMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -6747,13 +6747,13 @@ TEST_F(GenEmitterTest, teste751377e4a74306bc555) {
 TEST_F(GenEmitterTest, test36a4cc298255efdd1ef5) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6770,13 +6770,13 @@ TEST_F(GenEmitterTest, test36a4cc298255efdd1ef5) {
 TEST_F(GenEmitterTest, test43471dee97b0506909b2) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6792,14 +6792,14 @@ TEST_F(GenEmitterTest, test43471dee97b0506909b2) {
 
 TEST_F(GenEmitterTest, test959c85b4e833f72173a6) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6815,14 +6815,14 @@ TEST_F(GenEmitterTest, test959c85b4e833f72173a6) {
 
 TEST_F(GenEmitterTest, test3a09723dce29399bc865) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6838,14 +6838,14 @@ TEST_F(GenEmitterTest, test3a09723dce29399bc865) {
 
 TEST_F(GenEmitterTest, test958e404277a1c55139af) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6861,14 +6861,14 @@ TEST_F(GenEmitterTest, test958e404277a1c55139af) {
 
 TEST_F(GenEmitterTest, testb1823407ab0601edc9cb) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6884,14 +6884,14 @@ TEST_F(GenEmitterTest, testb1823407ab0601edc9cb) {
 
 TEST_F(GenEmitterTest, test9993e9dad983b28960aa) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6907,14 +6907,14 @@ TEST_F(GenEmitterTest, test9993e9dad983b28960aa) {
 
 TEST_F(GenEmitterTest, test8e87f559b25a9a20e11c) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -6930,13 +6930,13 @@ TEST_F(GenEmitterTest, test8e87f559b25a9a20e11c) {
 
 TEST_F(GenEmitterTest, testeb431be8504451636efe) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -6953,13 +6953,13 @@ TEST_F(GenEmitterTest, testeb431be8504451636efe) {
 
 TEST_F(GenEmitterTest, testf876965882befc7355df) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -6977,15 +6977,15 @@ TEST_F(GenEmitterTest, testf876965882befc7355df) {
 TEST_F(GenEmitterTest, testf7e1d47f266f0b940fed) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7004,15 +7004,15 @@ TEST_F(GenEmitterTest, testf7e1d47f266f0b940fed) {
 TEST_F(GenEmitterTest, teste5a4bc646f2182b78cc1) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7030,16 +7030,16 @@ TEST_F(GenEmitterTest, teste5a4bc646f2182b78cc1) {
 
 TEST_F(GenEmitterTest, test6cbedca25c9a8a6bb42e) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7057,16 +7057,16 @@ TEST_F(GenEmitterTest, test6cbedca25c9a8a6bb42e) {
 
 TEST_F(GenEmitterTest, test07613cc34874a5b47577) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7084,16 +7084,16 @@ TEST_F(GenEmitterTest, test07613cc34874a5b47577) {
 
 TEST_F(GenEmitterTest, testa55b7ac19580aeb82d32) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7111,16 +7111,16 @@ TEST_F(GenEmitterTest, testa55b7ac19580aeb82d32) {
 
 TEST_F(GenEmitterTest, test458f9af92dfb9f64a488) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7138,16 +7138,16 @@ TEST_F(GenEmitterTest, test458f9af92dfb9f64a488) {
 
 TEST_F(GenEmitterTest, testc4a9c3769e95770bb455) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7165,16 +7165,16 @@ TEST_F(GenEmitterTest, testc4a9c3769e95770bb455) {
 
 TEST_F(GenEmitterTest, testae56654f89fa2416f3db) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7192,16 +7192,16 @@ TEST_F(GenEmitterTest, testae56654f89fa2416f3db) {
 
 TEST_F(GenEmitterTest, test1635f71f27e7303c730e) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7219,16 +7219,16 @@ TEST_F(GenEmitterTest, test1635f71f27e7303c730e) {
 
 TEST_F(GenEmitterTest, testcd9d835a8d8b8622c63b) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7246,15 +7246,15 @@ TEST_F(GenEmitterTest, testcd9d835a8d8b8622c63b) {
 
 TEST_F(GenEmitterTest, test3c2d1f91e57040cb8fdd) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -7273,15 +7273,15 @@ TEST_F(GenEmitterTest, test3c2d1f91e57040cb8fdd) {
 
 TEST_F(GenEmitterTest, test9bd5b4c002b3b637747f) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -7301,16 +7301,16 @@ TEST_F(GenEmitterTest, test9bd5b4c002b3b637747f) {
 TEST_F(GenEmitterTest, testf6c71199cd45b5b8e7e0) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7330,16 +7330,16 @@ TEST_F(GenEmitterTest, testf6c71199cd45b5b8e7e0) {
 TEST_F(GenEmitterTest, test865b02b69742e5513963) {
   Emitter out;
   out << Comment("comment");
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7358,17 +7358,17 @@ TEST_F(GenEmitterTest, test865b02b69742e5513963) {
 
 TEST_F(GenEmitterTest, test86eb8783dc4367cda931) {
   Emitter out;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7387,17 +7387,17 @@ TEST_F(GenEmitterTest, test86eb8783dc4367cda931) {
 
 TEST_F(GenEmitterTest, test7f6604058a9d8e2e1219) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7416,17 +7416,17 @@ TEST_F(GenEmitterTest, test7f6604058a9d8e2e1219) {
 
 TEST_F(GenEmitterTest, test676b4abcb3cf0530e4da) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7445,17 +7445,17 @@ TEST_F(GenEmitterTest, test676b4abcb3cf0530e4da) {
 
 TEST_F(GenEmitterTest, teste7e52980e73d442a602b) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7474,17 +7474,17 @@ TEST_F(GenEmitterTest, teste7e52980e73d442a602b) {
 
 TEST_F(GenEmitterTest, testc3d6f480087db4bcd3a1) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7503,17 +7503,17 @@ TEST_F(GenEmitterTest, testc3d6f480087db4bcd3a1) {
 
 TEST_F(GenEmitterTest, test6943516ed43da6944e96) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7532,17 +7532,17 @@ TEST_F(GenEmitterTest, test6943516ed43da6944e96) {
 
 TEST_F(GenEmitterTest, testb7e880522d0778ae6e6f) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7561,17 +7561,17 @@ TEST_F(GenEmitterTest, testb7e880522d0778ae6e6f) {
 
 TEST_F(GenEmitterTest, testec39ee51992618c7b154) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7590,17 +7590,17 @@ TEST_F(GenEmitterTest, testec39ee51992618c7b154) {
 
 TEST_F(GenEmitterTest, test39f768713a9b3aaffe0d) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, _));
@@ -7619,16 +7619,16 @@ TEST_F(GenEmitterTest, test39f768713a9b3aaffe0d) {
 
 TEST_F(GenEmitterTest, testf287a68abc5b8ff7784d) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -7648,16 +7648,16 @@ TEST_F(GenEmitterTest, testf287a68abc5b8ff7784d) {
 
 TEST_F(GenEmitterTest, testc36154aa87842ba9699f) {
   Emitter out;
-  out << BeginMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -7678,10 +7678,10 @@ TEST_F(GenEmitterTest, testc36154aa87842ba9699f) {
 TEST_F(GenEmitterTest, testa75da84dfc8ee5507157) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -7695,10 +7695,10 @@ TEST_F(GenEmitterTest, testa75da84dfc8ee5507157) {
 TEST_F(GenEmitterTest, testc54a03d1735615f7bd60) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -7711,11 +7711,11 @@ TEST_F(GenEmitterTest, testc54a03d1735615f7bd60) {
 
 TEST_F(GenEmitterTest, testf5d72aba828875527d6f) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -7728,11 +7728,11 @@ TEST_F(GenEmitterTest, testf5d72aba828875527d6f) {
 
 TEST_F(GenEmitterTest, test9e8681a1b27a8524ec5e) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -7745,11 +7745,11 @@ TEST_F(GenEmitterTest, test9e8681a1b27a8524ec5e) {
 
 TEST_F(GenEmitterTest, test34678928e79e6eb160f4) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -7762,10 +7762,10 @@ TEST_F(GenEmitterTest, test34678928e79e6eb160f4) {
 
 TEST_F(GenEmitterTest, test07c6d6b9e133553d4532) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -7779,10 +7779,10 @@ TEST_F(GenEmitterTest, test07c6d6b9e133553d4532) {
 
 TEST_F(GenEmitterTest, test1531642db71e1aa8dd1c) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -7797,12 +7797,12 @@ TEST_F(GenEmitterTest, test1531642db71e1aa8dd1c) {
 TEST_F(GenEmitterTest, test22fde02c0bd0ecb8a527) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -7818,12 +7818,12 @@ TEST_F(GenEmitterTest, test22fde02c0bd0ecb8a527) {
 TEST_F(GenEmitterTest, test72430574ba42559cf917) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -7838,13 +7838,13 @@ TEST_F(GenEmitterTest, test72430574ba42559cf917) {
 
 TEST_F(GenEmitterTest, test067bce5d8aa6281a3e6f) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -7859,13 +7859,13 @@ TEST_F(GenEmitterTest, test067bce5d8aa6281a3e6f) {
 
 TEST_F(GenEmitterTest, testb1839ee8ced911bb1ed1) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -7880,13 +7880,13 @@ TEST_F(GenEmitterTest, testb1839ee8ced911bb1ed1) {
 
 TEST_F(GenEmitterTest, test5899c9cd7e5a40077178) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -7901,13 +7901,13 @@ TEST_F(GenEmitterTest, test5899c9cd7e5a40077178) {
 
 TEST_F(GenEmitterTest, test834f4e4a74c0ac6cd011) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -7922,13 +7922,13 @@ TEST_F(GenEmitterTest, test834f4e4a74c0ac6cd011) {
 
 TEST_F(GenEmitterTest, testd3aeee7524918cf227e7) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -7943,12 +7943,12 @@ TEST_F(GenEmitterTest, testd3aeee7524918cf227e7) {
 
 TEST_F(GenEmitterTest, test7c587549aa0bbd6e2d53) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -7964,12 +7964,12 @@ TEST_F(GenEmitterTest, test7c587549aa0bbd6e2d53) {
 
 TEST_F(GenEmitterTest, testc684ba00d512b6009b02) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -7986,13 +7986,13 @@ TEST_F(GenEmitterTest, testc684ba00d512b6009b02) {
 TEST_F(GenEmitterTest, testbe39189b638b9e0214dd) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8009,13 +8009,13 @@ TEST_F(GenEmitterTest, testbe39189b638b9e0214dd) {
 TEST_F(GenEmitterTest, test80326240018ececfa606) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8031,14 +8031,14 @@ TEST_F(GenEmitterTest, test80326240018ececfa606) {
 
 TEST_F(GenEmitterTest, test8a74653a376d02a2b6db) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8054,14 +8054,14 @@ TEST_F(GenEmitterTest, test8a74653a376d02a2b6db) {
 
 TEST_F(GenEmitterTest, testaa82cace20492eb66f60) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8077,14 +8077,14 @@ TEST_F(GenEmitterTest, testaa82cace20492eb66f60) {
 
 TEST_F(GenEmitterTest, testcd4a1cdb4e2a24cae5c1) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8100,14 +8100,14 @@ TEST_F(GenEmitterTest, testcd4a1cdb4e2a24cae5c1) {
 
 TEST_F(GenEmitterTest, testa9ef5ab0eada79175f6a) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8123,14 +8123,14 @@ TEST_F(GenEmitterTest, testa9ef5ab0eada79175f6a) {
 
 TEST_F(GenEmitterTest, test4060ba4b4f9b8193dcc4) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8146,14 +8146,14 @@ TEST_F(GenEmitterTest, test4060ba4b4f9b8193dcc4) {
 
 TEST_F(GenEmitterTest, test6cd2fc4be08857654fa0) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8169,13 +8169,13 @@ TEST_F(GenEmitterTest, test6cd2fc4be08857654fa0) {
 
 TEST_F(GenEmitterTest, testadb892f6183cde28d9cc) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -8192,13 +8192,13 @@ TEST_F(GenEmitterTest, testadb892f6183cde28d9cc) {
 
 TEST_F(GenEmitterTest, test5e830445d6cafe856b09) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -8216,12 +8216,12 @@ TEST_F(GenEmitterTest, test5e830445d6cafe856b09) {
 TEST_F(GenEmitterTest, test16a7d875f6358bdd36ee) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8237,12 +8237,12 @@ TEST_F(GenEmitterTest, test16a7d875f6358bdd36ee) {
 TEST_F(GenEmitterTest, test75b4342605739c88bc3f) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8257,13 +8257,13 @@ TEST_F(GenEmitterTest, test75b4342605739c88bc3f) {
 
 TEST_F(GenEmitterTest, test7d42488f1a02d045d278) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8278,13 +8278,13 @@ TEST_F(GenEmitterTest, test7d42488f1a02d045d278) {
 
 TEST_F(GenEmitterTest, test9ce404764c03c6644c98) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8299,13 +8299,13 @@ TEST_F(GenEmitterTest, test9ce404764c03c6644c98) {
 
 TEST_F(GenEmitterTest, testf9e413cd5405efcbd432) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8320,13 +8320,13 @@ TEST_F(GenEmitterTest, testf9e413cd5405efcbd432) {
 
 TEST_F(GenEmitterTest, test757c82faa95e2e507ee9) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8341,13 +8341,13 @@ TEST_F(GenEmitterTest, test757c82faa95e2e507ee9) {
 
 TEST_F(GenEmitterTest, testb73d72bf5de11964969f) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8362,12 +8362,12 @@ TEST_F(GenEmitterTest, testb73d72bf5de11964969f) {
 
 TEST_F(GenEmitterTest, test3926f169b9dce6db913f) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -8383,12 +8383,12 @@ TEST_F(GenEmitterTest, test3926f169b9dce6db913f) {
 
 TEST_F(GenEmitterTest, test77b0cc7e618a09e0556d) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -8405,14 +8405,14 @@ TEST_F(GenEmitterTest, test77b0cc7e618a09e0556d) {
 TEST_F(GenEmitterTest, test6817f3e5da2ad8823025) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8430,14 +8430,14 @@ TEST_F(GenEmitterTest, test6817f3e5da2ad8823025) {
 TEST_F(GenEmitterTest, test817ae48b78359d60888b) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8454,15 +8454,15 @@ TEST_F(GenEmitterTest, test817ae48b78359d60888b) {
 
 TEST_F(GenEmitterTest, test9db1bf6278dd7de937e6) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8479,15 +8479,15 @@ TEST_F(GenEmitterTest, test9db1bf6278dd7de937e6) {
 
 TEST_F(GenEmitterTest, test4d5ca5c891442ddf7e84) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8504,15 +8504,15 @@ TEST_F(GenEmitterTest, test4d5ca5c891442ddf7e84) {
 
 TEST_F(GenEmitterTest, testfb6eb22f4bf080b9ac8b) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8529,15 +8529,15 @@ TEST_F(GenEmitterTest, testfb6eb22f4bf080b9ac8b) {
 
 TEST_F(GenEmitterTest, test3ce4b4ec89282d701502) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8554,15 +8554,15 @@ TEST_F(GenEmitterTest, test3ce4b4ec89282d701502) {
 
 TEST_F(GenEmitterTest, testaf53ae415739a8812200) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8579,15 +8579,15 @@ TEST_F(GenEmitterTest, testaf53ae415739a8812200) {
 
 TEST_F(GenEmitterTest, test72d3de78c6508500cb00) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8604,15 +8604,15 @@ TEST_F(GenEmitterTest, test72d3de78c6508500cb00) {
 
 TEST_F(GenEmitterTest, test6dd3d3703718b37fa2a4) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8629,14 +8629,14 @@ TEST_F(GenEmitterTest, test6dd3d3703718b37fa2a4) {
 
 TEST_F(GenEmitterTest, testc0beca9064d8081d45c1) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -8654,14 +8654,14 @@ TEST_F(GenEmitterTest, testc0beca9064d8081d45c1) {
 
 TEST_F(GenEmitterTest, test14c55f7cd295d89763ca) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -8680,15 +8680,15 @@ TEST_F(GenEmitterTest, test14c55f7cd295d89763ca) {
 TEST_F(GenEmitterTest, test72a93f054d9296607dff) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8707,15 +8707,15 @@ TEST_F(GenEmitterTest, test72a93f054d9296607dff) {
 TEST_F(GenEmitterTest, testf0ac164fe5c38cc36922) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8733,16 +8733,16 @@ TEST_F(GenEmitterTest, testf0ac164fe5c38cc36922) {
 
 TEST_F(GenEmitterTest, test74efb7c560fd057d25ba) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8760,16 +8760,16 @@ TEST_F(GenEmitterTest, test74efb7c560fd057d25ba) {
 
 TEST_F(GenEmitterTest, test43adceaba606a7f5013f) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8787,16 +8787,16 @@ TEST_F(GenEmitterTest, test43adceaba606a7f5013f) {
 
 TEST_F(GenEmitterTest, test94160894abf5f0650ec9) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8814,16 +8814,16 @@ TEST_F(GenEmitterTest, test94160894abf5f0650ec9) {
 
 TEST_F(GenEmitterTest, testb77f1131af63dae91031) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8841,16 +8841,16 @@ TEST_F(GenEmitterTest, testb77f1131af63dae91031) {
 
 TEST_F(GenEmitterTest, test296aa575c385013e91f0) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8868,16 +8868,16 @@ TEST_F(GenEmitterTest, test296aa575c385013e91f0) {
 
 TEST_F(GenEmitterTest, test339bddce4b70064141c4) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8895,16 +8895,16 @@ TEST_F(GenEmitterTest, test339bddce4b70064141c4) {
 
 TEST_F(GenEmitterTest, test991a70285cf143adb7fe) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8922,16 +8922,16 @@ TEST_F(GenEmitterTest, test991a70285cf143adb7fe) {
 
 TEST_F(GenEmitterTest, test1b1ae70c1b5e7a1a2502) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -8949,15 +8949,15 @@ TEST_F(GenEmitterTest, test1b1ae70c1b5e7a1a2502) {
 
 TEST_F(GenEmitterTest, test02e58fb30f5a5b3616ec) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -8976,15 +8976,15 @@ TEST_F(GenEmitterTest, test02e58fb30f5a5b3616ec) {
 
 TEST_F(GenEmitterTest, testbdc3952445cad78094e2) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -9004,13 +9004,13 @@ TEST_F(GenEmitterTest, testbdc3952445cad78094e2) {
 TEST_F(GenEmitterTest, test5d24f2ab8e24cb71d6c9) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9027,13 +9027,13 @@ TEST_F(GenEmitterTest, test5d24f2ab8e24cb71d6c9) {
 TEST_F(GenEmitterTest, test1ca2c58583cb7dd8a765) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9049,14 +9049,14 @@ TEST_F(GenEmitterTest, test1ca2c58583cb7dd8a765) {
 
 TEST_F(GenEmitterTest, test6086aee45faab48750ad) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9072,14 +9072,14 @@ TEST_F(GenEmitterTest, test6086aee45faab48750ad) {
 
 TEST_F(GenEmitterTest, testdac42de03b96b1207ec4) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9095,14 +9095,14 @@ TEST_F(GenEmitterTest, testdac42de03b96b1207ec4) {
 
 TEST_F(GenEmitterTest, test10d18ea5e198359e218b) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9118,14 +9118,14 @@ TEST_F(GenEmitterTest, test10d18ea5e198359e218b) {
 
 TEST_F(GenEmitterTest, test56218e461d6be3a18500) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9141,14 +9141,14 @@ TEST_F(GenEmitterTest, test56218e461d6be3a18500) {
 
 TEST_F(GenEmitterTest, test9acfd124b72471e34bbd) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9164,14 +9164,14 @@ TEST_F(GenEmitterTest, test9acfd124b72471e34bbd) {
 
 TEST_F(GenEmitterTest, test2a1c3780a4dfaa43646e) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9187,13 +9187,13 @@ TEST_F(GenEmitterTest, test2a1c3780a4dfaa43646e) {
 
 TEST_F(GenEmitterTest, test91e4c547fdab9e8b1c67) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -9210,13 +9210,13 @@ TEST_F(GenEmitterTest, test91e4c547fdab9e8b1c67) {
 
 TEST_F(GenEmitterTest, test3d7e8318208742fe4358) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -9234,15 +9234,15 @@ TEST_F(GenEmitterTest, test3d7e8318208742fe4358) {
 TEST_F(GenEmitterTest, test2e4a92f93d5f9d8c5fed) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9261,15 +9261,15 @@ TEST_F(GenEmitterTest, test2e4a92f93d5f9d8c5fed) {
 TEST_F(GenEmitterTest, test9abf5d48ef7c6f2ed8a0) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9287,16 +9287,16 @@ TEST_F(GenEmitterTest, test9abf5d48ef7c6f2ed8a0) {
 
 TEST_F(GenEmitterTest, testc3428819fe7cfe88cf10) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9314,16 +9314,16 @@ TEST_F(GenEmitterTest, testc3428819fe7cfe88cf10) {
 
 TEST_F(GenEmitterTest, test8007ba3728b0fdbb0cb8) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9341,16 +9341,16 @@ TEST_F(GenEmitterTest, test8007ba3728b0fdbb0cb8) {
 
 TEST_F(GenEmitterTest, test6eedc1e3db4ceee9caf6) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9368,16 +9368,16 @@ TEST_F(GenEmitterTest, test6eedc1e3db4ceee9caf6) {
 
 TEST_F(GenEmitterTest, testd892f2048c7066c74b7e) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9395,16 +9395,16 @@ TEST_F(GenEmitterTest, testd892f2048c7066c74b7e) {
 
 TEST_F(GenEmitterTest, test736430339c2a221b6d89) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9422,16 +9422,16 @@ TEST_F(GenEmitterTest, test736430339c2a221b6d89) {
 
 TEST_F(GenEmitterTest, test6d51f33adb9324f438d1) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9449,16 +9449,16 @@ TEST_F(GenEmitterTest, test6d51f33adb9324f438d1) {
 
 TEST_F(GenEmitterTest, test00d50067643ed73a3f7f) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
   out << Comment("comment");
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9476,16 +9476,16 @@ TEST_F(GenEmitterTest, test00d50067643ed73a3f7f) {
 
 TEST_F(GenEmitterTest, test5fc029e9d46151d31a80) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9503,15 +9503,15 @@ TEST_F(GenEmitterTest, test5fc029e9d46151d31a80) {
 
 TEST_F(GenEmitterTest, test328542a5a4b65371d2c6) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -9530,15 +9530,15 @@ TEST_F(GenEmitterTest, test328542a5a4b65371d2c6) {
 
 TEST_F(GenEmitterTest, testf791a97db1c96e9f16c7) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginSeq;
   out << "foo";
-  out << EndSeq;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -9558,16 +9558,16 @@ TEST_F(GenEmitterTest, testf791a97db1c96e9f16c7) {
 TEST_F(GenEmitterTest, test44ac18a00d604391a169) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9587,16 +9587,16 @@ TEST_F(GenEmitterTest, test44ac18a00d604391a169) {
 TEST_F(GenEmitterTest, teste7ff269f6d95faa06abe) {
   Emitter out;
   out << Comment("comment");
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9615,17 +9615,17 @@ TEST_F(GenEmitterTest, teste7ff269f6d95faa06abe) {
 
 TEST_F(GenEmitterTest, test8d056d159803415c2c85) {
   Emitter out;
-  out << BeginSeq;
+  out << EMITTER_MANIP::BeginSeq;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9644,17 +9644,17 @@ TEST_F(GenEmitterTest, test8d056d159803415c2c85) {
 
 TEST_F(GenEmitterTest, test47ef0ff3da945fda8680) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9673,17 +9673,17 @@ TEST_F(GenEmitterTest, test47ef0ff3da945fda8680) {
 
 TEST_F(GenEmitterTest, test1f981851e5a72a91614b) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9702,17 +9702,17 @@ TEST_F(GenEmitterTest, test1f981851e5a72a91614b) {
 
 TEST_F(GenEmitterTest, test783be6c196784ca7ff30) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9731,17 +9731,17 @@ TEST_F(GenEmitterTest, test783be6c196784ca7ff30) {
 
 TEST_F(GenEmitterTest, test217dcab50ef45ac6d344) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9760,17 +9760,17 @@ TEST_F(GenEmitterTest, test217dcab50ef45ac6d344) {
 
 TEST_F(GenEmitterTest, testec71f98bc646a34c9327) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << Comment("comment");
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9789,17 +9789,17 @@ TEST_F(GenEmitterTest, testec71f98bc646a34c9327) {
 
 TEST_F(GenEmitterTest, test04595ac13c58c0740048) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << Comment("comment");
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9818,17 +9818,17 @@ TEST_F(GenEmitterTest, test04595ac13c58c0740048) {
 
 TEST_F(GenEmitterTest, test18d724e2ff0f869e9947) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
   out << Comment("comment");
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9847,17 +9847,17 @@ TEST_F(GenEmitterTest, test18d724e2ff0f869e9947) {
 
 TEST_F(GenEmitterTest, test9f80798acafd4cfec0aa) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
+  out << EMITTER_MANIP::EndMap;
   out << Comment("comment");
-  out << EndSeq;
+  out << EMITTER_MANIP::EndSeq;
 
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, _));
@@ -9876,16 +9876,16 @@ TEST_F(GenEmitterTest, test9f80798acafd4cfec0aa) {
 
 TEST_F(GenEmitterTest, testeabc051f6366e0275232) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));
@@ -9905,16 +9905,16 @@ TEST_F(GenEmitterTest, testeabc051f6366e0275232) {
 
 TEST_F(GenEmitterTest, teste33a98fb01ea45cc91dc) {
   Emitter out;
-  out << BeginSeq;
-  out << BeginMap;
+  out << EMITTER_MANIP::BeginSeq;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << BeginMap;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::BeginMap;
   out << "foo";
   out << "bar";
-  out << EndMap;
-  out << EndSeq;
+  out << EMITTER_MANIP::EndMap;
+  out << EMITTER_MANIP::EndSeq;
   out << Comment("comment");
 
   EXPECT_CALL(handler, OnDocumentStart(_));


### PR DESCRIPTION
This fixed `-Wshadow` warnings emitted when compiling with clang++

Signed-off-by: Ted Lyngmo <ted@lyncon.se>