### PR TITLE
Fix .pc paths for absolute GNUInstallDirs

### DIFF
--- a/yaml-cpp.pc.in
+++ b/yaml-cpp.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 
 Name: Yaml-cpp
 Description: A YAML parser and emitter for C++


### PR DESCRIPTION
GNUInstallDirs provided may be absolute paths, in which case appending
to the install prefix is not correct. We can instead use the provided
CMAKE_INSTALL_FULL_* variables, which are precomputed absolute paths.

https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html