### PR TITLE
test appveyor with shared libraries for dll export/import

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
 before_build:
    - cmd: mkdir build
    - cmd: cd build
-   - cmd: cmake .. -G "%CMAKE_GENERATOR%" -DCMAKE_GENERATOR_PLATFORM=%CMAKE_PLATFORM%
+   - cmd: cmake .. -G "%CMAKE_GENERATOR%" -DCMAKE_GENERATOR_PLATFORM=%CMAKE_PLATFORM% -DYAML_BUILD_SHARED_LIBS=ON
    - cmd: cd ..
 
 build_script:


### PR DESCRIPTION
I'm getting 

```
p\\src\\node_data.cpp(16): error C2370: 'm_amount': redefinition; different storage class
p\\include\yaml-cpp/node/detail/node.h(172): note: see declaration of 'm_amount'
```

so checking if it's a general "cmake" thing too