### PR TITLE
Revert "Revert "Revert "Hide most of non-public symbols by default (#984)" (#1038)""

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,6 @@ include(CMakeDependentOption)
 include(CheckCXXCompilerFlag)
 include(GNUInstallDirs)
 include(CTest)
-include(GenerateExportHeader)
-
-set(CMAKE_C_VISIBILITY_PRESET hidden)
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
 find_program(YAML_CPP_CLANG_FORMAT_EXE NAMES clang-format)
 
@@ -86,7 +81,6 @@ set_property(TARGET yaml-cpp
 target_include_directories(yaml-cpp
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
@@ -142,12 +136,6 @@ write_basic_package_version_file(
   "${PROJECT_BINARY_DIR}/yaml-cpp-config-version.cmake"
   COMPATIBILITY AnyNewerVersion)
 
-generate_export_header(yaml-cpp
-  BASE_NAME YAML_CPP
-  EXPORT_FILE_NAME "${PROJECT_BINARY_DIR}/include/yaml-cpp/dll.h"
-  EXPORT_MACRO_NAME YAML_CPP_API
-)
-
 configure_file(yaml-cpp.pc.in yaml-cpp.pc @ONLY)
 
 if (YAML_CPP_INSTALL)
@@ -157,9 +145,6 @@ if (YAML_CPP_INSTALL)
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 	install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-		FILES_MATCHING PATTERN "*.h")
-	install(DIRECTORY ${PROJECT_BINARY_DIR}/include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 		FILES_MATCHING PATTERN "*.h")
   install(EXPORT yaml-cpp-targets

--- a/include/yaml-cpp/dll.h
+++ b/include/yaml-cpp/dll.h
@@ -1,0 +1,33 @@
+#ifndef DLL_H_62B23520_7C8E_11DE_8A39_0800200C9A66
+#define DLL_H_62B23520_7C8E_11DE_8A39_0800200C9A66
+
+#if defined(_MSC_VER) ||                                            \
+    (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
+     (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
+#pragma once
+#endif
+
+// The following ifdef block is the standard way of creating macros which make
+// exporting from a DLL simpler. All files within this DLL are compiled with the
+// yaml_cpp_EXPORTS symbol defined on the command line. This symbol should not
+// be defined on any project that uses this DLL. This way any other project
+// whose source files include this file see YAML_CPP_API functions as being
+// imported from a DLL, whereas this DLL sees symbols defined with this macro as
+// being exported.
+#undef YAML_CPP_API
+
+#ifdef YAML_CPP_DLL      // Using or Building YAML-CPP DLL (definition defined
+                         // manually)
+#ifdef yaml_cpp_EXPORTS  // Building YAML-CPP DLL (definition created by CMake
+                         // or defined manually)
+//	#pragma message( "Defining YAML_CPP_API for DLL export" )
+#define YAML_CPP_API __declspec(dllexport)
+#else  // yaml_cpp_EXPORTS
+//	#pragma message( "Defining YAML_CPP_API for DLL import" )
+#define YAML_CPP_API __declspec(dllimport)
+#endif  // yaml_cpp_EXPORTS
+#else   // YAML_CPP_DLL
+#define YAML_CPP_API
+#endif  // YAML_CPP_DLL
+
+#endif  // DLL_H_62B23520_7C8E_11DE_8A39_0800200C9A66

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -13,7 +13,7 @@
 
 namespace YAML {
 namespace detail {
-std::atomic<size_t> node::m_amount{0};
+YAML_CPP_API std::atomic<size_t> node::m_amount{0};
 
 const std::string& node_data::empty_scalar() {
   static const std::string svalue;

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -13,7 +13,7 @@
 
 namespace YAML {
 namespace detail {
-YAML_CPP_API std::atomic<size_t> node::m_amount{0};
+std::atomic<size_t> node::m_amount{0};
 
 const std::string& node_data::empty_scalar() {
   static const std::string svalue;


### PR DESCRIPTION
Reverts jbeder/yaml-cpp#1045

See the discussion in #1046. The issue with this PR is that it starts using the build system to generate source code, which (a) makes it no longer possible to just add the sources to a project without using CMake, and (b) requires that to support any other build system (e.g. Bazel, which I'd like to support), we'd have to duplicate this source-generating logic in that other build system also.

@pinotree If you see this, I'm open to PRs that solve the problem you were trying to solve without generating source code.