### PR TITLE
include name of anchor in invalid anchor error

### DIFF
--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -65,7 +65,7 @@ const char* const ZERO_INDENT_IN_BLOCK =
 const char* const CHAR_IN_BLOCK = "unexpected character in block scalar";
 const char* const AMBIGUOUS_ANCHOR =
     "cannot assign the same alias to multiple nodes";
-const char* const UNKNOWN_ANCHOR = "the referenced anchor is not defined";
+const char* const UNKNOWN_ANCHOR = "the referenced anchor is not defined: ";
 
 const char* const INVALID_NODE =
     "invalid node; this may result from using a map iterator as a sequence "

--- a/src/singledocparser.cpp
+++ b/src/singledocparser.cpp
@@ -424,8 +424,11 @@ anchor_t SingleDocParser::RegisterAnchor(const std::string& name) {
 anchor_t SingleDocParser::LookupAnchor(const Mark& mark,
                                        const std::string& name) const {
   auto it = m_anchors.find(name);
-  if (it == m_anchors.end())
-    throw ParserException(mark, ErrorMsg::UNKNOWN_ANCHOR);
+  if (it == m_anchors.end()) {
+    std::stringstream ss;
+    ss << ErrorMsg::UNKNOWN_ANCHOR << name;
+    throw ParserException(mark, ss.str());
+  }
 
   return it->second;
 }


### PR DESCRIPTION
This includes the name of the anchor that we failed to lookup, making it easier to understand the cause of the error