### PR TITLE
Fix single cr not recognized

### DIFF
--- a/src/exp.h
+++ b/src/exp.h
@@ -37,7 +37,7 @@ inline const RegEx& Blank() {
   return e;
 }
 inline const RegEx& Break() {
-  static const RegEx e = RegEx('\n') | RegEx("\r\n");
+  static const RegEx e = RegEx('\n') | RegEx("\r");
   return e;
 }
 inline const RegEx& BlankOrBreak() {

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -968,6 +968,14 @@ TEST_F(EmitterTest, UserType) {
   ExpectEmit("- x: 5\n  bar: hello\n- x: 3\n  bar: goodbye");
 }
 
+TEST_F(EmitterTest, UserType2) {
+  out << BeginSeq;
+  out << Foo(5, "\r");
+  out << EndSeq;
+
+  ExpectEmit("- x: 5\n  bar: \"\\r\"");
+}
+
 TEST_F(EmitterTest, UserTypeInContainer) {
   std::vector<Foo> fv;
   fv.push_back(Foo(5, "hello"));


### PR DESCRIPTION
Emitting a usertype containing a string having a single \r (carrigage return, i.e. w/o a following \n) leads to, in my opinion, YAML violating the standard at 5.4 [25] + [26]. The proposed patch fixes that with all tests still passing. A new test has been added to in a separate commit to show the issue.