### PR TITLE
Prevent trailing spaces when emitting literal strings

### DIFF
--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -366,13 +366,13 @@ bool WriteDoubleQuotedString(ostream_wrapper& out, const std::string& str,
 bool WriteLiteralString(ostream_wrapper& out, const std::string& str,
                         std::size_t indent) {
   out << "|\n";
-  out << IndentTo(indent);
   int codePoint;
   for (std::string::const_iterator i = str.begin();
        GetNextCodePointAndAdvance(codePoint, i, str.end());) {
     if (codePoint == '\n') {
-      out << "\n" << IndentTo(indent);
+      out << "\n";
     } else {
+      out<< IndentTo(indent);
       WriteCodePoint(out, codePoint);
     }
   }

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -382,6 +382,20 @@ TEST_F(EmitterTest, ScalarFormat) {
       "crazy\tsymbols that we like");
 }
 
+TEST_F(EmitterTest, LiteralWithoutTrailingSpaces) {
+  out << YAML::BeginMap;
+  out << YAML::Key << "key";
+  out << YAML::Literal;
+  out << "expect that with two newlines\n\n"
+         "no spaces are emitted in the empty line";
+  out << YAML::EndMap;
+
+  ExpectEmit(
+      "key: |\n"
+      "  expect that with two newlines\n\n"
+      "  no spaces are emitted in the empty line");
+}
+
 TEST_F(EmitterTest, AutoLongKeyScalar) {
   out << BeginMap;
   out << Key << Literal << "multi-line\nscalar";

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -385,7 +385,7 @@ TEST_F(EmitterTest, ScalarFormat) {
 TEST_F(EmitterTest, LiteralWithoutTrailingSpaces) {
   out << YAML::BeginMap;
   out << YAML::Key << "key";
-  out << YAML::Literal;
+  out << YAML::Value << YAML::Literal;
   out << "expect that with two newlines\n\n"
          "no spaces are emitted in the empty line";
   out << YAML::EndMap;

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -769,17 +769,5 @@ TEST_F(NodeEmitterTest, NestFlowMapListNode) {
 
   ExpectOutput("{position: [1.5, 2.25, 3.125]}", mapNode);
 }
-
-TEST_F(NodeEmitterTest, LiteralWithoutTrailingSpaces) {
-  YAML::Emitter emitter;
-  emitter << YAML::BeginMap;
-  emitter << YAML::Key << "key";
-  emitter << YAML::Literal;
-  emitter << "value\n\nwith newlines";
-  emitter << YAML::EndMap;
-
-  ASSERT_TRUE(emitter.good());
-  EXPECT_STREQ("key: |\n  value\n\n  with newlines", emitter.c_str());
-}
 }
 }

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -769,5 +769,17 @@ TEST_F(NodeEmitterTest, NestFlowMapListNode) {
 
   ExpectOutput("{position: [1.5, 2.25, 3.125]}", mapNode);
 }
+
+TEST_F(NodeEmitterTest, LiteralWithoutTrailingSpaces) {
+  YAML::Emitter emitter;
+  emitter << YAML::BeginMap;
+  emitter << YAML::Key << "key";
+  emitter << YAML::Literal;
+  emitter << "value\n\nwith newlines";
+  emitter << YAML::EndMap;
+
+  ASSERT_TRUE(emitter.good());
+  EXPECT_STREQ("key: |\n  value\n\n  with newlines", emitter.c_str());
+}
 }
 }


### PR DESCRIPTION
This behavior matches the format expectations of the Red Hat yaml
language server.