### PR TITLE
-Werror=old-style-cast

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -128,7 +128,7 @@ ConvertStreamTo(std::stringstream& stream, T& rhs) {
   if ((stream >> std::noskipws >> num) && (stream >> std::ws).eof()) {
     if (num >= (std::numeric_limits<T>::min)() &&
         num <= (std::numeric_limits<T>::max)()) {
-      rhs = (T)num;
+      rhs = static_cast<T>(num);
       return true;
     }
   }


### PR DESCRIPTION
use of old-style cast to ‘T’ [-Werror=old-style-cast]
  131 | rhs = (T)num;