### PR TITLE
Install pkgconfig and cmake files into arch-dependent locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,9 +142,7 @@ set_target_properties(yaml-cpp PROPERTIES
   PROJECT_LABEL "yaml-cpp ${yaml-cpp-label-postfix}"
   DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
 
-# FIXME(felix2012): A more common place for the cmake export would be
-# `CMAKE_INSTALL_LIBDIR`, as e.g. done in ubuntu or in this project for GTest
-set(CONFIG_EXPORT_DIR "${CMAKE_INSTALL_DATADIR}/cmake/yaml-cpp")
+set(CONFIG_EXPORT_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/yaml-cpp")
 set(EXPORT_TARGETS yaml-cpp)
 configure_package_config_file(
   "${PROJECT_SOURCE_DIR}/yaml-cpp-config.cmake.in"
@@ -175,7 +173,7 @@ if (YAML_CPP_INSTALL)
       "${PROJECT_BINARY_DIR}/yaml-cpp-config-version.cmake"
     DESTINATION "${CONFIG_EXPORT_DIR}")
   install(FILES "${PROJECT_BINARY_DIR}/yaml-cpp.pc"
-    DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig)
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
 unset(CONFIG_EXPORT_DIR)
 


### PR DESCRIPTION
This restores the CMake / installed files behaviour of version 0.6.3 which changed in 0.7.0, resulting in arch-dependent files ending up in /usr/share instead of $prefix/libdir. This is required on multiarch/cross layouts setting the prefix to e.g.  `/usr/x86_64-pc-linux-gnu` or `/usr/i686-pc-linux-gnu` so a pkg-config file in /usr/share like

```
prefix=/usr/x86_64-pc-linux-gnu
exec_prefix=${prefix}
includedir=${prefix}/include
libdir=${exec_prefix}/lib

Name: Yaml-cpp
Description: A YAML parser and emitter for C++
Version: 0.7.0
Requires:
Libs: -L${libdir} -lyaml-cpp
Cflags: -I${includedir}
```

would be wrong as it contains arch-specific code.