### PR TITLE
Use static_cast<unsigned char> on DecodeBase64 to prevent SEGV on negative values

### DIFF
--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -79,7 +79,7 @@ std::vector<unsigned char> DecodeBase64(const std::string &input) {
       // skip newlines
       continue;
     }
-    unsigned char d = decoding[static_cast<unsigned>(input[i])];
+    unsigned char d = decoding[static_cast<unsigned char>(input[i])];
     if (d == 255)
       return ret_type();
 

--- a/test/binary_test.cpp
+++ b/test/binary_test.cpp
@@ -1,0 +1,14 @@
+#include "gtest/gtest.h"
+#include <yaml-cpp/binary.h>
+
+TEST(BinaryTest, DecodingSimple) {
+  std::string input{90, 71, 86, 104, 90, 71, 74, 108, 90, 87, 89, 61};
+  const std::vector<unsigned char> &result = YAML::DecodeBase64(input);
+  EXPECT_EQ(std::string(result.begin(), result.end()), "deadbeef");
+}
+
+TEST(BinaryTest, DecodingNoCrashOnNegative) {
+  std::string input{-58, -1, -99, 109};
+  const std::vector<unsigned char> &result = YAML::DecodeBase64(input);
+  EXPECT_TRUE(result.empty());
+}


### PR DESCRIPTION
Hi,
I found that `DecodeBase64` would crash on input string with negative values,
if the `static_cast` is performed with target type `unsigned` (instead of `unsigned char`).

Although this is a minor thing, let me know if there's anything more I can help with this patch.
Thank you.