### PR TITLE
Update cmakelists to use system googletest if available.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
           os: [ubuntu-latest, windows-latest, macos-latest]
           cxx_standard: [11, 17, 20]
           build: [static, shared]
+          googletest: [build, system]
           generator: ["Default Generator", "MinGW Makefiles"]
           exclude:
           - os: macos-latest
@@ -25,14 +26,26 @@ jobs:
             generator: "MinGW Makefiles"
           - os: ubuntu-latest
             generator: "MinGW Makefiles"
+          - os: macos-latest
+            googletest: system
+          - os: windows-latest
+            googletest: system
       env:
         YAML_BUILD_SHARED_LIBS: ${{ matrix.build == 'shared' && 'ON' || 'OFF' }}
+        YAML_USE_SYSTEM_GTEST: ${{ matrix.googletest == 'system' && 'ON' || 'OFF' }}
         CMAKE_GENERATOR: >-
           ${{format(matrix.generator != 'Default Generator' && '-G "{0}"' || '', matrix.generator)}}
         CMAKE_INSTALL_PREFIX: "${{ github.workspace }}/install-prefix"
         CMAKE_BUILD_TYPE: Debug
       runs-on: ${{ matrix.os }}
       steps:
+
+        - uses: awalsh128/cache-apt-pkgs-action@latest
+          if: matrix.os == 'ubuntu-latest'
+          with:
+            packages: googletest libgmock-dev libgtest-dev
+            version: 1.0
+
         - uses: actions/checkout@v3
 
         - name: Configure
@@ -45,6 +58,7 @@ jobs:
               -D CMAKE_INSTALL_PREFIX="${{ env.CMAKE_INSTALL_PREFIX }}" \
               -D CMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
               -D YAML_BUILD_SHARED_LIBS=${{ env.YAML_BUILD_SHARED_LIBS }} \
+              -D YAML_USE_SYSTEM_GTEST=${{ env.YAML_USE_SYSTEM_GTEST }} \
               -D YAML_CPP_BUILD_TESTS=ON
 
         - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ option(YAML_BUILD_SHARED_LIBS "Build yaml-cpp shared library" ${BUILD_SHARED_LIB
 option(YAML_CPP_INSTALL "Enable generation of yaml-cpp install targets" ${YAML_CPP_MAIN_PROJECT})
 option(YAML_CPP_FORMAT_SOURCE "Format source" ${YAML_CPP_MAIN_PROJECT})
 option(YAML_CPP_DISABLE_UNINSTALL  "Disable uninstallation of yaml-cpp" OFF)
+option(YAML_USE_SYSTEM_GTEST "Use system googletest if found" OFF)
 
 cmake_dependent_option(YAML_CPP_BUILD_TESTS
   "Enable yaml-cpp tests" OFF

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,11 +4,17 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 set(BUILD_MOCK ON CACHE BOOL "" FORCE)
 set(CMAKE_POLICY_DEFAULT_CMP0048 NEW)
 
-add_subdirectory(
-  "${CMAKE_CURRENT_SOURCE_DIR}/gtest-1.11.0"
-  "${CMAKE_CURRENT_BINARY_DIR}/prefix")
-
-include_directories(SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/gtest-1.11.0/googletest/include")
+if(YAML_USE_SYSTEM_GTEST)
+  find_package(GTest)
+  if (NOT GTEST_FOUND)
+    message(FATAL_ERROR "system googletest was requested but not found")
+  endif()
+else()
+    add_subdirectory(
+      "${CMAKE_CURRENT_SOURCE_DIR}/gtest-1.11.0"
+      "${CMAKE_CURRENT_BINARY_DIR}/prefix")
+    include_directories(SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/gtest-1.11.0/googletest/include")
+endif()
 
 set(test-new-api-pattern "new-api/*.cpp")
 set(test-source-pattern "*.cpp" "integration/*.cpp" "node/*.cpp")
@@ -38,6 +44,7 @@ target_link_libraries(yaml-cpp-tests
   PRIVATE
     Threads::Threads
     yaml-cpp
+    gtest
     gmock)
 
 set_property(TARGET yaml-cpp-tests PROPERTY CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
There is no need to use the embedded gtest code copy in Linux systems, if they already provide the googletest framework system-wide.
Search for it, and fallback to the embedded one if the system one is not detected.

This patch has been also contributed by Simon Quigley <tsimonq2@debian.org>