### PR TITLE
Improve build and fix single cr on windows

### DIFF
--- a/src/exp.h
+++ b/src/exp.h
@@ -37,7 +37,7 @@ inline const RegEx& Blank() {
   return e;
 }
 inline const RegEx& Break() {
-  static const RegEx e = RegEx('\n') | RegEx("\r");
+  static const RegEx e = RegEx('\n') | RegEx("\r\n") | RegEx('\r');
   return e;
 }
 inline const RegEx& BlankOrBreak() {

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -345,5 +345,20 @@ TEST(NodeTest, LoadTagWithNullScalar) {
   EXPECT_TRUE(node.IsNull());
 }
 
+TEST(LoadNodeTest, BlockCRNLEncoded) {
+  Node node = Load(
+      "blockText: |\r\n"
+      "  some arbitrary text \r\n"
+      "  spanning some \r\n"
+      "  lines, that are split \r\n"
+      "  by CR and NL\r\n"
+      "followup: 1");
+  EXPECT_EQ(
+      "some arbitrary text \nspanning some \nlines, that are split \nby CR and "
+      "NL\n",
+      node["blockText"].as<std::string>());
+  EXPECT_EQ(1, node["followup"].as<int>());
+}
+
 }  // namespace
 }  // namespace YAML


### PR DESCRIPTION
PR #1094 introduced a regression when block value in a file with CRNL line endings was parsed. The Break regular expression needed to consume both the CR and the NL, but it also needs to consume single CR, when they are not followed by a NL. This PR fixes #1098 and additionally tries to improve bazel build.