### PR TITLE
Improve bazel build for Windows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,5 +58,5 @@ jobs:
           shell: bash
           run: |
             cd "${{ github.workspace }}"
-            bazel test :all
+            bazel test test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     branches: [ master ]
   workflow_dispatch:
 jobs:
-  build:
+  cmake-build:
       strategy:
         matrix:
           os: [ubuntu-latest, windows-latest, macos-latest]
@@ -40,7 +40,7 @@ jobs:
           shell: bash
           run: cd build && ctest --output-on-failure
 
-  bz-build:
+  bazel-build:
       strategy:
         matrix:
           os: [ubuntu-latest, windows-latest, macos-latest]
@@ -52,13 +52,11 @@ jobs:
           shell: bash
           run: |
             cd "${{ github.workspace }}"
-            bazel build '//:yaml-cpp'
+            bazel build ...
 
         - name: Test
           shell: bash
           run: |
             cd "${{ github.workspace }}"
-            # For some reason 'bazel test //test:test' gets the first / stripped on windows in CI.
-            # Therefore use this ugly version, which is working on all platforms.
-            bazel test test
+            bazel test ...
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,11 +52,11 @@ jobs:
           shell: bash
           run: |
             cd "${{ github.workspace }}"
-            bazel build ...
+            bazel build :all
 
         - name: Test
           shell: bash
           run: |
             cd "${{ github.workspace }}"
-            bazel test ...
+            bazel test :all
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,3 +39,26 @@ jobs:
         - name: Test
           shell: bash
           run: cd build && ctest --output-on-failure
+
+  bz-build:
+      strategy:
+        matrix:
+          os: [ubuntu-latest, windows-latest, macos-latest]
+      runs-on: ${{ matrix.os }}
+      steps:
+        - uses: actions/checkout@v2
+
+        - name: Build
+          shell: bash
+          run: |
+            cd "${{ github.workspace }}"
+            bazel build '//:yaml-cpp'
+
+        - name: Test
+          shell: bash
+          run: |
+            cd "${{ github.workspace }}"
+            # For some reason 'bazel test //test:test' gets the first / stripped on windows in CI.
+            # Therefore use this ugly version, which is working on all platforms.
+            bazel test test
+

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,6 @@
 yaml_cpp_defines = select({
     # On Windows, ensure static linking is used.
-    "@envoy//bazel:windows_x86_64": ["YAML_CPP_STATIC_DEFINE", "YAML_CPP_NO_CONTRIB"],
+    "@platforms//os:windows": ["YAML_CPP_STATIC_DEFINE", "YAML_CPP_NO_CONTRIB"],
     "//conditions:default": [],
 })
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,9 @@
+yaml_cpp_defines = select({
+    # On Windows, ensure static linking is used.
+    "@envoy//bazel:windows_x86_64": ["YAML_CPP_STATIC_DEFINE", "YAML_CPP_NO_CONTRIB"],
+    "//conditions:default": [],
+})
+
 cc_library(
     name = "yaml-cpp_internal",
     visibility = ["//:__subpackages__"],
@@ -11,4 +17,5 @@ cc_library(
     includes = ["include"],
     hdrs = glob(["include/**/*.h"]),
     srcs = glob(["src/**/*.cpp", "src/**/*.h"]),
+    defines = yaml_cpp_defines,
 )


### PR DESCRIPTION
Windows builds need some defines being set to use the static linking.
Also add bazel builds to the CI.

Split from #1099 .