### PR TITLE
Implement a customization point for types not default constructible

### DIFF
--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -41,6 +41,23 @@ template <class T> using CustomVector = std::vector<T,CustomAllocator<T>>;
 template <class T> using CustomList = std::list<T,CustomAllocator<T>>;
 template <class K, class V, class C=std::less<K>> using CustomMap = std::map<K,V,C,CustomAllocator<std::pair<const K,V>>>;
 
+struct Vec3 {
+  double x, y, z;
+  bool operator==(const Vec3& rhs) const {
+    return x == rhs.x && y == rhs.y && z == rhs.z;
+  }
+};
+
+#ifdef YAML_CPP_HAS_DECODE_DISPATCHER
+struct NonDefCtorVec3 {
+  double x, y, z;
+  NonDefCtorVec3(double x, double y, double z) : x(x), y(y), z(z) {}
+  bool operator==(const NonDefCtorVec3& rhs) const {
+    return x == rhs.x && y == rhs.y && z == rhs.z;
+  }
+};
+#endif
+
 }  // anonymous namespace
 
 using ::testing::AnyOf;
@@ -55,6 +72,41 @@ using ::testing::Eq;
   }
 
 namespace YAML {
+
+template<>
+struct convert<Vec3> {
+  static Node encode(const Vec3& rhs) {
+    Node node;
+    node.push_back(rhs.x);
+    node.push_back(rhs.y);
+    node.push_back(rhs.z);
+    return node;
+  }
+
+  static bool decode(const Node& node, Vec3& rhs) {
+    if(!node.IsSequence() || node.size() != 3) {
+      return false;
+    }
+
+    rhs.x = node[0].as<double>();
+    rhs.y = node[1].as<double>();
+    rhs.z = node[2].as<double>();
+    return true;
+  }
+};
+
+#ifdef YAML_CPP_HAS_DECODE_DISPATCHER
+template <>
+struct decode_dispatcher<NonDefCtorVec3> {
+  static std::optional<NonDefCtorVec3> dispatch(const Node& node) {
+    if (!node.IsSequence() || node.size() != 3) {
+      return std::nullopt;
+    }
+    return {{node[0].as<double>(), node[1].as<double>(), node[2].as<double>()}};
+  }
+};
+#endif
+
 namespace {
 TEST(NodeTest, SimpleScalar) {
   Node node = Node("Hello, World!");
@@ -643,6 +695,28 @@ TEST(NodeTest, AccessNonexistentKeyOnConstNode) {
   node["3"] = "4";
   const YAML::Node& other = node;
   ASSERT_FALSE(other["5"]);
+}
+
+TEST(NodeTest, CustomClassDecoding) {
+  YAML::Node node;
+  node.push_back(1.0);
+  node.push_back(2.0);
+  node.push_back(3.0);
+  ASSERT_TRUE(node.IsSequence());
+  EXPECT_EQ(node.as<Vec3>(), (Vec3{1.0, 2.0, 3.0}));
+}
+
+TEST(NodeTest, CustomNonDefaultConstructibleClassDecoding) {
+#ifdef YAML_CPP_HAS_DECODE_DISPATCHER
+  YAML::Node node;
+  node.push_back(1.0);
+  node.push_back(2.0);
+  node.push_back(3.0);
+  ASSERT_TRUE(node.IsSequence());
+  EXPECT_EQ(node.as<NonDefCtorVec3>(), (NonDefCtorVec3{1.0, 2.0, 3.0}));
+#else
+  GTEST_SKIP() << "Compile with C++17 for customizing non-default-constructible custom types.";
+#endif
 }
 
 class NodeEmitterTest : public ::testing::Test {


### PR DESCRIPTION
This patch adds a customization point `YAML::decode_dispatcher<T>::dispatch` which:

- allows decoding types that aren't default constructible,
- delegates to `YAML::convert<T>::decode` by default for backward compatibility,
- is enabled only when compiled with C++17 or newer since it depends on `std::optional`.

Notes:

- Compiling with C++17 automatically enables this feature.
- Relevant tests are added. Tested it locally (gcc 10.2 on debian buster) to confirm all tests passes with both C++11 & C++17.
- `YAML_CPP_HAS_DECODE_DISPATCHER` macro is exposed allowing checking this feature.
- Its signature has an `Enable` template parameter giving more flexibility, e.g. to allow SFINAE downstream:
```cpp
namespace YAML {
template <typename T, typename Enable = void>
struct decode_dispatcher {
  static std::optional<T> dispatch(const Node& node) {
   // ...
  }
};
}
```

Example:

  ```cpp
  #include <yaml-cpp/node/impl.h>

  struct Vec3 {
    double x, y, z;
    Vec3(double x, double y, double z) : x(x), y(y), z(z) {}
    // ...
  };

  namespace YAML {
  template<>
  struct decode_dispatcher<Vec3> {
    static std::optional<Vec3> dispatch(const Node& node) {
      if(!node.IsSequence() || node.size() != 3)
        return std::nullopt;
      return Vec3(
        node[0].as<double>(),
        node[1].as<double>(),
        node[2].as<double>()
      );
    }
  };
  }
  ```

Possibly closes: #993.