### PR TITLE
Create target "format" by default only if yaml-cpp is main cmake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ cmake_dependent_option(YAML_CPP_INSTALL
 cmake_dependent_option(YAML_MSVC_SHARED_RT
   "MSVC: Build yaml-cpp with shared runtime libs (/MD)" ON
   "MSVC" OFF)
+cmake_dependent_option(YAML_CPP_ENABLE_FORMAT
+  "Enable format target" ON
+  "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
 set(yaml-cpp-type STATIC)
 set(yaml-cpp-label-postfix "static")
@@ -165,7 +168,7 @@ if(YAML_CPP_BUILD_TOOLS)
 	add_subdirectory(util)
 endif()
 
-if (YAML_CPP_CLANG_FORMAT_EXE)
+if (YAML_CPP_ENABLE_FORMAT AND YAML_CPP_CLANG_FORMAT_EXE)
   add_custom_target(format
     COMMAND clang-format --style=file -i $<TARGET_PROPERTY:yaml-cpp,SOURCES>
     COMMAND_EXPAND_LISTS


### PR DESCRIPTION
## Use Case

I included yaml-cpp with [`FetchContent`](https://cmake.org/cmake/help/latest/module/FetchContent.html).
I don't want to have in my targets, a `format` target that do not format my main project.

## Fix

I introduce cmake option `YAML_CPP_ENABLE_FORMAT` that is ON by default when yaml-cpp is root project, and OFF otherwise.
Then target `format` is created `if (YAML_CPP_ENABLE_FORMAT AND YAML_CPP_CLANG_FORMAT_EXE)`