### PR TITLE
Fix for current version of G++11

### DIFF
--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -31,63 +31,63 @@ const std::string Emitter::GetLastError() const {
 
 // global setters
 bool Emitter::SetOutputCharset(EMITTER_MANIP value) {
-  return m_pState->SetOutputCharset(value, FmtScope::Global);
+  return m_pState->SetOutputCharset(value, FmtScopeTypeValue::Global);
 }
 
 bool Emitter::SetStringFormat(EMITTER_MANIP value) {
-  return m_pState->SetStringFormat(value, FmtScope::Global);
+  return m_pState->SetStringFormat(value, FmtScopeTypeValue::Global);
 }
 
 bool Emitter::SetBoolFormat(EMITTER_MANIP value) {
   bool ok = false;
-  if (m_pState->SetBoolFormat(value, FmtScope::Global))
+  if (m_pState->SetBoolFormat(value, FmtScopeTypeValue::Global))
     ok = true;
-  if (m_pState->SetBoolCaseFormat(value, FmtScope::Global))
+  if (m_pState->SetBoolCaseFormat(value, FmtScopeTypeValue::Global))
     ok = true;
-  if (m_pState->SetBoolLengthFormat(value, FmtScope::Global))
+  if (m_pState->SetBoolLengthFormat(value, FmtScopeTypeValue::Global))
     ok = true;
   return ok;
 }
 
 bool Emitter::SetNullFormat(EMITTER_MANIP value) {
-  return m_pState->SetNullFormat(value, FmtScope::Global);
+  return m_pState->SetNullFormat(value, FmtScopeTypeValue::Global);
 }
 
 bool Emitter::SetIntBase(EMITTER_MANIP value) {
-  return m_pState->SetIntFormat(value, FmtScope::Global);
+  return m_pState->SetIntFormat(value, FmtScopeTypeValue::Global);
 }
 
 bool Emitter::SetSeqFormat(EMITTER_MANIP value) {
-  return m_pState->SetFlowType(GroupType::Seq, value, FmtScope::Global);
+  return m_pState->SetFlowType(GroupTypeValue::Seq, value, FmtScopeTypeValue::Global);
 }
 
 bool Emitter::SetMapFormat(EMITTER_MANIP value) {
   bool ok = false;
-  if (m_pState->SetFlowType(GroupType::Map, value, FmtScope::Global))
+  if (m_pState->SetFlowType(GroupTypeValue::Map, value, FmtScopeTypeValue::Global))
     ok = true;
-  if (m_pState->SetMapKeyFormat(value, FmtScope::Global))
+  if (m_pState->SetMapKeyFormat(value, FmtScopeTypeValue::Global))
     ok = true;
   return ok;
 }
 
 bool Emitter::SetIndent(std::size_t n) {
-  return m_pState->SetIndent(n, FmtScope::Global);
+  return m_pState->SetIndent(n, FmtScopeTypeValue::Global);
 }
 
 bool Emitter::SetPreCommentIndent(std::size_t n) {
-  return m_pState->SetPreCommentIndent(n, FmtScope::Global);
+  return m_pState->SetPreCommentIndent(n, FmtScopeTypeValue::Global);
 }
 
 bool Emitter::SetPostCommentIndent(std::size_t n) {
-  return m_pState->SetPostCommentIndent(n, FmtScope::Global);
+  return m_pState->SetPostCommentIndent(n, FmtScopeTypeValue::Global);
 }
 
 bool Emitter::SetFloatPrecision(std::size_t n) {
-  return m_pState->SetFloatPrecision(n, FmtScope::Global);
+  return m_pState->SetFloatPrecision(n, FmtScopeTypeValue::Global);
 }
 
 bool Emitter::SetDoublePrecision(std::size_t n) {
-  return m_pState->SetDoublePrecision(n, FmtScope::Global);
+  return m_pState->SetDoublePrecision(n, FmtScopeTypeValue::Global);
 }
 
 void Emitter::RestoreGlobalModifiedSettings() {
@@ -137,15 +137,15 @@ Emitter& Emitter::SetLocalValue(EMITTER_MANIP value) {
 }
 
 Emitter& Emitter::SetLocalIndent(const _Indent& indent) {
-  m_pState->SetIndent(indent.value, FmtScope::Local);
+  m_pState->SetIndent(indent.value, FmtScopeTypeValue::Local);
   return *this;
 }
 
 Emitter& Emitter::SetLocalPrecision(const _Precision& precision) {
   if (precision.floatPrecision >= 0)
-    m_pState->SetFloatPrecision(precision.floatPrecision, FmtScope::Local);
+    m_pState->SetFloatPrecision(precision.floatPrecision, FmtScopeTypeValue::Local);
   if (precision.doublePrecision >= 0)
-    m_pState->SetDoublePrecision(precision.doublePrecision, FmtScope::Local);
+    m_pState->SetDoublePrecision(precision.doublePrecision, FmtScopeTypeValue::Local);
   return *this;
 }
 
@@ -154,7 +154,7 @@ void Emitter::EmitBeginDoc() {
   if (!good())
     return;
 
-  if (m_pState->CurGroupType() != GroupType::NoType) {
+  if (m_pState->CurGroupType() != GroupTypeValue::NoType) {
     m_pState->SetError("Unexpected begin document");
     return;
   }
@@ -176,7 +176,7 @@ void Emitter::EmitEndDoc() {
   if (!good())
     return;
 
-  if (m_pState->CurGroupType() != GroupType::NoType) {
+  if (m_pState->CurGroupType() != GroupTypeValue::NoType) {
     m_pState->SetError("Unexpected begin document");
     return;
   }
@@ -196,25 +196,25 @@ void Emitter::EmitBeginSeq() {
   if (!good())
     return;
 
-  PrepareNode(m_pState->NextGroupType(GroupType::Seq));
+  PrepareNode(m_pState->NextGroupType(GroupTypeValue::Seq));
 
-  m_pState->StartedGroup(GroupType::Seq);
+  m_pState->StartedGroup(GroupTypeValue::Seq);
 }
 
 // EmitEndSeq
 void Emitter::EmitEndSeq() {
   if (!good())
     return;
-  FlowType::value originalType = m_pState->CurGroupFlowType();
+  FlowTypeValue originalType = m_pState->CurGroupFlowType();
 
   if (m_pState->CurGroupChildCount() == 0)
     m_pState->ForceFlow();
 
-  if (m_pState->CurGroupFlowType() == FlowType::Flow) {
+  if (m_pState->CurGroupFlowType() == FlowTypeValue::Flow) {
     if (m_stream.comment())
       m_stream << "\n";
     m_stream << IndentTo(m_pState->CurIndent());
-    if (originalType == FlowType::Block) {
+    if (originalType ==FlowTypeValue::Block) {
       m_stream << "[";
     } else {
       if (m_pState->CurGroupChildCount() == 0 && !m_pState->HasBegunNode())
@@ -223,7 +223,7 @@ void Emitter::EmitEndSeq() {
     m_stream << "]";
   }
 
-  m_pState->EndedGroup(GroupType::Seq);
+  m_pState->EndedGroup(GroupTypeValue::Seq);
 }
 
 // EmitBeginMap
@@ -231,25 +231,25 @@ void Emitter::EmitBeginMap() {
   if (!good())
     return;
 
-  PrepareNode(m_pState->NextGroupType(GroupType::Map));
+  PrepareNode(m_pState->NextGroupType(GroupTypeValue::Map));
 
-  m_pState->StartedGroup(GroupType::Map);
+  m_pState->StartedGroup(GroupTypeValue::Map);
 }
 
 // EmitEndMap
 void Emitter::EmitEndMap() {
   if (!good())
     return;
-  FlowType::value originalType = m_pState->CurGroupFlowType();
+  FlowTypeValue originalType = m_pState->CurGroupFlowType();
 
   if (m_pState->CurGroupChildCount() == 0)
     m_pState->ForceFlow();
 
-  if (m_pState->CurGroupFlowType() == FlowType::Flow) {
+  if (m_pState->CurGroupFlowType() == FlowTypeValue::Flow) {
     if (m_stream.comment())
       m_stream << "\n";
     m_stream << IndentTo(m_pState->CurIndent());
-    if (originalType == FlowType::Block) {
+    if (originalType == FlowTypeValue::Block) {
       m_stream << "{";
     } else {
       if (m_pState->CurGroupChildCount() == 0 && !m_pState->HasBegunNode())
@@ -258,7 +258,7 @@ void Emitter::EmitEndMap() {
     m_stream << "}";
   }
 
-  m_pState->EndedGroup(GroupType::Map);
+  m_pState->EndedGroup(GroupTypeValue::Map);
 }
 
 // EmitNewline
@@ -720,12 +720,12 @@ Emitter& Emitter::Write(const std::string& str) {
 
   StringEscaping::value stringEscaping = GetStringEscapingStyle(m_pState->GetOutputCharset());
 
-  const StringFormat::value strFormat =
+  const StringFormat strFormat =
       Utils::ComputeStringFormat(str, m_pState->GetStringFormat(),
                                  m_pState->CurGroupFlowType(), stringEscaping == StringEscaping::NonAscii);
 
   if (strFormat == StringFormat::Literal || str.size() > 1024)
-    m_pState->SetMapKeyFormat(YAML::LongKey, FmtScope::Local);
+    m_pState->SetMapKeyFormat(YAML::LongKey, FmtScopeTypeValue::Local);
 
   PrepareNode(EmitterNodeType::Scalar);
 

--- a/src/emitterstate.cpp
+++ b/src/emitterstate.cpp
@@ -40,16 +40,16 @@ EmitterState::~EmitterState() = default;
 // . We blindly tries to set all possible formatters to this value
 // . Only the ones that make sense will be accepted
 void EmitterState::SetLocalValue(EMITTER_MANIP value) {
-  SetOutputCharset(value, FmtScope::Local);
-  SetStringFormat(value, FmtScope::Local);
-  SetBoolFormat(value, FmtScope::Local);
-  SetBoolCaseFormat(value, FmtScope::Local);
-  SetBoolLengthFormat(value, FmtScope::Local);
-  SetNullFormat(value, FmtScope::Local);
-  SetIntFormat(value, FmtScope::Local);
-  SetFlowType(GroupType::Seq, value, FmtScope::Local);
-  SetFlowType(GroupType::Map, value, FmtScope::Local);
-  SetMapKeyFormat(value, FmtScope::Local);
+  SetOutputCharset(value, FmtScopeTypeValue::Local);
+  SetStringFormat(value, FmtScopeTypeValue::Local);
+  SetBoolFormat(value, FmtScopeTypeValue::Local);
+  SetBoolCaseFormat(value, FmtScopeTypeValue::Local);
+  SetBoolLengthFormat(value, FmtScopeTypeValue::Local);
+  SetNullFormat(value, FmtScopeTypeValue::Local);
+  SetIntFormat(value, FmtScopeTypeValue::Local);
+  SetFlowType(GroupTypeValue::Seq, value, FmtScopeTypeValue::Local);
+  SetFlowType(GroupTypeValue::Map, value, FmtScopeTypeValue::Local);
+  SetMapKeyFormat(value, FmtScopeTypeValue::Local);
 }
 
 void EmitterState::SetAnchor() { m_hasAnchor = true; }
@@ -66,7 +66,7 @@ void EmitterState::SetLongKey() {
     return;
   }
 
-  assert(m_groups.back()->type == GroupType::Map);
+  assert(m_groups.back()->type == GroupTypeValue::Map);
   m_groups.back()->longKey = true;
 }
 
@@ -76,7 +76,7 @@ void EmitterState::ForceFlow() {
     return;
   }
 
-  m_groups.back()->flowType = FlowType::Flow;
+  m_groups.back()->flowType = FlowTypeValue::Flow;
 }
 
 void EmitterState::StartedNode() {
@@ -96,8 +96,8 @@ void EmitterState::StartedNode() {
 }
 
 EmitterNodeType::value EmitterState::NextGroupType(
-    GroupType::value type) const {
-  if (type == GroupType::Seq) {
+    GroupTypeValue type) const {
+  if (type == GroupTypeValue::Seq) {
     if (GetFlowType(type) == Block)
       return EmitterNodeType::BlockSeq;
     return EmitterNodeType::FlowSeq;
@@ -129,7 +129,7 @@ void EmitterState::StartedScalar() {
   ClearModifiedSettings();
 }
 
-void EmitterState::StartedGroup(GroupType::value type) {
+void EmitterState::StartedGroup(GroupTypeValue type) {
   StartedNode();
 
   const std::size_t lastGroupIndent =
@@ -147,18 +147,18 @@ void EmitterState::StartedGroup(GroupType::value type) {
 
   // set up group
   if (GetFlowType(type) == Block) {
-    pGroup->flowType = FlowType::Block;
+    pGroup->flowType = FlowTypeValue::Block;
   } else {
-    pGroup->flowType = FlowType::Flow;
+    pGroup->flowType = FlowTypeValue::Flow;
   }
   pGroup->indent = GetIndent();
 
   m_groups.push_back(std::move(pGroup));
 }
 
-void EmitterState::EndedGroup(GroupType::value type) {
+void EmitterState::EndedGroup(GroupTypeValue type) {
   if (m_groups.empty()) {
-    if (type == GroupType::Seq) {
+    if (type == GroupTypeValue::Seq) {
       return SetError(ErrorMsg::UNEXPECTED_END_SEQ);
     }
     return SetError(ErrorMsg::UNEXPECTED_END_MAP);
@@ -203,12 +203,12 @@ EmitterNodeType::value EmitterState::CurGroupNodeType() const {
   return m_groups.back()->NodeType();
 }
 
-GroupType::value EmitterState::CurGroupType() const {
-  return m_groups.empty() ? GroupType::NoType : m_groups.back()->type;
+GroupTypeValue EmitterState::CurGroupType() const {
+  return m_groups.empty() ? GroupTypeValue::NoType : m_groups.back()->type;
 }
 
-FlowType::value EmitterState::CurGroupFlowType() const {
-  return m_groups.empty() ? FlowType::NoType : m_groups.back()->flowType;
+FlowTypeValue EmitterState::CurGroupFlowType() const {
+  return m_groups.empty() ? FlowTypeValue::NoType : m_groups.back()->flowType;
 }
 
 std::size_t EmitterState::CurGroupIndent() const {
@@ -238,7 +238,7 @@ void EmitterState::RestoreGlobalModifiedSettings() {
 }
 
 bool EmitterState::SetOutputCharset(EMITTER_MANIP value,
-                                    FmtScope::value scope) {
+                                    FmtScopeTypeValue scope) {
   switch (value) {
     case EmitNonAscii:
     case EscapeNonAscii:
@@ -250,7 +250,7 @@ bool EmitterState::SetOutputCharset(EMITTER_MANIP value,
   }
 }
 
-bool EmitterState::SetStringFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetStringFormat(EMITTER_MANIP value, FmtScopeTypeValue scope) {
   switch (value) {
     case Auto:
     case SingleQuoted:
@@ -263,7 +263,7 @@ bool EmitterState::SetStringFormat(EMITTER_MANIP value, FmtScope::value scope) {
   }
 }
 
-bool EmitterState::SetBoolFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetBoolFormat(EMITTER_MANIP value, FmtScopeTypeValue scope) {
   switch (value) {
     case OnOffBool:
     case TrueFalseBool:
@@ -276,7 +276,7 @@ bool EmitterState::SetBoolFormat(EMITTER_MANIP value, FmtScope::value scope) {
 }
 
 bool EmitterState::SetBoolLengthFormat(EMITTER_MANIP value,
-                                       FmtScope::value scope) {
+                                       FmtScopeTypeValue scope) {
   switch (value) {
     case LongBool:
     case ShortBool:
@@ -288,7 +288,7 @@ bool EmitterState::SetBoolLengthFormat(EMITTER_MANIP value,
 }
 
 bool EmitterState::SetBoolCaseFormat(EMITTER_MANIP value,
-                                     FmtScope::value scope) {
+                                     FmtScopeTypeValue scope) {
   switch (value) {
     case UpperCase:
     case LowerCase:
@@ -300,7 +300,7 @@ bool EmitterState::SetBoolCaseFormat(EMITTER_MANIP value,
   }
 }
 
-bool EmitterState::SetNullFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetNullFormat(EMITTER_MANIP value, FmtScopeTypeValue scope) {
   switch (value) {
     case LowerNull:
     case UpperNull:
@@ -313,7 +313,7 @@ bool EmitterState::SetNullFormat(EMITTER_MANIP value, FmtScope::value scope) {
   }
 }
 
-bool EmitterState::SetIntFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetIntFormat(EMITTER_MANIP value, FmtScopeTypeValue scope) {
   switch (value) {
     case Dec:
     case Hex:
@@ -325,7 +325,7 @@ bool EmitterState::SetIntFormat(EMITTER_MANIP value, FmtScope::value scope) {
   }
 }
 
-bool EmitterState::SetIndent(std::size_t value, FmtScope::value scope) {
+bool EmitterState::SetIndent(std::size_t value, FmtScopeTypeValue scope) {
   if (value <= 1)
     return false;
 
@@ -334,7 +334,7 @@ bool EmitterState::SetIndent(std::size_t value, FmtScope::value scope) {
 }
 
 bool EmitterState::SetPreCommentIndent(std::size_t value,
-                                       FmtScope::value scope) {
+                                       FmtScopeTypeValue scope) {
   if (value == 0)
     return false;
 
@@ -343,7 +343,7 @@ bool EmitterState::SetPreCommentIndent(std::size_t value,
 }
 
 bool EmitterState::SetPostCommentIndent(std::size_t value,
-                                        FmtScope::value scope) {
+                                        FmtScopeTypeValue scope) {
   if (value == 0)
     return false;
 
@@ -351,28 +351,28 @@ bool EmitterState::SetPostCommentIndent(std::size_t value,
   return true;
 }
 
-bool EmitterState::SetFlowType(GroupType::value groupType, EMITTER_MANIP value,
-                               FmtScope::value scope) {
+bool EmitterState::SetFlowType(GroupTypeValue groupType, EMITTER_MANIP value,
+                               FmtScopeTypeValue scope) {
   switch (value) {
     case Block:
     case Flow:
-      _Set(groupType == GroupType::Seq ? m_seqFmt : m_mapFmt, value, scope);
+      _Set(groupType == GroupTypeValue::Seq ? m_seqFmt : m_mapFmt, value, scope);
       return true;
     default:
       return false;
   }
 }
 
-EMITTER_MANIP EmitterState::GetFlowType(GroupType::value groupType) const {
+EMITTER_MANIP EmitterState::GetFlowType(GroupTypeValue groupType) const {
   // force flow style if we're currently in a flow
-  if (CurGroupFlowType() == FlowType::Flow)
+  if (CurGroupFlowType() == FlowTypeValue::Flow)
     return Flow;
 
   // otherwise, go with what's asked of us
-  return (groupType == GroupType::Seq ? m_seqFmt.get() : m_mapFmt.get());
+  return (groupType == GroupTypeValue::Seq ? m_seqFmt.get() : m_mapFmt.get());
 }
 
-bool EmitterState::SetMapKeyFormat(EMITTER_MANIP value, FmtScope::value scope) {
+bool EmitterState::SetMapKeyFormat(EMITTER_MANIP value, FmtScopeTypeValue scope) {
   switch (value) {
     case Auto:
     case LongKey:
@@ -383,7 +383,7 @@ bool EmitterState::SetMapKeyFormat(EMITTER_MANIP value, FmtScope::value scope) {
   }
 }
 
-bool EmitterState::SetFloatPrecision(std::size_t value, FmtScope::value scope) {
+bool EmitterState::SetFloatPrecision(std::size_t value, FmtScopeTypeValue scope) {
   if (value > std::numeric_limits<float>::max_digits10)
     return false;
   _Set(m_floatPrecision, value, scope);
@@ -391,7 +391,7 @@ bool EmitterState::SetFloatPrecision(std::size_t value, FmtScope::value scope) {
 }
 
 bool EmitterState::SetDoublePrecision(std::size_t value,
-                                      FmtScope::value scope) {
+                                      FmtScopeTypeValue scope) {
   if (value > std::numeric_limits<double>::max_digits10)
     return false;
   _Set(m_doublePrecision, value, scope);

--- a/src/emitterstate.h
+++ b/src/emitterstate.h
@@ -18,15 +18,9 @@
 #include <vector>
 
 namespace YAML {
-struct FmtScope {
-  enum value { Local, Global };
-};
-struct GroupType {
-  enum value { NoType, Seq, Map };
-};
-struct FlowType {
-  enum value { NoType, Flow, Block };
-};
+enum class FlowTypeValue { NoType, Flow, Block };
+enum class GroupTypeValue { NoType, Seq, Map };
+enum class FmtScopeTypeValue { Local, Global };
 
 class EmitterState {
  public:
@@ -51,14 +45,14 @@ class EmitterState {
   void StartedDoc();
   void EndedDoc();
   void StartedScalar();
-  void StartedGroup(GroupType::value type);
-  void EndedGroup(GroupType::value type);
+  void StartedGroup(GroupTypeValue type);
+  void EndedGroup(GroupTypeValue type);
 
-  EmitterNodeType::value NextGroupType(GroupType::value type) const;
+  EmitterNodeType::value NextGroupType(GroupTypeValue type) const;
   EmitterNodeType::value CurGroupNodeType() const;
 
-  GroupType::value CurGroupType() const;
-  FlowType::value CurGroupFlowType() const;
+  GroupTypeValue CurGroupType() const;
+  FlowTypeValue CurGroupFlowType() const;
   std::size_t CurGroupIndent() const;
   std::size_t CurGroupChildCount() const;
   bool CurGroupLongKey() const;
@@ -79,50 +73,50 @@ class EmitterState {
   // formatters
   void SetLocalValue(EMITTER_MANIP value);
 
-  bool SetOutputCharset(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetOutputCharset(EMITTER_MANIP value, FmtScopeTypeValue scope);
   EMITTER_MANIP GetOutputCharset() const { return m_charset.get(); }
 
-  bool SetStringFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetStringFormat(EMITTER_MANIP value, FmtScopeTypeValue scope);
   EMITTER_MANIP GetStringFormat() const { return m_strFmt.get(); }
 
-  bool SetBoolFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetBoolFormat(EMITTER_MANIP value, FmtScopeTypeValue scope);
   EMITTER_MANIP GetBoolFormat() const { return m_boolFmt.get(); }
 
-  bool SetBoolLengthFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetBoolLengthFormat(EMITTER_MANIP value, FmtScopeTypeValue scope);
   EMITTER_MANIP GetBoolLengthFormat() const { return m_boolLengthFmt.get(); }
 
-  bool SetBoolCaseFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetBoolCaseFormat(EMITTER_MANIP value, FmtScopeTypeValue scope);
   EMITTER_MANIP GetBoolCaseFormat() const { return m_boolCaseFmt.get(); }
 
-  bool SetNullFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetNullFormat(EMITTER_MANIP value, FmtScopeTypeValue scope);
   EMITTER_MANIP GetNullFormat() const { return m_nullFmt.get(); }
 
-  bool SetIntFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetIntFormat(EMITTER_MANIP value, FmtScopeTypeValue scope);
   EMITTER_MANIP GetIntFormat() const { return m_intFmt.get(); }
 
-  bool SetIndent(std::size_t value, FmtScope::value scope);
+  bool SetIndent(std::size_t value, FmtScopeTypeValue scope);
   std::size_t GetIndent() const { return m_indent.get(); }
 
-  bool SetPreCommentIndent(std::size_t value, FmtScope::value scope);
+  bool SetPreCommentIndent(std::size_t value, FmtScopeTypeValue scope);
   std::size_t GetPreCommentIndent() const { return m_preCommentIndent.get(); }
-  bool SetPostCommentIndent(std::size_t value, FmtScope::value scope);
+  bool SetPostCommentIndent(std::size_t value, FmtScopeTypeValue scope);
   std::size_t GetPostCommentIndent() const { return m_postCommentIndent.get(); }
 
-  bool SetFlowType(GroupType::value groupType, EMITTER_MANIP value,
-                   FmtScope::value scope);
-  EMITTER_MANIP GetFlowType(GroupType::value groupType) const;
+  bool SetFlowType(GroupTypeValue groupType, EMITTER_MANIP value,
+                   FmtScopeTypeValue scope);
+  EMITTER_MANIP GetFlowType(GroupTypeValue groupType) const;
 
-  bool SetMapKeyFormat(EMITTER_MANIP value, FmtScope::value scope);
+  bool SetMapKeyFormat(EMITTER_MANIP value, FmtScopeTypeValue scope);
   EMITTER_MANIP GetMapKeyFormat() const { return m_mapKeyFmt.get(); }
 
-  bool SetFloatPrecision(std::size_t value, FmtScope::value scope);
+  bool SetFloatPrecision(std::size_t value, FmtScopeTypeValue scope);
   std::size_t GetFloatPrecision() const { return m_floatPrecision.get(); }
-  bool SetDoublePrecision(std::size_t value, FmtScope::value scope);
+  bool SetDoublePrecision(std::size_t value, FmtScopeTypeValue scope);
   std::size_t GetDoublePrecision() const { return m_doublePrecision.get(); }
 
  private:
   template <typename T>
-  void _Set(Setting<T>& fmt, T value, FmtScope::value scope);
+  void _Set(Setting<T>& fmt, T value,FmtScopeTypeValue scope);
 
   void StartedNode();
 
@@ -151,7 +145,7 @@ class EmitterState {
   SettingChanges m_globalModifiedSettings;
 
   struct Group {
-    explicit Group(GroupType::value type_)
+    explicit Group(GroupTypeValue type_)
         : type(type_),
           flowType{},
           indent(0),
@@ -159,8 +153,8 @@ class EmitterState {
           longKey(false),
           modifiedSettings{} {}
 
-    GroupType::value type;
-    FlowType::value flowType;
+    GroupTypeValue type;
+    FlowTypeValue flowType;
     std::size_t indent;
     std::size_t childCount;
     bool longKey;
@@ -168,13 +162,13 @@ class EmitterState {
     SettingChanges modifiedSettings;
 
     EmitterNodeType::value NodeType() const {
-      if (type == GroupType::Seq) {
-        if (flowType == FlowType::Flow)
+      if (type == GroupTypeValue::Seq) {
+        if (flowType == FlowTypeValue::Flow)
           return EmitterNodeType::FlowSeq;
         else
           return EmitterNodeType::BlockSeq;
       } else {
-        if (flowType == FlowType::Flow)
+        if (flowType == FlowTypeValue::Flow)
           return EmitterNodeType::FlowMap;
         else
           return EmitterNodeType::BlockMap;
@@ -196,12 +190,12 @@ class EmitterState {
 };
 
 template <typename T>
-void EmitterState::_Set(Setting<T>& fmt, T value, FmtScope::value scope) {
+void EmitterState::_Set(Setting<T>& fmt, T value, FmtScopeTypeValue scope) {
   switch (scope) {
-    case FmtScope::Local:
+    case FmtScopeTypeValue::Local:
       m_modifiedSettings.push(fmt.set(value));
       break;
-    case FmtScope::Global:
+    case FmtScopeTypeValue::Global:
       fmt.set(value);
       m_globalModifiedSettings.push(
           fmt.set(value));  // this pushes an identity set, so when we restore,

--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -152,7 +152,7 @@ void WriteCodePoint(ostream_wrapper& out, int codePoint) {
   }
 }
 
-bool IsValidPlainScalar(const std::string& str, FlowType::value flowType,
+bool IsValidPlainScalar(const std::string& str, FlowTypeValue flowType,
                         bool allowOnlyAscii) {
   // check against null
   if (IsNullString(str)) {
@@ -160,7 +160,7 @@ bool IsValidPlainScalar(const std::string& str, FlowType::value flowType,
   }
 
   // check the start
-  const RegEx& start = (flowType == FlowType::Flow ? Exp::PlainScalarInFlow()
+  const RegEx& start = (flowType == FlowTypeValue::Flow ? Exp::PlainScalarInFlow()
                                                    : Exp::PlainScalar());
   if (!start.Matches(str)) {
     return false;
@@ -182,7 +182,7 @@ bool IsValidPlainScalar(const std::string& str, FlowType::value flowType,
       Exp::NotPrintable() | Exp::Utf8_ByteOrderMark() | Exp::Break() |
       Exp::Tab();
   const RegEx& disallowed =
-      flowType == FlowType::Flow ? disallowed_flow : disallowed_block;
+      flowType == FlowTypeValue::Flow ? disallowed_flow : disallowed_block;
 
   StringCharSource buffer(str.c_str(), str.size());
   while (buffer) {
@@ -206,9 +206,9 @@ bool IsValidSingleQuotedScalar(const std::string& str, bool escapeNonAscii) {
   });
 }
 
-bool IsValidLiteralScalar(const std::string& str, FlowType::value flowType,
+bool IsValidLiteralScalar(const std::string& str, FlowTypeValue flowType,
                           bool escapeNonAscii) {
-  if (flowType == FlowType::Flow) {
+  if (flowType == FlowTypeValue::Flow) {
     return false;
   }
 
@@ -267,9 +267,9 @@ bool WriteAliasName(ostream_wrapper& out, const std::string& str) {
 }
 }  // namespace
 
-StringFormat::value ComputeStringFormat(const std::string& str,
+StringFormat ComputeStringFormat(const std::string& str,
                                         EMITTER_MANIP strFormat,
-                                        FlowType::value flowType,
+                                        FlowTypeValue flowType,
                                         bool escapeNonAscii) {
   switch (strFormat) {
     case Auto:

--- a/src/emitterutils.h
+++ b/src/emitterutils.h
@@ -20,8 +20,8 @@ class ostream_wrapper;
 namespace YAML {
 class Binary;
 
-struct StringFormat {
-  enum value { Plain, SingleQuoted, DoubleQuoted, Literal };
+enum class StringFormat {
+  Plain, SingleQuoted, DoubleQuoted, Literal
 };
 
 struct StringEscaping {
@@ -29,9 +29,9 @@ struct StringEscaping {
 };
 
 namespace Utils {
-StringFormat::value ComputeStringFormat(const std::string& str,
+StringFormat ComputeStringFormat(const std::string& str,
                                         EMITTER_MANIP strFormat,
-                                        FlowType::value flowType,
+                                        FlowTypeValue flowType,
                                         bool escapeNonAscii);
 
 bool WriteSingleQuotedString(ostream_wrapper& out, const std::string& str);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,12 +4,13 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 set(BUILD_MOCK ON CACHE BOOL "" FORCE)
 set(CMAKE_POLICY_DEFAULT_CMP0048 NEW)
 
-add_subdirectory(
-  "${CMAKE_CURRENT_SOURCE_DIR}/gtest-1.10.0"
-  "${CMAKE_CURRENT_BINARY_DIR}/prefix")
-
-include_directories(SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/gtest-1.10.0/googletest/include")
-
+#add_subdirectory(
+#  "${CMAKE_CURRENT_SOURCE_DIR}/gtest-1.10.0"
+#  "${CMAKE_CURRENT_BINARY_DIR}/prefix")
+#
+#include_directories(SYSTEM "${CMAKE_CURRENT_SOURCE_DIR}/gtest-1.10.0/googletest/include")
+find_package(GTest REQUIRED)
+include_directories(${GTEST_INCLUDE_DIRS})
 set(test-new-api-pattern "new-api/*.cpp")
 set(test-source-pattern "*.cpp" "integration/*.cpp" "node/*.cpp")
 if (CMAKE_VERSION VERSION_GREATER 3.11)
@@ -44,6 +45,5 @@ set_property(TARGET yaml-cpp-tests PROPERTY CXX_STANDARD_REQUIRED ON)
 if (NOT DEFINED CMAKE_CXX_STANDARD)
   set_target_properties(yaml-cpp-tests PROPERTIES CXX_STANDARD 11)
 endif()
-
 
 add_test(yaml-cpp::test yaml-cpp-tests)


### PR DESCRIPTION
The current compiler gnu c++ requires enum class instead of what you used otherwise complains about duplicate identifier. Moreover there's actually no need to include gtest inside the repository since in common Linux distribution  we've already have it. Since i use to my final project i will go deeper to fix this project.


	modified:   src/emitter.cpp
	modified:   src/emitterstate.cpp
	modified:   src/emitterstate.h
	modified:   src/emitterutils.cpp
	modified:   src/emitterutils.h
	modified:   test/CMakeLists.txt