### PR TITLE
redef with diff storage class in VS

### DIFF
--- a/include/yaml-cpp/node/detail/node.h
+++ b/include/yaml-cpp/node/detail/node.h
@@ -169,7 +169,7 @@ class node {
   using nodes = std::set<node*, less>;
   nodes m_dependencies;
   size_t m_index;
-  static std::atomic<size_t> m_amount;
+  static YAML_CPP_API std::atomic<size_t> m_amount;
 };
 }  // namespace detail
 }  // namespace YAML


### PR DESCRIPTION
\yaml\src\node_data.cpp(16): error C2370: 'm_amount': redefinition; different storage class
\yaml\include\yaml-cpp/node/detail/node.h(172): note: see declaration of 'm_amount'