### PR TITLE
Make pseudo enum classes into proper enum classes

### DIFF
--- a/include/yaml-cpp/emitfromevents.h
+++ b/include/yaml-cpp/emitfromevents.h
@@ -33,11 +33,11 @@ class EmitFromEvents : public EventHandler {
                         anchor_t anchor, const std::string& value) override;
 
   void OnSequenceStart(const Mark& mark, const std::string& tag,
-                               anchor_t anchor, EmitterStyle::value style) override;
+                               anchor_t anchor, EmitterStyle style) override;
   void OnSequenceEnd() override;
 
   void OnMapStart(const Mark& mark, const std::string& tag,
-                          anchor_t anchor, EmitterStyle::value style) override;
+                          anchor_t anchor, EmitterStyle style) override;
   void OnMapEnd() override;
 
  private:
@@ -47,10 +47,8 @@ class EmitFromEvents : public EventHandler {
  private:
   Emitter& m_emitter;
 
-  struct State {
-    enum value { WaitingForSequenceEntry, WaitingForKey, WaitingForValue };
-  };
-  std::stack<State::value> m_stateStack;
+  enum class State { WaitingForSequenceEntry, WaitingForKey, WaitingForValue };
+  std::stack<State> m_stateStack;
 };
 }
 

--- a/include/yaml-cpp/emitter.h
+++ b/include/yaml-cpp/emitter.h
@@ -103,24 +103,24 @@ class YAML_CPP_API Emitter {
   void EmitKindTag();
   void EmitTag(bool verbatim, const _Tag& tag);
 
-  void PrepareNode(EmitterNodeType::value child);
-  void PrepareTopNode(EmitterNodeType::value child);
-  void FlowSeqPrepareNode(EmitterNodeType::value child);
-  void BlockSeqPrepareNode(EmitterNodeType::value child);
+  void PrepareNode(EmitterNodeType child);
+  void PrepareTopNode(EmitterNodeType child);
+  void FlowSeqPrepareNode(EmitterNodeType child);
+  void BlockSeqPrepareNode(EmitterNodeType child);
 
-  void FlowMapPrepareNode(EmitterNodeType::value child);
+  void FlowMapPrepareNode(EmitterNodeType child);
 
-  void FlowMapPrepareLongKey(EmitterNodeType::value child);
-  void FlowMapPrepareLongKeyValue(EmitterNodeType::value child);
-  void FlowMapPrepareSimpleKey(EmitterNodeType::value child);
-  void FlowMapPrepareSimpleKeyValue(EmitterNodeType::value child);
+  void FlowMapPrepareLongKey(EmitterNodeType child);
+  void FlowMapPrepareLongKeyValue(EmitterNodeType child);
+  void FlowMapPrepareSimpleKey(EmitterNodeType child);
+  void FlowMapPrepareSimpleKeyValue(EmitterNodeType child);
 
-  void BlockMapPrepareNode(EmitterNodeType::value child);
+  void BlockMapPrepareNode(EmitterNodeType child);
 
-  void BlockMapPrepareLongKey(EmitterNodeType::value child);
-  void BlockMapPrepareLongKeyValue(EmitterNodeType::value child);
-  void BlockMapPrepareSimpleKey(EmitterNodeType::value child);
-  void BlockMapPrepareSimpleKeyValue(EmitterNodeType::value child);
+  void BlockMapPrepareLongKey(EmitterNodeType child);
+  void BlockMapPrepareLongKeyValue(EmitterNodeType child);
+  void BlockMapPrepareSimpleKey(EmitterNodeType child);
+  void BlockMapPrepareSimpleKeyValue(EmitterNodeType child);
 
   void SpaceOrIndentTo(bool requireSpace, std::size_t indent);
 

--- a/include/yaml-cpp/emitterdef.h
+++ b/include/yaml-cpp/emitterdef.h
@@ -8,9 +8,7 @@
 #endif
 
 namespace YAML {
-struct EmitterNodeType {
-  enum value { NoType, Property, Scalar, FlowSeq, BlockSeq, FlowMap, BlockMap };
-};
+  enum class EmitterNodeType { NoType, Property, Scalar, FlowSeq, BlockSeq, FlowMap, BlockMap };
 }
 
 #endif  // EMITTERDEF_H_62B23520_7C8E_11DE_8A39_0800200C9A66

--- a/include/yaml-cpp/emittermanip.h
+++ b/include/yaml-cpp/emittermanip.h
@@ -91,16 +91,14 @@ struct _Anchor {
 inline _Anchor Anchor(const std::string& content) { return _Anchor(content); }
 
 struct _Tag {
-  struct Type {
-    enum value { Verbatim, PrimaryHandle, NamedHandle };
-  };
+  enum class Type { Verbatim, PrimaryHandle, NamedHandle };
 
   explicit _Tag(const std::string& prefix_, const std::string& content_,
-                Type::value type_)
+                Type type_)
       : prefix(prefix_), content(content_), type(type_) {}
   std::string prefix;
   std::string content;
-  Type::value type;
+  Type type;
 };
 
 inline _Tag VerbatimTag(const std::string& content) {

--- a/include/yaml-cpp/emitterstyle.h
+++ b/include/yaml-cpp/emitterstyle.h
@@ -8,9 +8,7 @@
 #endif
 
 namespace YAML {
-struct EmitterStyle {
-  enum value { Default, Block, Flow };
-};
+enum class EmitterStyle { Default, Block, Flow };
 }
 
 #endif  // EMITTERSTYLE_H_62B23520_7C8E_11DE_8A39_0800200C9A66

--- a/include/yaml-cpp/eventhandler.h
+++ b/include/yaml-cpp/eventhandler.h
@@ -28,11 +28,11 @@ class EventHandler {
                         anchor_t anchor, const std::string& value) = 0;
 
   virtual void OnSequenceStart(const Mark& mark, const std::string& tag,
-                               anchor_t anchor, EmitterStyle::value style) = 0;
+                               anchor_t anchor, EmitterStyle style) = 0;
   virtual void OnSequenceEnd() = 0;
 
   virtual void OnMapStart(const Mark& mark, const std::string& tag,
-                          anchor_t anchor, EmitterStyle::value style) = 0;
+                          anchor_t anchor, EmitterStyle style) = 0;
   virtual void OnMapEnd() = 0;
 
   virtual void OnAnchor(const Mark& /*mark*/,

--- a/include/yaml-cpp/node/detail/node.h
+++ b/include/yaml-cpp/node/detail/node.h
@@ -33,11 +33,11 @@ class node {
 
   bool is_defined() const { return m_pRef->is_defined(); }
   const Mark& mark() const { return m_pRef->mark(); }
-  NodeType::value type() const { return m_pRef->type(); }
+  NodeType type() const { return m_pRef->type(); }
 
   const std::string& scalar() const { return m_pRef->scalar(); }
   const std::string& tag() const { return m_pRef->tag(); }
-  EmitterStyle::value style() const { return m_pRef->style(); }
+  EmitterStyle style() const { return m_pRef->style(); }
 
   template <typename T>
   bool equals(const T& rhs, shared_memory_holder pMemory);
@@ -73,7 +73,7 @@ class node {
 
   void set_mark(const Mark& mark) { m_pRef->set_mark(mark); }
 
-  void set_type(NodeType::value type) {
+  void set_type(NodeType type) {
     if (type != NodeType::Undefined)
       mark_defined();
     m_pRef->set_type(type);
@@ -92,7 +92,7 @@ class node {
   }
 
   // style
-  void set_style(EmitterStyle::value style) {
+  void set_style(EmitterStyle style) {
     mark_defined();
     m_pRef->set_style(style);
   }

--- a/include/yaml-cpp/node/detail/node_data.h
+++ b/include/yaml-cpp/node/detail/node_data.h
@@ -35,20 +35,20 @@ class YAML_CPP_API node_data {
 
   void mark_defined();
   void set_mark(const Mark& mark);
-  void set_type(NodeType::value type);
+  void set_type(NodeType type);
   void set_tag(const std::string& tag);
   void set_null();
   void set_scalar(const std::string& scalar);
-  void set_style(EmitterStyle::value style);
+  void set_style(EmitterStyle style);
 
   bool is_defined() const { return m_isDefined; }
   const Mark& mark() const { return m_mark; }
-  NodeType::value type() const {
+  NodeType type() const {
     return m_isDefined ? m_type : NodeType::Undefined;
   }
   const std::string& scalar() const { return m_scalar; }
   const std::string& tag() const { return m_tag; }
-  EmitterStyle::value style() const { return m_style; }
+  EmitterStyle style() const { return m_style; }
 
   // size/iterator
   std::size_t size() const;
@@ -100,9 +100,9 @@ class YAML_CPP_API node_data {
  private:
   bool m_isDefined;
   Mark m_mark;
-  NodeType::value m_type;
+  NodeType m_type;
   std::string m_tag;
-  EmitterStyle::value m_style;
+  EmitterStyle m_style;
 
   // scalar
   std::string m_scalar;

--- a/include/yaml-cpp/node/detail/node_iterator.h
+++ b/include/yaml-cpp/node/detail/node_iterator.h
@@ -18,9 +18,7 @@
 
 namespace YAML {
 namespace detail {
-struct iterator_type {
-  enum value { NoneType, Sequence, Map };
-};
+enum class iterator_type { NoneType, Sequence, Map };
 
 template <typename V>
 struct node_iterator_value : public std::pair<V*, V*> {
@@ -167,7 +165,7 @@ class node_iterator_base {
   }
 
  private:
-  typename iterator_type::value m_type;
+  iterator_type m_type;
 
   SeqIter m_seqIt;
   MapIter m_mapIt, m_mapEnd;

--- a/include/yaml-cpp/node/detail/node_ref.h
+++ b/include/yaml-cpp/node/detail/node_ref.h
@@ -22,20 +22,20 @@ class node_ref {
 
   bool is_defined() const { return m_pData->is_defined(); }
   const Mark& mark() const { return m_pData->mark(); }
-  NodeType::value type() const { return m_pData->type(); }
+  NodeType type() const { return m_pData->type(); }
   const std::string& scalar() const { return m_pData->scalar(); }
   const std::string& tag() const { return m_pData->tag(); }
-  EmitterStyle::value style() const { return m_pData->style(); }
+  EmitterStyle style() const { return m_pData->style(); }
 
   void mark_defined() { m_pData->mark_defined(); }
   void set_data(const node_ref& rhs) { m_pData = rhs.m_pData; }
 
   void set_mark(const Mark& mark) { m_pData->set_mark(mark); }
-  void set_type(NodeType::value type) { m_pData->set_type(type); }
+  void set_type(NodeType type) { m_pData->set_type(type); }
   void set_tag(const std::string& tag) { m_pData->set_tag(tag); }
   void set_null() { m_pData->set_null(); }
   void set_scalar(const std::string& scalar) { m_pData->set_scalar(scalar); }
-  void set_style(EmitterStyle::value style) { m_pData->set_style(style); }
+  void set_style(EmitterStyle style) { m_pData->set_style(style); }
 
   // size/iterator
   std::size_t size() const { return m_pData->size(); }

--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -19,7 +19,7 @@ namespace YAML {
 inline Node::Node()
     : m_isValid(true), m_invalidKey{}, m_pMemory(nullptr), m_pNode(nullptr) {}
 
-inline Node::Node(NodeType::value type)
+inline Node::Node(NodeType type)
     : m_isValid(true),
       m_invalidKey{},
       m_pMemory(new detail::memory_holder),
@@ -79,7 +79,7 @@ inline Mark Node::Mark() const {
   return m_pNode ? m_pNode->mark() : Mark::null_mark();
 }
 
-inline NodeType::value Node::Type() const {
+inline NodeType Node::Type() const {
   if (!m_isValid)
     throw InvalidNode(m_invalidKey);
   return m_pNode ? m_pNode->type() : NodeType::Null;
@@ -180,13 +180,13 @@ inline void Node::SetTag(const std::string& tag) {
   m_pNode->set_tag(tag);
 }
 
-inline EmitterStyle::value Node::Style() const {
+inline EmitterStyle Node::Style() const {
   if (!m_isValid)
     throw InvalidNode(m_invalidKey);
   return m_pNode ? m_pNode->style() : EmitterStyle::Default;
 }
 
-inline void Node::SetStyle(EmitterStyle::value style) {
+inline void Node::SetStyle(EmitterStyle style) {
   EnsureNodeExists();
   m_pNode->set_style(style);
 }

--- a/include/yaml-cpp/node/node.h
+++ b/include/yaml-cpp/node/node.h
@@ -42,7 +42,7 @@ class YAML_CPP_API Node {
   using const_iterator = YAML::const_iterator;
 
   Node();
-  explicit Node(NodeType::value type);
+  explicit Node(NodeType type);
   template <typename T>
   explicit Node(const T& rhs);
   explicit Node(const detail::iterator_value& rhs);
@@ -50,7 +50,7 @@ class YAML_CPP_API Node {
   ~Node();
 
   YAML::Mark Mark() const;
-  NodeType::value Type() const;
+  NodeType Type() const;
   bool IsDefined() const;
   bool IsNull() const { return Type() == NodeType::Null; }
   bool IsScalar() const { return Type() == NodeType::Scalar; }
@@ -73,8 +73,8 @@ class YAML_CPP_API Node {
 
   // style
   // WARNING: This API might change in future releases.
-  EmitterStyle::value Style() const;
-  void SetStyle(EmitterStyle::value style);
+  EmitterStyle Style() const;
+  void SetStyle(EmitterStyle style);
 
   // assignment
   bool is(const Node& rhs) const;

--- a/include/yaml-cpp/node/type.h
+++ b/include/yaml-cpp/node/type.h
@@ -8,9 +8,7 @@
 #endif
 
 namespace YAML {
-struct NodeType {
-  enum value { Undefined, Null, Scalar, Sequence, Map };
-};
+enum class NodeType { Undefined, Null, Scalar, Sequence, Map };
 }
 
 #endif  // VALUE_TYPE_H_62B23520_7C8E_11DE_8A39_0800200C9A66

--- a/src/collectionstack.h
+++ b/src/collectionstack.h
@@ -11,30 +11,28 @@
 #include <stack>
 
 namespace YAML {
-struct CollectionType {
-  enum value { NoCollection, BlockMap, BlockSeq, FlowMap, FlowSeq, CompactMap };
-};
+enum class CollectionType { NoCollection, BlockMap, BlockSeq, FlowMap, FlowSeq, CompactMap };
 
 class CollectionStack {
  public:
   CollectionStack() : collectionStack{} {}
-  CollectionType::value GetCurCollectionType() const {
+  CollectionType GetCurCollectionType() const {
     if (collectionStack.empty())
       return CollectionType::NoCollection;
     return collectionStack.top();
   }
 
-  void PushCollectionType(CollectionType::value type) {
+  void PushCollectionType(CollectionType type) {
     collectionStack.push(type);
   }
-  void PopCollectionType(CollectionType::value type) {
+  void PopCollectionType(CollectionType type) {
     assert(type == GetCurCollectionType());
     (void)type;
     collectionStack.pop();
   }
 
  private:
-  std::stack<CollectionType::value> collectionStack;
+  std::stack<CollectionType> collectionStack;
 };
 }  // namespace YAML
 

--- a/src/contrib/graphbuilderadapter.cpp
+++ b/src/contrib/graphbuilderadapter.cpp
@@ -31,7 +31,7 @@ void GraphBuilderAdapter::OnScalar(const Mark &mark, const std::string &tag,
 void GraphBuilderAdapter::OnSequenceStart(const Mark &mark,
                                           const std::string &tag,
                                           anchor_t anchor,
-                                          EmitterStyle::value /* style */) {
+                                          EmitterStyle /* style */) {
   void *pNode = m_builder.NewSequence(mark, tag, GetCurrentParent());
   m_containers.push(ContainerFrame(pNode));
   RegisterAnchor(anchor, pNode);
@@ -46,7 +46,7 @@ void GraphBuilderAdapter::OnSequenceEnd() {
 
 void GraphBuilderAdapter::OnMapStart(const Mark &mark, const std::string &tag,
                                      anchor_t anchor,
-                                     EmitterStyle::value /* style */) {
+                                     EmitterStyle /* style */) {
   void *pNode = m_builder.NewMap(mark, tag, GetCurrentParent());
   m_containers.push(ContainerFrame(pNode, m_pKeyNode));
   m_pKeyNode = nullptr;

--- a/src/contrib/graphbuilderadapter.h
+++ b/src/contrib/graphbuilderadapter.h
@@ -45,11 +45,11 @@ class GraphBuilderAdapter : public EventHandler {
                         anchor_t anchor, const std::string& value);
 
   virtual void OnSequenceStart(const Mark& mark, const std::string& tag,
-                               anchor_t anchor, EmitterStyle::value style);
+                               anchor_t anchor, EmitterStyle style);
   virtual void OnSequenceEnd();
 
   virtual void OnMapStart(const Mark& mark, const std::string& tag,
-                          anchor_t anchor, EmitterStyle::value style);
+                          anchor_t anchor, EmitterStyle style);
   virtual void OnMapEnd();
 
   void* RootNode() const { return m_pRootNode; }

--- a/src/emitfromevents.cpp
+++ b/src/emitfromevents.cpp
@@ -46,7 +46,7 @@ void EmitFromEvents::OnScalar(const Mark&, const std::string& tag,
 
 void EmitFromEvents::OnSequenceStart(const Mark&, const std::string& tag,
                                      anchor_t anchor,
-                                     EmitterStyle::value style) {
+                                     EmitterStyle style) {
   BeginNode();
   EmitProps(tag, anchor);
   switch (style) {
@@ -72,7 +72,7 @@ void EmitFromEvents::OnSequenceEnd() {
 }
 
 void EmitFromEvents::OnMapStart(const Mark&, const std::string& tag,
-                                anchor_t anchor, EmitterStyle::value style) {
+                                anchor_t anchor, EmitterStyle style) {
   BeginNode();
   EmitProps(tag, anchor);
   switch (style) {

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -205,7 +205,7 @@ void Emitter::EmitBeginSeq() {
 void Emitter::EmitEndSeq() {
   if (!good())
     return;
-  FlowType::value originalType = m_pState->CurGroupFlowType();
+  FlowType originalType = m_pState->CurGroupFlowType();
 
   if (m_pState->CurGroupChildCount() == 0)
     m_pState->ForceFlow();
@@ -240,7 +240,7 @@ void Emitter::EmitBeginMap() {
 void Emitter::EmitEndMap() {
   if (!good())
     return;
-  FlowType::value originalType = m_pState->CurGroupFlowType();
+  FlowType originalType = m_pState->CurGroupFlowType();
 
   if (m_pState->CurGroupChildCount() == 0)
     m_pState->ForceFlow();
@@ -275,7 +275,7 @@ bool Emitter::CanEmitNewline() const { return true; }
 
 // Put the stream in a state so we can simply write the next node
 // E.g., if we're in a sequence, write the "- "
-void Emitter::PrepareNode(EmitterNodeType::value child) {
+void Emitter::PrepareNode(EmitterNodeType child) {
   switch (m_pState->CurGroupNodeType()) {
     case EmitterNodeType::NoType:
       PrepareTopNode(child);
@@ -299,7 +299,7 @@ void Emitter::PrepareNode(EmitterNodeType::value child) {
   }
 }
 
-void Emitter::PrepareTopNode(EmitterNodeType::value child) {
+void Emitter::PrepareTopNode(EmitterNodeType child) {
   if (child == EmitterNodeType::NoType)
     return;
 
@@ -325,7 +325,7 @@ void Emitter::PrepareTopNode(EmitterNodeType::value child) {
   }
 }
 
-void Emitter::FlowSeqPrepareNode(EmitterNodeType::value child) {
+void Emitter::FlowSeqPrepareNode(EmitterNodeType child) {
   const std::size_t lastIndent = m_pState->LastIndent();
 
   if (!m_pState->HasBegunNode()) {
@@ -356,7 +356,7 @@ void Emitter::FlowSeqPrepareNode(EmitterNodeType::value child) {
   }
 }
 
-void Emitter::BlockSeqPrepareNode(EmitterNodeType::value child) {
+void Emitter::BlockSeqPrepareNode(EmitterNodeType child) {
   const std::size_t curIndent = m_pState->CurIndent();
   const std::size_t nextIndent = curIndent + m_pState->CurGroupIndent();
 
@@ -390,7 +390,7 @@ void Emitter::BlockSeqPrepareNode(EmitterNodeType::value child) {
   }
 }
 
-void Emitter::FlowMapPrepareNode(EmitterNodeType::value child) {
+void Emitter::FlowMapPrepareNode(EmitterNodeType child) {
   if (m_pState->CurGroupChildCount() % 2 == 0) {
     if (m_pState->GetMapKeyFormat() == LongKey)
       m_pState->SetLongKey();
@@ -407,7 +407,7 @@ void Emitter::FlowMapPrepareNode(EmitterNodeType::value child) {
   }
 }
 
-void Emitter::FlowMapPrepareLongKey(EmitterNodeType::value child) {
+void Emitter::FlowMapPrepareLongKey(EmitterNodeType child) {
   const std::size_t lastIndent = m_pState->LastIndent();
 
   if (!m_pState->HasBegunNode()) {
@@ -438,7 +438,7 @@ void Emitter::FlowMapPrepareLongKey(EmitterNodeType::value child) {
   }
 }
 
-void Emitter::FlowMapPrepareLongKeyValue(EmitterNodeType::value child) {
+void Emitter::FlowMapPrepareLongKeyValue(EmitterNodeType child) {
   const std::size_t lastIndent = m_pState->LastIndent();
 
   if (!m_pState->HasBegunNode()) {
@@ -466,7 +466,7 @@ void Emitter::FlowMapPrepareLongKeyValue(EmitterNodeType::value child) {
   }
 }
 
-void Emitter::FlowMapPrepareSimpleKey(EmitterNodeType::value child) {
+void Emitter::FlowMapPrepareSimpleKey(EmitterNodeType child) {
   const std::size_t lastIndent = m_pState->LastIndent();
 
   if (!m_pState->HasBegunNode()) {
@@ -497,7 +497,7 @@ void Emitter::FlowMapPrepareSimpleKey(EmitterNodeType::value child) {
   }
 }
 
-void Emitter::FlowMapPrepareSimpleKeyValue(EmitterNodeType::value child) {
+void Emitter::FlowMapPrepareSimpleKeyValue(EmitterNodeType child) {
   const std::size_t lastIndent = m_pState->LastIndent();
 
   if (!m_pState->HasBegunNode()) {
@@ -528,7 +528,7 @@ void Emitter::FlowMapPrepareSimpleKeyValue(EmitterNodeType::value child) {
   }
 }
 
-void Emitter::BlockMapPrepareNode(EmitterNodeType::value child) {
+void Emitter::BlockMapPrepareNode(EmitterNodeType child) {
   if (m_pState->CurGroupChildCount() % 2 == 0) {
     if (m_pState->GetMapKeyFormat() == LongKey)
       m_pState->SetLongKey();
@@ -548,7 +548,7 @@ void Emitter::BlockMapPrepareNode(EmitterNodeType::value child) {
   }
 }
 
-void Emitter::BlockMapPrepareLongKey(EmitterNodeType::value child) {
+void Emitter::BlockMapPrepareLongKey(EmitterNodeType child) {
   const std::size_t curIndent = m_pState->CurIndent();
   const std::size_t childCount = m_pState->CurGroupChildCount();
 
@@ -583,7 +583,7 @@ void Emitter::BlockMapPrepareLongKey(EmitterNodeType::value child) {
   }
 }
 
-void Emitter::BlockMapPrepareLongKeyValue(EmitterNodeType::value child) {
+void Emitter::BlockMapPrepareLongKeyValue(EmitterNodeType child) {
   const std::size_t curIndent = m_pState->CurIndent();
 
   if (child == EmitterNodeType::NoType)
@@ -613,7 +613,7 @@ void Emitter::BlockMapPrepareLongKeyValue(EmitterNodeType::value child) {
   }
 }
 
-void Emitter::BlockMapPrepareSimpleKey(EmitterNodeType::value child) {
+void Emitter::BlockMapPrepareSimpleKey(EmitterNodeType child) {
   const std::size_t curIndent = m_pState->CurIndent();
   const std::size_t childCount = m_pState->CurGroupChildCount();
 
@@ -641,7 +641,7 @@ void Emitter::BlockMapPrepareSimpleKey(EmitterNodeType::value child) {
   }
 }
 
-void Emitter::BlockMapPrepareSimpleKeyValue(EmitterNodeType::value child) {
+void Emitter::BlockMapPrepareSimpleKeyValue(EmitterNodeType child) {
   const std::size_t curIndent = m_pState->CurIndent();
   const std::size_t nextIndent = curIndent + m_pState->CurGroupIndent();
 
@@ -702,7 +702,7 @@ void Emitter::StartedScalar() { m_pState->StartedScalar(); }
 // *******************************************************************************************
 // overloads of Write
 
-StringEscaping::value GetStringEscapingStyle(const EMITTER_MANIP emitterManip) {
+StringEscaping GetStringEscapingStyle(const EMITTER_MANIP emitterManip) {
   switch (emitterManip) {
     case EscapeNonAscii:
       return StringEscaping::NonAscii;
@@ -718,9 +718,9 @@ Emitter& Emitter::Write(const std::string& str) {
   if (!good())
     return *this;
 
-  StringEscaping::value stringEscaping = GetStringEscapingStyle(m_pState->GetOutputCharset());
+  StringEscaping stringEscaping = GetStringEscapingStyle(m_pState->GetOutputCharset());
 
-  const StringFormat::value strFormat =
+  const StringFormat strFormat =
       Utils::ComputeStringFormat(str, m_pState->GetStringFormat(),
                                  m_pState->CurGroupFlowType(), stringEscaping == StringEscaping::NonAscii);
 

--- a/src/emitterstate.cpp
+++ b/src/emitterstate.cpp
@@ -95,8 +95,8 @@ void EmitterState::StartedNode() {
   m_hasNonContent = false;
 }
 
-EmitterNodeType::value EmitterState::NextGroupType(
-    GroupType::value type) const {
+EmitterNodeType EmitterState::NextGroupType(
+    GroupType type) const {
   if (type == GroupType::Seq) {
     if (GetFlowType(type) == Block)
       return EmitterNodeType::BlockSeq;
@@ -129,7 +129,7 @@ void EmitterState::StartedScalar() {
   ClearModifiedSettings();
 }
 
-void EmitterState::StartedGroup(GroupType::value type) {
+void EmitterState::StartedGroup(GroupType type) {
   StartedNode();
 
   const std::size_t lastGroupIndent =
@@ -156,7 +156,7 @@ void EmitterState::StartedGroup(GroupType::value type) {
   m_groups.push_back(std::move(pGroup));
 }
 
-void EmitterState::EndedGroup(GroupType::value type) {
+void EmitterState::EndedGroup(GroupType type) {
   if (m_groups.empty()) {
     if (type == GroupType::Seq) {
       return SetError(ErrorMsg::UNEXPECTED_END_SEQ);
@@ -195,7 +195,7 @@ void EmitterState::EndedGroup(GroupType::value type) {
   m_hasNonContent = false;
 }
 
-EmitterNodeType::value EmitterState::CurGroupNodeType() const {
+EmitterNodeType EmitterState::CurGroupNodeType() const {
   if (m_groups.empty()) {
     return EmitterNodeType::NoType;
   }
@@ -203,11 +203,11 @@ EmitterNodeType::value EmitterState::CurGroupNodeType() const {
   return m_groups.back()->NodeType();
 }
 
-GroupType::value EmitterState::CurGroupType() const {
+GroupType EmitterState::CurGroupType() const {
   return m_groups.empty() ? GroupType::NoType : m_groups.back()->type;
 }
 
-FlowType::value EmitterState::CurGroupFlowType() const {
+FlowType EmitterState::CurGroupFlowType() const {
   return m_groups.empty() ? FlowType::NoType : m_groups.back()->flowType;
 }
 
@@ -238,7 +238,7 @@ void EmitterState::RestoreGlobalModifiedSettings() {
 }
 
 bool EmitterState::SetOutputCharset(EMITTER_MANIP value,
-                                    FmtScope::value scope) {
+                                    FmtScope scope) {
   switch (value) {
     case EmitNonAscii:
     case EscapeNonAscii:
@@ -250,7 +250,7 @@ bool EmitterState::SetOutputCharset(EMITTER_MANIP value,
   }
 }
 
-bool EmitterState::SetStringFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetStringFormat(EMITTER_MANIP value, FmtScope scope) {
   switch (value) {
     case Auto:
     case SingleQuoted:
@@ -263,7 +263,7 @@ bool EmitterState::SetStringFormat(EMITTER_MANIP value, FmtScope::value scope) {
   }
 }
 
-bool EmitterState::SetBoolFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetBoolFormat(EMITTER_MANIP value, FmtScope scope) {
   switch (value) {
     case OnOffBool:
     case TrueFalseBool:
@@ -276,7 +276,7 @@ bool EmitterState::SetBoolFormat(EMITTER_MANIP value, FmtScope::value scope) {
 }
 
 bool EmitterState::SetBoolLengthFormat(EMITTER_MANIP value,
-                                       FmtScope::value scope) {
+                                       FmtScope scope) {
   switch (value) {
     case LongBool:
     case ShortBool:
@@ -288,7 +288,7 @@ bool EmitterState::SetBoolLengthFormat(EMITTER_MANIP value,
 }
 
 bool EmitterState::SetBoolCaseFormat(EMITTER_MANIP value,
-                                     FmtScope::value scope) {
+                                     FmtScope scope) {
   switch (value) {
     case UpperCase:
     case LowerCase:
@@ -300,7 +300,7 @@ bool EmitterState::SetBoolCaseFormat(EMITTER_MANIP value,
   }
 }
 
-bool EmitterState::SetNullFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetNullFormat(EMITTER_MANIP value, FmtScope scope) {
   switch (value) {
     case LowerNull:
     case UpperNull:
@@ -313,7 +313,7 @@ bool EmitterState::SetNullFormat(EMITTER_MANIP value, FmtScope::value scope) {
   }
 }
 
-bool EmitterState::SetIntFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetIntFormat(EMITTER_MANIP value, FmtScope scope) {
   switch (value) {
     case Dec:
     case Hex:
@@ -325,7 +325,7 @@ bool EmitterState::SetIntFormat(EMITTER_MANIP value, FmtScope::value scope) {
   }
 }
 
-bool EmitterState::SetIndent(std::size_t value, FmtScope::value scope) {
+bool EmitterState::SetIndent(std::size_t value, FmtScope scope) {
   if (value <= 1)
     return false;
 
@@ -334,7 +334,7 @@ bool EmitterState::SetIndent(std::size_t value, FmtScope::value scope) {
 }
 
 bool EmitterState::SetPreCommentIndent(std::size_t value,
-                                       FmtScope::value scope) {
+                                       FmtScope scope) {
   if (value == 0)
     return false;
 
@@ -343,7 +343,7 @@ bool EmitterState::SetPreCommentIndent(std::size_t value,
 }
 
 bool EmitterState::SetPostCommentIndent(std::size_t value,
-                                        FmtScope::value scope) {
+                                        FmtScope scope) {
   if (value == 0)
     return false;
 
@@ -351,8 +351,8 @@ bool EmitterState::SetPostCommentIndent(std::size_t value,
   return true;
 }
 
-bool EmitterState::SetFlowType(GroupType::value groupType, EMITTER_MANIP value,
-                               FmtScope::value scope) {
+bool EmitterState::SetFlowType(GroupType groupType, EMITTER_MANIP value,
+                               FmtScope scope) {
   switch (value) {
     case Block:
     case Flow:
@@ -363,7 +363,7 @@ bool EmitterState::SetFlowType(GroupType::value groupType, EMITTER_MANIP value,
   }
 }
 
-EMITTER_MANIP EmitterState::GetFlowType(GroupType::value groupType) const {
+EMITTER_MANIP EmitterState::GetFlowType(GroupType groupType) const {
   // force flow style if we're currently in a flow
   if (CurGroupFlowType() == FlowType::Flow)
     return Flow;
@@ -372,7 +372,7 @@ EMITTER_MANIP EmitterState::GetFlowType(GroupType::value groupType) const {
   return (groupType == GroupType::Seq ? m_seqFmt.get() : m_mapFmt.get());
 }
 
-bool EmitterState::SetMapKeyFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetMapKeyFormat(EMITTER_MANIP value, FmtScope scope) {
   switch (value) {
     case Auto:
     case LongKey:
@@ -383,7 +383,7 @@ bool EmitterState::SetMapKeyFormat(EMITTER_MANIP value, FmtScope::value scope) {
   }
 }
 
-bool EmitterState::SetFloatPrecision(std::size_t value, FmtScope::value scope) {
+bool EmitterState::SetFloatPrecision(std::size_t value, FmtScope scope) {
   if (value > std::numeric_limits<float>::max_digits10)
     return false;
   _Set(m_floatPrecision, value, scope);
@@ -391,7 +391,7 @@ bool EmitterState::SetFloatPrecision(std::size_t value, FmtScope::value scope) {
 }
 
 bool EmitterState::SetDoublePrecision(std::size_t value,
-                                      FmtScope::value scope) {
+                                      FmtScope scope) {
   if (value > std::numeric_limits<double>::max_digits10)
     return false;
   _Set(m_doublePrecision, value, scope);

--- a/src/emitterstate.h
+++ b/src/emitterstate.h
@@ -18,15 +18,9 @@
 #include <vector>
 
 namespace YAML {
-struct FmtScope {
-  enum value { Local, Global };
-};
-struct GroupType {
-  enum value { NoType, Seq, Map };
-};
-struct FlowType {
-  enum value { NoType, Flow, Block };
-};
+enum class FmtScope { Local, Global };
+enum class GroupType { NoType, Seq, Map };
+enum class FlowType { NoType, Flow, Block };
 
 class EmitterState {
  public:
@@ -51,14 +45,14 @@ class EmitterState {
   void StartedDoc();
   void EndedDoc();
   void StartedScalar();
-  void StartedGroup(GroupType::value type);
-  void EndedGroup(GroupType::value type);
+  void StartedGroup(GroupType type);
+  void EndedGroup(GroupType type);
 
-  EmitterNodeType::value NextGroupType(GroupType::value type) const;
-  EmitterNodeType::value CurGroupNodeType() const;
+  EmitterNodeType NextGroupType(GroupType type) const;
+  EmitterNodeType CurGroupNodeType() const;
 
-  GroupType::value CurGroupType() const;
-  FlowType::value CurGroupFlowType() const;
+  GroupType CurGroupType() const;
+  FlowType CurGroupFlowType() const;
   std::size_t CurGroupIndent() const;
   std::size_t CurGroupChildCount() const;
   bool CurGroupLongKey() const;
@@ -79,50 +73,50 @@ class EmitterState {
   // formatters
   void SetLocalValue(EMITTER_MANIP value);
 
-  bool SetOutputCharset(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetOutputCharset(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetOutputCharset() const { return m_charset.get(); }
 
-  bool SetStringFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetStringFormat(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetStringFormat() const { return m_strFmt.get(); }
 
-  bool SetBoolFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetBoolFormat(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetBoolFormat() const { return m_boolFmt.get(); }
 
-  bool SetBoolLengthFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetBoolLengthFormat(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetBoolLengthFormat() const { return m_boolLengthFmt.get(); }
 
-  bool SetBoolCaseFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetBoolCaseFormat(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetBoolCaseFormat() const { return m_boolCaseFmt.get(); }
 
-  bool SetNullFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetNullFormat(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetNullFormat() const { return m_nullFmt.get(); }
 
-  bool SetIntFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetIntFormat(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetIntFormat() const { return m_intFmt.get(); }
 
-  bool SetIndent(std::size_t value, FmtScope::value scope);
+  bool SetIndent(std::size_t value, FmtScope scope);
   std::size_t GetIndent() const { return m_indent.get(); }
 
-  bool SetPreCommentIndent(std::size_t value, FmtScope::value scope);
+  bool SetPreCommentIndent(std::size_t value, FmtScope scope);
   std::size_t GetPreCommentIndent() const { return m_preCommentIndent.get(); }
-  bool SetPostCommentIndent(std::size_t value, FmtScope::value scope);
+  bool SetPostCommentIndent(std::size_t value, FmtScope scope);
   std::size_t GetPostCommentIndent() const { return m_postCommentIndent.get(); }
 
-  bool SetFlowType(GroupType::value groupType, EMITTER_MANIP value,
-                   FmtScope::value scope);
-  EMITTER_MANIP GetFlowType(GroupType::value groupType) const;
+  bool SetFlowType(GroupType groupType, EMITTER_MANIP value,
+                   FmtScope scope);
+  EMITTER_MANIP GetFlowType(GroupType groupType) const;
 
-  bool SetMapKeyFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetMapKeyFormat(EMITTER_MANIP value, FmtScope scope);
   EMITTER_MANIP GetMapKeyFormat() const { return m_mapKeyFmt.get(); }
 
-  bool SetFloatPrecision(std::size_t value, FmtScope::value scope);
+  bool SetFloatPrecision(std::size_t value, FmtScope scope);
   std::size_t GetFloatPrecision() const { return m_floatPrecision.get(); }
-  bool SetDoublePrecision(std::size_t value, FmtScope::value scope);
+  bool SetDoublePrecision(std::size_t value, FmtScope scope);
   std::size_t GetDoublePrecision() const { return m_doublePrecision.get(); }
 
  private:
   template <typename T>
-  void _Set(Setting<T>& fmt, T value, FmtScope::value scope);
+  void _Set(Setting<T>& fmt, T value, FmtScope scope);
 
   void StartedNode();
 
@@ -151,7 +145,7 @@ class EmitterState {
   SettingChanges m_globalModifiedSettings;
 
   struct Group {
-    explicit Group(GroupType::value type_)
+    explicit Group(GroupType type_)
         : type(type_),
           flowType{},
           indent(0),
@@ -159,15 +153,15 @@ class EmitterState {
           longKey(false),
           modifiedSettings{} {}
 
-    GroupType::value type;
-    FlowType::value flowType;
+    GroupType type;
+    FlowType flowType;
     std::size_t indent;
     std::size_t childCount;
     bool longKey;
 
     SettingChanges modifiedSettings;
 
-    EmitterNodeType::value NodeType() const {
+    EmitterNodeType NodeType() const {
       if (type == GroupType::Seq) {
         if (flowType == FlowType::Flow)
           return EmitterNodeType::FlowSeq;
@@ -196,7 +190,7 @@ class EmitterState {
 };
 
 template <typename T>
-void EmitterState::_Set(Setting<T>& fmt, T value, FmtScope::value scope) {
+void EmitterState::_Set(Setting<T>& fmt, T value, FmtScope scope) {
   switch (scope) {
     case FmtScope::Local:
       m_modifiedSettings.push(fmt.set(value));

--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -152,7 +152,7 @@ void WriteCodePoint(ostream_wrapper& out, int codePoint) {
   }
 }
 
-bool IsValidPlainScalar(const std::string& str, FlowType::value flowType,
+bool IsValidPlainScalar(const std::string& str, FlowType flowType,
                         bool allowOnlyAscii) {
   // check against null
   if (IsNullString(str)) {
@@ -206,7 +206,7 @@ bool IsValidSingleQuotedScalar(const std::string& str, bool escapeNonAscii) {
   });
 }
 
-bool IsValidLiteralScalar(const std::string& str, FlowType::value flowType,
+bool IsValidLiteralScalar(const std::string& str, FlowType flowType,
                           bool escapeNonAscii) {
   if (flowType == FlowType::Flow) {
     return false;
@@ -227,7 +227,7 @@ std::pair<uint16_t, uint16_t> EncodeUTF16SurrogatePair(int codePoint) {
   };
 }
 
-void WriteDoubleQuoteEscapeSequence(ostream_wrapper& out, int codePoint, StringEscaping::value stringEscapingStyle) {
+void WriteDoubleQuoteEscapeSequence(ostream_wrapper& out, int codePoint, StringEscaping stringEscapingStyle) {
   static const char hexDigits[] = "0123456789abcdef";
 
   out << "\\";
@@ -267,9 +267,9 @@ bool WriteAliasName(ostream_wrapper& out, const std::string& str) {
 }
 }  // namespace
 
-StringFormat::value ComputeStringFormat(const std::string& str,
+StringFormat ComputeStringFormat(const std::string& str,
                                         EMITTER_MANIP strFormat,
-                                        FlowType::value flowType,
+                                        FlowType flowType,
                                         bool escapeNonAscii) {
   switch (strFormat) {
     case Auto:
@@ -317,7 +317,7 @@ bool WriteSingleQuotedString(ostream_wrapper& out, const std::string& str) {
 }
 
 bool WriteDoubleQuotedString(ostream_wrapper& out, const std::string& str,
-                             StringEscaping::value stringEscaping) {
+                             StringEscaping stringEscaping) {
   out << "\"";
   int codePoint;
   for (std::string::const_iterator i = str.begin();
@@ -379,7 +379,7 @@ bool WriteLiteralString(ostream_wrapper& out, const std::string& str,
   return true;
 }
 
-bool WriteChar(ostream_wrapper& out, char ch, StringEscaping::value stringEscapingStyle) {
+bool WriteChar(ostream_wrapper& out, char ch, StringEscaping stringEscapingStyle) {
   if (('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z')) {
     out << ch;
   } else if (ch == '\"') {

--- a/src/emitterutils.h
+++ b/src/emitterutils.h
@@ -20,27 +20,22 @@ class ostream_wrapper;
 namespace YAML {
 class Binary;
 
-struct StringFormat {
-  enum value { Plain, SingleQuoted, DoubleQuoted, Literal };
-};
-
-struct StringEscaping {
-  enum value { None, NonAscii, JSON };
-};
+enum class StringFormat { Plain, SingleQuoted, DoubleQuoted, Literal };
+enum class StringEscaping { None, NonAscii, JSON };
 
 namespace Utils {
-StringFormat::value ComputeStringFormat(const std::string& str,
+StringFormat ComputeStringFormat(const std::string& str,
                                         EMITTER_MANIP strFormat,
-                                        FlowType::value flowType,
+                                        FlowType flowType,
                                         bool escapeNonAscii);
 
 bool WriteSingleQuotedString(ostream_wrapper& out, const std::string& str);
 bool WriteDoubleQuotedString(ostream_wrapper& out, const std::string& str,
-                             StringEscaping::value stringEscaping);
+                             StringEscaping stringEscaping);
 bool WriteLiteralString(ostream_wrapper& out, const std::string& str,
                         std::size_t indent);
 bool WriteChar(ostream_wrapper& out, char ch,
-               StringEscaping::value stringEscapingStyle);
+               StringEscaping stringEscapingStyle);
 bool WriteComment(ostream_wrapper& out, const std::string& str,
                   std::size_t postCommentIndent);
 bool WriteAlias(ostream_wrapper& out, const std::string& str);

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -40,7 +40,7 @@ void node_data::mark_defined() {
 
 void node_data::set_mark(const Mark& mark) { m_mark = mark; }
 
-void node_data::set_type(NodeType::value type) {
+void node_data::set_type(NodeType type) {
   if (type == NodeType::Undefined) {
     m_type = type;
     m_isDefined = false;
@@ -73,7 +73,7 @@ void node_data::set_type(NodeType::value type) {
 
 void node_data::set_tag(const std::string& tag) { m_tag = tag; }
 
-void node_data::set_style(EmitterStyle::value style) { m_style = style; }
+void node_data::set_style(EmitterStyle style) { m_style = style; }
 
 void node_data::set_null() {
   m_isDefined = true;

--- a/src/nodebuilder.cpp
+++ b/src/nodebuilder.cpp
@@ -53,7 +53,7 @@ void NodeBuilder::OnScalar(const Mark& mark, const std::string& tag,
 }
 
 void NodeBuilder::OnSequenceStart(const Mark& mark, const std::string& tag,
-                                  anchor_t anchor, EmitterStyle::value style) {
+                                  anchor_t anchor, EmitterStyle style) {
   detail::node& node = Push(mark, anchor);
   node.set_tag(tag);
   node.set_type(NodeType::Sequence);
@@ -63,7 +63,7 @@ void NodeBuilder::OnSequenceStart(const Mark& mark, const std::string& tag,
 void NodeBuilder::OnSequenceEnd() { Pop(); }
 
 void NodeBuilder::OnMapStart(const Mark& mark, const std::string& tag,
-                             anchor_t anchor, EmitterStyle::value style) {
+                             anchor_t anchor, EmitterStyle style) {
   detail::node& node = Push(mark, anchor);
   node.set_type(NodeType::Map);
   node.set_tag(tag);

--- a/src/nodebuilder.h
+++ b/src/nodebuilder.h
@@ -44,11 +44,11 @@ class NodeBuilder : public EventHandler {
                         anchor_t anchor, const std::string& value) override;
 
   void OnSequenceStart(const Mark& mark, const std::string& tag,
-                               anchor_t anchor, EmitterStyle::value style) override;
+                               anchor_t anchor, EmitterStyle style) override;
   void OnSequenceEnd() override;
 
   void OnMapStart(const Mark& mark, const std::string& tag,
-                          anchor_t anchor, EmitterStyle::value style) override;
+                          anchor_t anchor, EmitterStyle style) override;
   void OnMapEnd() override;
 
  private:

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -16,11 +16,11 @@ class NullEventHandler : public EventHandler {
                         const std::string&) {}
 
   virtual void OnSequenceStart(const Mark&, const std::string&, anchor_t,
-                               EmitterStyle::value /* style */) {}
+                               EmitterStyle /* style */) {}
   virtual void OnSequenceEnd() {}
 
   virtual void OnMapStart(const Mark&, const std::string&, anchor_t,
-                          EmitterStyle::value /* style */) {}
+                          EmitterStyle /* style */) {}
   virtual void OnMapEnd() {}
 };
 

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -267,7 +267,7 @@ TEST(NodeTest, IncompleteJson) {
 
 struct SingleNodeTestCase {
   std::string input;
-  NodeType::value nodeType;
+  NodeType nodeType;
   int nodeSize;
   std::string expected_content;
 };

--- a/test/mock_event_handler.h
+++ b/test/mock_event_handler.h
@@ -19,11 +19,11 @@ class MockEventHandler : public EventHandler {
                               const std::string&));
 
   MOCK_METHOD4(OnSequenceStart, void(const Mark&, const std::string&, anchor_t,
-                                     EmitterStyle::value));
+                                     EmitterStyle));
   MOCK_METHOD0(OnSequenceEnd, void());
 
   MOCK_METHOD4(OnMapStart, void(const Mark&, const std::string&, anchor_t,
-                                EmitterStyle::value));
+                                EmitterStyle));
   MOCK_METHOD0(OnMapEnd, void());
   MOCK_METHOD2(OnAnchor, void(const Mark&, const std::string&));
 };

--- a/util/parse.cpp
+++ b/util/parse.cpp
@@ -29,11 +29,11 @@ class NullEventHandler : public YAML::EventHandler {
                 const std::string&) override {}
 
   void OnSequenceStart(const YAML::Mark&, const std::string&, YAML::anchor_t,
-                       YAML::EmitterStyle::value) override {}
+                       YAML::EmitterStyle) override {}
   void OnSequenceEnd() override {}
 
   void OnMapStart(const YAML::Mark&, const std::string&, YAML::anchor_t,
-                  YAML::EmitterStyle::value) override {}
+                  YAML::EmitterStyle) override {}
   void OnMapEnd() override {}
 };
 

--- a/util/read.cpp
+++ b/util/read.cpp
@@ -20,10 +20,10 @@ class NullEventHandler : public YAML::EventHandler {
   void OnScalar(const Mark&, const std::string&, anchor_t,
                 const std::string&) override {}
   void OnSequenceStart(const Mark&, const std::string&, anchor_t,
-                       YAML::EmitterStyle::value style) override {}
+                       YAML::EmitterStyle style) override {}
   void OnSequenceEnd() override {}
   void OnMapStart(const Mark&, const std::string&, anchor_t,
-                  YAML::EmitterStyle::value style) override {}
+                  YAML::EmitterStyle style) override {}
   void OnMapEnd() override {}
 };
 

--- a/util/sandbox.cpp
+++ b/util/sandbox.cpp
@@ -18,10 +18,10 @@ class NullEventHandler : public YAML::EventHandler {
   void OnScalar(const Mark&, const std::string&, anchor_t,
                 const std::string&) override {}
   void OnSequenceStart(const Mark&, const std::string&, anchor_t,
-                       YAML::EmitterStyle::value style) override {}
+                       YAML::EmitterStyle style) override {}
   void OnSequenceEnd() override {}
   void OnMapStart(const Mark&, const std::string&, anchor_t,
-                  YAML::EmitterStyle::value style) override {}
+                  YAML::EmitterStyle style) override {}
   void OnMapEnd() override {}
 };
 


### PR DESCRIPTION
This changes some constructs like this
```
    struct FmtScope {
      enum value { Local, Global };
    };
    struct GroupType {
      enum value { NoType, Seq, Map };
    };
    struct FlowType {
      enum value { NoType, Flow, Block };
    };
```
into this
```
    enum class FmtScope { Local, Global };
    enum class GroupType { NoType, Seq, Map };
    enum class FlowType { NoType, Flow, Block };
```
The full list of pseudo enum classes now turned into real enum classes:
```
enum class State { WaitingForSequenceEntry, WaitingForKey, WaitingForValue };
enum class EmitterNodeType { NoType, Property, Scalar, FlowSeq, BlockSeq, FlowMap, BlockMap };
enum class Type { Verbatim, PrimaryHandle, NamedHandle };
enum class EmitterStyle { Default, Block, Flow };
enum class iterator_type { NoneType, Sequence, Map };
enum class NodeType { Undefined, Null, Scalar, Sequence, Map };
enum class CollectionType { NoCollection, BlockMap, BlockSeq, FlowMap, FlowSeq, CompactMap };
enum class FmtScope { Local, Global };
enum class GroupType { NoType, Seq, Map };
enum class FlowType { NoType, Flow, Block };
enum class StringFormat { Plain, SingleQuoted, DoubleQuoted, Literal };
enum class StringEscaping { None, NonAscii, JSON };
```
Signed-off-by: Ted Lyngmo <ted@lyncon.se>