### PR TITLE
Make enum's into enum classes

### DIFF
--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -327,7 +327,7 @@ inline const Node Node::operator[](const Key& key) const {
   detail::node* value =
       static_cast<const detail::node&>(*m_pNode).get(key, m_pMemory);
   if (!value) {
-    return Node(ZombieNode, key_to_string(key));
+    return Node(Zombie::ZombieNode, key_to_string(key));
   }
   return Node(*value, m_pMemory);
 }
@@ -352,7 +352,7 @@ inline const Node Node::operator[](const Node& key) const {
   detail::node* value =
       static_cast<const detail::node&>(*m_pNode).get(*key.m_pNode, m_pMemory);
   if (!value) {
-    return Node(ZombieNode, key_to_string(key));
+    return Node(Zombie::ZombieNode, key_to_string(key));
   }
   return Node(*value, m_pMemory);
 }

--- a/include/yaml-cpp/node/iterator.h
+++ b/include/yaml-cpp/node/iterator.h
@@ -21,9 +21,9 @@ struct iterator_value : public Node, std::pair<Node, Node> {
   iterator_value() = default;
   explicit iterator_value(const Node& rhs)
       : Node(rhs),
-        std::pair<Node, Node>(Node(Node::ZombieNode), Node(Node::ZombieNode)) {}
+        std::pair<Node, Node>(Node(Node::Zombie::ZombieNode), Node(Node::Zombie::ZombieNode)) {}
   explicit iterator_value(const Node& key, const Node& value)
-      : Node(Node::ZombieNode), std::pair<Node, Node>(key, value) {}
+      : Node(Node::Zombie::ZombieNode), std::pair<Node, Node>(key, value) {}
 };
 }
 }

--- a/include/yaml-cpp/node/node.h
+++ b/include/yaml-cpp/node/node.h
@@ -114,7 +114,7 @@ class YAML_CPP_API Node {
   void force_insert(const Key& key, const Value& value);
 
  private:
-  enum Zombie { ZombieNode };
+  enum class Zombie { ZombieNode };
   explicit Node(Zombie);
   explicit Node(Zombie, const std::string&);
   explicit Node(detail::node& node, detail::shared_memory_holder pMemory);

--- a/include/yaml-cpp/traits.h
+++ b/include/yaml-cpp/traits.h
@@ -15,71 +15,71 @@
 namespace YAML {
 template <typename>
 struct is_numeric {
-  enum { value = false };
+  static constexpr bool value = false;
 };
 
 template <>
 struct is_numeric<char> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 template <>
 struct is_numeric<unsigned char> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 template <>
 struct is_numeric<int> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 template <>
 struct is_numeric<unsigned int> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 template <>
 struct is_numeric<long int> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 template <>
 struct is_numeric<unsigned long int> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 template <>
 struct is_numeric<short int> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 template <>
 struct is_numeric<unsigned short int> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 #if defined(_MSC_VER) && (_MSC_VER < 1310)
 template <>
 struct is_numeric<__int64> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 template <>
 struct is_numeric<unsigned __int64> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 #else
 template <>
 struct is_numeric<long long> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 template <>
 struct is_numeric<unsigned long long> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 #endif
 template <>
 struct is_numeric<float> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 template <>
 struct is_numeric<double> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 template <>
 struct is_numeric<long double> {
-  enum { value = true };
+  static constexpr bool value = true;
 };
 
 template <bool, class T = void>

--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -15,7 +15,7 @@
 namespace YAML {
 namespace Utils {
 namespace {
-enum { REPLACEMENT_CHARACTER = 0xFFFD };
+constexpr int REPLACEMENT_CHARACTER = 0xFFFD;
 
 bool IsAnchorChar(int ch) {  // test for ns-anchor-char
   switch (ch) {

--- a/src/exp.h
+++ b/src/exp.h
@@ -69,7 +69,7 @@ inline const RegEx& Hex() {
 inline const RegEx& NotPrintable() {
   static const RegEx e =
       RegEx(0) |
-      RegEx("\x01\x02\x03\x04\x05\x06\x07\x08\x0B\x0C\x7F", REGEX_OR) |
+      RegEx("\x01\x02\x03\x04\x05\x06\x07\x08\x0B\x0C\x7F", REGEX_OP::REGEX_OR) |
       RegEx(0x0E, 0x1F) |
       (RegEx('\xC2') + (RegEx('\x80', '\x84') | RegEx('\x86', '\x9F')));
   return e;
@@ -110,7 +110,7 @@ inline const RegEx& Value() {
   return e;
 }
 inline const RegEx& ValueInFlow() {
-  static const RegEx e = RegEx(':') + (BlankOrBreak() | RegEx(",]}", REGEX_OR));
+  static const RegEx e = RegEx(':') + (BlankOrBreak() | RegEx(",]}", REGEX_OP::REGEX_OR));
   return e;
 }
 inline const RegEx& ValueInJSONFlow() {
@@ -122,20 +122,20 @@ inline const RegEx Comment() {
   return e;
 }
 inline const RegEx& Anchor() {
-  static const RegEx e = !(RegEx("[]{},", REGEX_OR) | BlankOrBreak());
+  static const RegEx e = !(RegEx("[]{},", REGEX_OP::REGEX_OR) | BlankOrBreak());
   return e;
 }
 inline const RegEx& AnchorEnd() {
-  static const RegEx e = RegEx("?:,]}%@`", REGEX_OR) | BlankOrBreak();
+  static const RegEx e = RegEx("?:,]}%@`", REGEX_OP::REGEX_OR) | BlankOrBreak();
   return e;
 }
 inline const RegEx& URI() {
-  static const RegEx e = Word() | RegEx("#;/?:@&=+$,_.!~*'()[]", REGEX_OR) |
+  static const RegEx e = Word() | RegEx("#;/?:@&=+$,_.!~*'()[]", REGEX_OP::REGEX_OR) |
                          (RegEx('%') + Hex() + Hex());
   return e;
 }
 inline const RegEx& Tag() {
-  static const RegEx e = Word() | RegEx("#;/?:@&=+$_.~*'()", REGEX_OR) |
+  static const RegEx e = Word() | RegEx("#;/?:@&=+$_.~*'()", REGEX_OP::REGEX_OR) |
                          (RegEx('%') + Hex() + Hex());
   return e;
 }
@@ -148,14 +148,14 @@ inline const RegEx& Tag() {
 // space.
 inline const RegEx& PlainScalar() {
   static const RegEx e =
-      !(BlankOrBreak() | RegEx(",[]{}#&*!|>\'\"%@`", REGEX_OR) |
-        (RegEx("-?:", REGEX_OR) + (BlankOrBreak() | RegEx())));
+      !(BlankOrBreak() | RegEx(",[]{}#&*!|>\'\"%@`", REGEX_OP::REGEX_OR) |
+        (RegEx("-?:", REGEX_OP::REGEX_OR) + (BlankOrBreak() | RegEx())));
   return e;
 }
 inline const RegEx& PlainScalarInFlow() {
   static const RegEx e =
-      !(BlankOrBreak() | RegEx("?,[]{}#&*!|>\'\"%@`", REGEX_OR) |
-        (RegEx("-:", REGEX_OR) + (Blank() | RegEx())));
+      !(BlankOrBreak() | RegEx("?,[]{}#&*!|>\'\"%@`", REGEX_OP::REGEX_OR) |
+        (RegEx("-:", REGEX_OP::REGEX_OR) + (Blank() | RegEx())));
   return e;
 }
 inline const RegEx& EndScalar() {
@@ -164,8 +164,8 @@ inline const RegEx& EndScalar() {
 }
 inline const RegEx& EndScalarInFlow() {
   static const RegEx e =
-      (RegEx(':') + (BlankOrBreak() | RegEx() | RegEx(",]}", REGEX_OR))) |
-      RegEx(",?[]{}", REGEX_OR);
+      (RegEx(':') + (BlankOrBreak() | RegEx() | RegEx(",]}", REGEX_OP::REGEX_OR))) |
+      RegEx(",?[]{}", REGEX_OP::REGEX_OR);
   return e;
 }
 
@@ -188,7 +188,7 @@ inline const RegEx& EscBreak() {
 }
 
 inline const RegEx& ChompIndicator() {
-  static const RegEx e = RegEx("+-", REGEX_OR);
+  static const RegEx e = RegEx("+-", REGEX_OP::REGEX_OR);
   return e;
 }
 inline const RegEx& Chomp() {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -43,7 +43,7 @@ void Parser::ParseDirectives() {
 
   while (!m_pScanner->empty()) {
     Token& token = m_pScanner->peek();
-    if (token.type != Token::DIRECTIVE) {
+    if (token.type != Token::TYPE::DIRECTIVE) {
       break;
     }
 

--- a/src/regex_yaml.cpp
+++ b/src/regex_yaml.cpp
@@ -4,38 +4,38 @@ namespace YAML {
 // constructors
 
 RegEx::RegEx(REGEX_OP op) : m_op(op), m_a(0), m_z(0), m_params{} {}
-RegEx::RegEx() : RegEx(REGEX_EMPTY) {}
+RegEx::RegEx() : RegEx(REGEX_OP::REGEX_EMPTY) {}
 
-RegEx::RegEx(char ch) : m_op(REGEX_MATCH), m_a(ch), m_z(0), m_params{} {}
+RegEx::RegEx(char ch) : m_op(REGEX_OP::REGEX_MATCH), m_a(ch), m_z(0), m_params{} {}
 
-RegEx::RegEx(char a, char z) : m_op(REGEX_RANGE), m_a(a), m_z(z), m_params{} {}
+RegEx::RegEx(char a, char z) : m_op(REGEX_OP::REGEX_RANGE), m_a(a), m_z(z), m_params{} {}
 
 RegEx::RegEx(const std::string& str, REGEX_OP op)
     : m_op(op), m_a(0), m_z(0), m_params(str.begin(), str.end()) {}
 
 // combination constructors
 RegEx operator!(const RegEx& ex) {
-  RegEx ret(REGEX_NOT);
+  RegEx ret(REGEX_OP::REGEX_NOT);
   ret.m_params.push_back(ex);
   return ret;
 }
 
 RegEx operator|(const RegEx& ex1, const RegEx& ex2) {
-  RegEx ret(REGEX_OR);
+  RegEx ret(REGEX_OP::REGEX_OR);
   ret.m_params.push_back(ex1);
   ret.m_params.push_back(ex2);
   return ret;
 }
 
 RegEx operator&(const RegEx& ex1, const RegEx& ex2) {
-  RegEx ret(REGEX_AND);
+  RegEx ret(REGEX_OP::REGEX_AND);
   ret.m_params.push_back(ex1);
   ret.m_params.push_back(ex2);
   return ret;
 }
 
 RegEx operator+(const RegEx& ex1, const RegEx& ex2) {
-  RegEx ret(REGEX_SEQ);
+  RegEx ret(REGEX_OP::REGEX_SEQ);
   ret.m_params.push_back(ex1);
   ret.m_params.push_back(ex2);
   return ret;

--- a/src/regex_yaml.h
+++ b/src/regex_yaml.h
@@ -15,7 +15,7 @@
 namespace YAML {
 class Stream;
 
-enum REGEX_OP {
+enum class REGEX_OP {
   REGEX_EMPTY,
   REGEX_MATCH,
   REGEX_RANGE,
@@ -33,7 +33,7 @@ class YAML_CPP_API RegEx {
   RegEx();
   explicit RegEx(char ch);
   RegEx(char a, char z);
-  RegEx(const std::string& str, REGEX_OP op = REGEX_SEQ);
+  RegEx(const std::string& str, REGEX_OP op = REGEX_OP::REGEX_SEQ);
   ~RegEx() = default;
 
   friend YAML_CPP_API RegEx operator!(const RegEx& ex);

--- a/src/regeximpl.h
+++ b/src/regeximpl.h
@@ -56,8 +56,8 @@ template <>
 inline bool RegEx::IsValidSource<StringCharSource>(
     const StringCharSource& source) const {
   switch (m_op) {
-    case REGEX_MATCH:
-    case REGEX_RANGE:
+    case REGEX_OP::REGEX_MATCH:
+    case REGEX_OP::REGEX_RANGE:
       return source;
     default:
       return true;
@@ -72,19 +72,19 @@ inline int RegEx::Match(const Source& source) const {
 template <typename Source>
 inline int RegEx::MatchUnchecked(const Source& source) const {
   switch (m_op) {
-    case REGEX_EMPTY:
+    case REGEX_OP::REGEX_EMPTY:
       return MatchOpEmpty(source);
-    case REGEX_MATCH:
+    case REGEX_OP::REGEX_MATCH:
       return MatchOpMatch(source);
-    case REGEX_RANGE:
+    case REGEX_OP::REGEX_RANGE:
       return MatchOpRange(source);
-    case REGEX_OR:
+    case REGEX_OP::REGEX_OR:
       return MatchOpOr(source);
-    case REGEX_AND:
+    case REGEX_OP::REGEX_AND:
       return MatchOpAnd(source);
-    case REGEX_NOT:
+    case REGEX_OP::REGEX_NOT:
       return MatchOpNot(source);
-    case REGEX_SEQ:
+    case REGEX_OP::REGEX_SEQ:
       return MatchOpSeq(source);
   }
 

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -56,12 +56,12 @@ void Scanner::EnsureTokensInQueue() {
       Token& token = m_tokens.front();
 
       // if this guy's valid, then we're done
-      if (token.status == Token::VALID) {
+      if (token.status == Token::STATUS::VALID) {
         return;
       }
 
       // here's where we clean up the impossible tokens
-      if (token.status == Token::INVALID) {
+      if (token.status == Token::STATUS::INVALID) {
         m_tokens.pop();
         continue;
       }
@@ -246,7 +246,7 @@ void Scanner::StartStream() {
   m_startedStream = true;
   m_simpleKeyAllowed = true;
   std::unique_ptr<IndentMarker> pIndent(
-      new IndentMarker(-1, IndentMarker::NONE));
+      new IndentMarker(-1, IndentMarker::INDENT_TYPE::NONE));
   m_indentRefs.push_back(std::move(pIndent));
   m_indents.push(&m_indentRefs.back());
 }
@@ -271,11 +271,11 @@ Token* Scanner::PushToken(Token::TYPE type) {
 
 Token::TYPE Scanner::GetStartTokenFor(IndentMarker::INDENT_TYPE type) const {
   switch (type) {
-    case IndentMarker::SEQ:
-      return Token::BLOCK_SEQ_START;
-    case IndentMarker::MAP:
-      return Token::BLOCK_MAP_START;
-    case IndentMarker::NONE:
+    case IndentMarker::INDENT_TYPE::SEQ:
+      return Token::TYPE::BLOCK_SEQ_START;
+    case IndentMarker::INDENT_TYPE::MAP:
+      return Token::TYPE::BLOCK_MAP_START;
+    case IndentMarker::INDENT_TYPE::NONE:
       assert(false);
       break;
   }
@@ -299,8 +299,8 @@ Scanner::IndentMarker* Scanner::PushIndentTo(int column,
     return nullptr;
   }
   if (indent.column == lastIndent.column &&
-      !(indent.type == IndentMarker::SEQ &&
-        lastIndent.type == IndentMarker::MAP)) {
+      !(indent.type == IndentMarker::INDENT_TYPE::SEQ &&
+        lastIndent.type == IndentMarker::INDENT_TYPE::MAP)) {
     return nullptr;
   }
 
@@ -326,7 +326,7 @@ void Scanner::PopIndentToHere() {
       break;
     }
     if (indent.column == INPUT.column() &&
-        !(indent.type == IndentMarker::SEQ &&
+        !(indent.type == IndentMarker::INDENT_TYPE::SEQ &&
           !Exp::BlockEntry().Matches(INPUT))) {
       break;
     }
@@ -335,7 +335,7 @@ void Scanner::PopIndentToHere() {
   }
 
   while (!m_indents.empty() &&
-         m_indents.top()->status == IndentMarker::INVALID) {
+         m_indents.top()->status == IndentMarker::STATUS::INVALID) {
     PopIndent();
   }
 }
@@ -349,7 +349,7 @@ void Scanner::PopAllIndents() {
   // now pop away
   while (!m_indents.empty()) {
     const IndentMarker& indent = *m_indents.top();
-    if (indent.type == IndentMarker::NONE) {
+    if (indent.type == IndentMarker::INDENT_TYPE::NONE) {
       break;
     }
 
@@ -361,15 +361,15 @@ void Scanner::PopIndent() {
   const IndentMarker& indent = *m_indents.top();
   m_indents.pop();
 
-  if (indent.status != IndentMarker::VALID) {
+  if (indent.status != IndentMarker::STATUS::VALID) {
     InvalidateSimpleKey();
     return;
   }
 
-  if (indent.type == IndentMarker::SEQ) {
-    m_tokens.push(Token(Token::BLOCK_SEQ_END, INPUT.mark()));
-  } else if (indent.type == IndentMarker::MAP) {
-    m_tokens.push(Token(Token::BLOCK_MAP_END, INPUT.mark()));
+  if (indent.type == IndentMarker::INDENT_TYPE::SEQ) {
+    m_tokens.push(Token(Token::TYPE::BLOCK_SEQ_END, INPUT.mark()));
+  } else if (indent.type == IndentMarker::INDENT_TYPE::MAP) {
+    m_tokens.push(Token(Token::TYPE::BLOCK_MAP_END, INPUT.mark()));
   }
 }
 

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -46,10 +46,10 @@ class Scanner {
 
  private:
   struct IndentMarker {
-    enum INDENT_TYPE { MAP, SEQ, NONE };
-    enum STATUS { VALID, INVALID, UNKNOWN };
+    enum class INDENT_TYPE { MAP, SEQ, NONE };
+    enum class STATUS { VALID, INVALID, UNKNOWN };
     IndentMarker(int column_, INDENT_TYPE type_)
-        : column(column_), type(type_), status(VALID), pStartToken(nullptr) {}
+        : column(column_), type(type_), status(STATUS::VALID), pStartToken(nullptr) {}
 
     int column;
     INDENT_TYPE type;
@@ -57,7 +57,7 @@ class Scanner {
     Token *pStartToken;
   };
 
-  enum FLOW_MARKER { FLOW_MAP, FLOW_SEQ };
+  enum class FLOW_MARKER { FLOW_MAP, FLOW_SEQ };
 
  private:
   // scanning

--- a/src/scanscalar.h
+++ b/src/scanscalar.h
@@ -13,9 +13,9 @@
 #include "stream.h"
 
 namespace YAML {
-enum CHOMP { STRIP = -1, CLIP, KEEP };
-enum ACTION { NONE, BREAK, THROW };
-enum FOLD { DONT_FOLD, FOLD_BLOCK, FOLD_FLOW };
+enum class CHOMP { STRIP = -1, CLIP, KEEP };
+enum class ACTION { NONE, BREAK, THROW };
+enum class FOLD { DONT_FOLD, FOLD_BLOCK, FOLD_FLOW };
 
 struct ScanScalarParams {
   ScanScalarParams()
@@ -25,11 +25,11 @@ struct ScanScalarParams {
         detectIndent(false),
         eatLeadingWhitespace(0),
         escape(0),
-        fold(DONT_FOLD),
+        fold(FOLD::DONT_FOLD),
         trimTrailingSpaces(0),
-        chomp(CLIP),
-        onDocIndicator(NONE),
-        onTabInIndentation(NONE),
+        chomp(CHOMP::CLIP),
+        onDocIndicator(ACTION::NONE),
+        onTabInIndentation(ACTION::NONE),
         leadingSpaces(false) {}
 
   // input:

--- a/src/simplekey.cpp
+++ b/src/simplekey.cpp
@@ -16,20 +16,20 @@ void Scanner::SimpleKey::Validate() {
   //       we "garbage collect" them so we can
   //       always refer to them
   if (pIndent)
-    pIndent->status = IndentMarker::VALID;
+    pIndent->status = IndentMarker::STATUS::VALID;
   if (pMapStart)
-    pMapStart->status = Token::VALID;
+    pMapStart->status = Token::STATUS::VALID;
   if (pKey)
-    pKey->status = Token::VALID;
+    pKey->status = Token::STATUS::VALID;
 }
 
 void Scanner::SimpleKey::Invalidate() {
   if (pIndent)
-    pIndent->status = IndentMarker::INVALID;
+    pIndent->status = IndentMarker::STATUS::INVALID;
   if (pMapStart)
-    pMapStart->status = Token::INVALID;
+    pMapStart->status = Token::STATUS::INVALID;
   if (pKey)
-    pKey->status = Token::INVALID;
+    pKey->status = Token::STATUS::INVALID;
 }
 
 // CanInsertPotentialSimpleKey
@@ -63,18 +63,18 @@ void Scanner::InsertPotentialSimpleKey() {
 
   // first add a map start, if necessary
   if (InBlockContext()) {
-    key.pIndent = PushIndentTo(INPUT.column(), IndentMarker::MAP);
+    key.pIndent = PushIndentTo(INPUT.column(), IndentMarker::INDENT_TYPE::MAP);
     if (key.pIndent) {
-      key.pIndent->status = IndentMarker::UNKNOWN;
+      key.pIndent->status = IndentMarker::STATUS::UNKNOWN;
       key.pMapStart = key.pIndent->pStartToken;
-      key.pMapStart->status = Token::UNVERIFIED;
+      key.pMapStart->status = Token::STATUS::UNVERIFIED;
     }
   }
 
   // then add the (now unverified) key
-  m_tokens.push(Token(Token::KEY, INPUT.mark()));
+  m_tokens.push(Token(Token::TYPE::KEY, INPUT.mark()));
   key.pKey = &m_tokens.back();
-  key.pKey->status = Token::UNVERIFIED;
+  key.pKey->status = Token::STATUS::UNVERIFIED;
 
   m_simpleKeys.push(key);
 }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -218,22 +218,22 @@ Stream::Stream(std::istream& input)
 
   switch (state) {
     case uis_utf8:
-      m_charSet = utf8;
+      m_charSet = CharacterSet::utf8;
       break;
     case uis_utf16le:
-      m_charSet = utf16le;
+      m_charSet = CharacterSet::utf16le;
       break;
     case uis_utf16be:
-      m_charSet = utf16be;
+      m_charSet = CharacterSet::utf16be;
       break;
     case uis_utf32le:
-      m_charSet = utf32le;
+      m_charSet = CharacterSet::utf32le;
       break;
     case uis_utf32be:
-      m_charSet = utf32be;
+      m_charSet = CharacterSet::utf32be;
       break;
     default:
-      m_charSet = utf8;
+      m_charSet = CharacterSet::utf8;
       break;
   }
 
@@ -301,19 +301,19 @@ void Stream::AdvanceCurrent() {
 bool Stream::_ReadAheadTo(size_t i) const {
   while (m_input.good() && (m_readahead.size() <= i)) {
     switch (m_charSet) {
-      case utf8:
+      case CharacterSet::utf8:
         StreamInUtf8();
         break;
-      case utf16le:
+      case CharacterSet::utf16le:
         StreamInUtf16();
         break;
-      case utf16be:
+      case CharacterSet::utf16be:
         StreamInUtf16();
         break;
-      case utf32le:
+      case CharacterSet::utf32le:
         StreamInUtf32();
         break;
-      case utf32be:
+      case CharacterSet::utf32be:
         StreamInUtf32();
         break;
     }
@@ -336,7 +336,7 @@ void Stream::StreamInUtf8() const {
 void Stream::StreamInUtf16() const {
   unsigned long ch = 0;
   unsigned char bytes[2];
-  int nBigEnd = (m_charSet == utf16be) ? 0 : 1;
+  int nBigEnd = (m_charSet == CharacterSet::utf16be) ? 0 : 1;
 
   bytes[0] = GetNextByte();
   bytes[1] = GetNextByte();
@@ -426,7 +426,7 @@ void Stream::StreamInUtf32() const {
 
   unsigned long ch = 0;
   unsigned char bytes[4];
-  int* pIndexes = (m_charSet == utf32be) ? indexes[1] : indexes[0];
+  int* pIndexes = (m_charSet == CharacterSet::utf32be) ? indexes[1] : indexes[0];
 
   bytes[0] = GetNextByte();
   bytes[1] = GetNextByte();

--- a/src/stream.h
+++ b/src/stream.h
@@ -47,7 +47,7 @@ class Stream {
   void ResetColumn() { m_mark.column = 0; }
 
  private:
-  enum CharacterSet { utf8, utf16le, utf16be, utf32le, utf32be };
+  enum class CharacterSet { utf8, utf16le, utf16be, utf32le, utf32be };
 
   std::istream& m_input;
   Mark m_mark;

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -9,20 +9,20 @@ namespace YAML {
 Tag::Tag(const Token& token)
     : type(static_cast<TYPE>(token.data)), handle{}, value{} {
   switch (type) {
-    case VERBATIM:
+    case TYPE::VERBATIM:
       value = token.value;
       break;
-    case PRIMARY_HANDLE:
+    case TYPE::PRIMARY_HANDLE:
       value = token.value;
       break;
-    case SECONDARY_HANDLE:
+    case TYPE::SECONDARY_HANDLE:
       value = token.value;
       break;
-    case NAMED_HANDLE:
+    case TYPE::NAMED_HANDLE:
       handle = token.value;
       value = token.params[0];
       break;
-    case NON_SPECIFIC:
+    case TYPE::NON_SPECIFIC:
       break;
     default:
       assert(false);
@@ -31,15 +31,15 @@ Tag::Tag(const Token& token)
 
 const std::string Tag::Translate(const Directives& directives) {
   switch (type) {
-    case VERBATIM:
+    case TYPE::VERBATIM:
       return value;
-    case PRIMARY_HANDLE:
+    case TYPE::PRIMARY_HANDLE:
       return directives.TranslateTagHandle("!") + value;
-    case SECONDARY_HANDLE:
+    case TYPE::SECONDARY_HANDLE:
       return directives.TranslateTagHandle("!!") + value;
-    case NAMED_HANDLE:
+    case TYPE::NAMED_HANDLE:
       return directives.TranslateTagHandle("!" + handle + "!") + value;
-    case NON_SPECIFIC:
+    case TYPE::NON_SPECIFIC:
       // TODO:
       return "!";
     default:

--- a/src/tag.h
+++ b/src/tag.h
@@ -14,7 +14,7 @@ struct Directives;
 struct Token;
 
 struct Tag {
-  enum TYPE {
+  enum class TYPE {
     VERBATIM,
     PRIMARY_HANDLE,
     SECONDARY_HANDLE,

--- a/src/token.h
+++ b/src/token.h
@@ -22,8 +22,8 @@ const std::string TokenNames[] = {
 
 struct Token {
   // enums
-  enum STATUS { VALID, INVALID, UNVERIFIED };
-  enum TYPE {
+  enum class STATUS { VALID, INVALID, UNVERIFIED };
+  enum class TYPE {
     DIRECTIVE,
     DOC_START,
     DOC_END,
@@ -49,10 +49,10 @@ struct Token {
 
   // data
   Token(TYPE type_, const Mark& mark_)
-      : status(VALID), type(type_), mark(mark_), value{}, params{}, data(0) {}
+      : status(STATUS::VALID), type(type_), mark(mark_), value{}, params{}, data(0) {}
 
   friend std::ostream& operator<<(std::ostream& out, const Token& token) {
-    out << TokenNames[token.type] << std::string(": ") << token.value;
+    out << TokenNames[static_cast<int>(token.type)] << std::string(": ") << token.value;
     for (const std::string& param : token.params)
       out << std::string(" ") << param;
     return out;

--- a/test/regex_test.cpp
+++ b/test/regex_test.cpp
@@ -165,7 +165,7 @@ TEST(RegExTest, OperatorPlus) {
 
 TEST(RegExTest, StringOr) {
   std::string str = "abcde";
-  RegEx ex = RegEx(str, YAML::REGEX_OR);
+  RegEx ex = RegEx(str, YAML::REGEX_OP::REGEX_OR);
 
   for (size_t i = 0; i < str.size(); ++i) {
     EXPECT_TRUE(ex.Matches(str.substr(i, 1)));


### PR DESCRIPTION
This makes all `enum`'s into `enum class`es except for:

* The internal enum's in `src/stream.cpp`:
    ```
    UtfIntroState
    UtfIntroCharType
    ```
* `EMITTER_MANIP` (covered separately in #989)
* Pseudo enum's (covered separately in #990)

Signed-off-by: Ted Lyngmo <ted@lyncon.se>