### PR TITLE
[.github/workflows/build.yml] enable to run of test at the 'windows-latest' environment.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
             cmake --build . --parallel 4
 
           # tests are failing for unknown reasons
-        - if: matrix.os == 'ubuntu-latest'
+        - if: matrix.os != 'macos-latest'
           name: Test shared
           shell: bash
           run: cd build && ctest --output-on-failure

--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -75,7 +75,7 @@ std::vector<unsigned char> DecodeBase64(const std::string &input) {
 
   unsigned value = 0;
   for (std::size_t i = 0, cnt = 0; i < input.size(); i++) {
-    if (std::isspace(input[i])) {
+    if (std::isspace(static_cast<unsigned char>(input[i]))) {
       // skip newlines
       continue;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,3 +47,10 @@ endif()
 
 
 add_test(yaml-cpp::test yaml-cpp-tests)
+
+if (build-windows-dll)
+  add_custom_command(
+    TARGET yaml-cpp-tests
+    POST_BUILD COMMAND ${CMAKE_COMMAND} -E
+    copy_if_different "$<TARGET_FILE:yaml-cpp>" "$<TARGET_FILE_DIR:yaml-cpp-tests>")
+endif()


### PR DESCRIPTION
Hello.

This request fix all know issues that was detected while run pipeline at the Windows platform:
-  dll was not placed near to the test binary, so ctest tool could not execute a binary;
- used std::isspace with non 'unsigned char' type of argument do not pass assert check at MSVC environment, but such casting should be provided for all environments according to [documentation](https://en.cppreference.com/w/cpp/string/byte/isspace) on that function.

This request partially replace #1057 - only enabling to run at macOS left there.

Thank you.
