### PR TITLE
bump minimum cmake versions in gtest 

### DIFF
--- a/test/gtest-1.10.0/CMakeLists.txt
+++ b/test/gtest-1.10.0/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Note: CMake support is community-based. The maintainers do not use CMake
 # internally.
 
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 2.9)
 
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/test/gtest-1.10.0/googlemock/CMakeLists.txt
+++ b/test/gtest-1.10.0/googlemock/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
   cmake_policy(SET CMP0048 NEW)
   project(gmock VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 2.9)
 
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()

--- a/test/gtest-1.10.0/googletest/CMakeLists.txt
+++ b/test/gtest-1.10.0/googletest/CMakeLists.txt
@@ -53,7 +53,7 @@ else()
   cmake_policy(SET CMP0048 NEW)
   project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 2.9)
 
 if (POLICY CMP0063) # Visibility
   cmake_policy(SET CMP0063 NEW)


### PR DESCRIPTION
bump minimum cmake versions in gtest to eliminate cmake deprecation warnings