### PR TITLE
Fix escaping anchors in keys

### DIFF
--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -176,11 +176,11 @@ bool IsValidPlainScalar(const std::string& str, FlowType::value flowType,
   static const RegEx& disallowed_flow =
       Exp::EndScalarInFlow() | (Exp::BlankOrBreak() + Exp::Comment()) |
       Exp::NotPrintable() | Exp::Utf8_ByteOrderMark() | Exp::Break() |
-      Exp::Tab();
+      Exp::Tab() | Exp::Ampersand();
   static const RegEx& disallowed_block =
       Exp::EndScalar() | (Exp::BlankOrBreak() + Exp::Comment()) |
       Exp::NotPrintable() | Exp::Utf8_ByteOrderMark() | Exp::Break() |
-      Exp::Tab();
+      Exp::Tab() | Exp::Ampersand();
   const RegEx& disallowed =
       flowType == FlowType::Flow ? disallowed_flow : disallowed_block;
 

--- a/src/exp.h
+++ b/src/exp.h
@@ -117,6 +117,10 @@ inline const RegEx& ValueInJSONFlow() {
   static const RegEx e = RegEx(':');
   return e;
 }
+inline const RegEx& Ampersand() {
+  static const RegEx e = RegEx('&');
+  return e;
+}
 inline const RegEx Comment() {
   static const RegEx e = RegEx('#');
   return e;

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -1624,6 +1624,15 @@ NodeB:
   k: [*k0, *k1])");
 }
 
+TEST_F(EmitterTest, AnchorEncoding) {
+  Node node;
+  node["--- &$ [*$]1"] = 1;
+  out << node;
+  ExpectEmit("\"--- &$ [*$]1\": 1");
+  Node reparsed = YAML::Load(out.c_str());
+  EXPECT_EQ(reparsed["--- &$ [*$]1"].as<int>(), 1);
+}
+
 class EmitterErrorTest : public ::testing::Test {
  protected:
   void ExpectEmitError(const std::string& expectedError) {
@@ -1694,5 +1703,6 @@ TEST_F(EmitterErrorTest, InvalidAlias) {
 
   ExpectEmitError(ErrorMsg::INVALID_ALIAS);
 }
+
 }  // namespace
 }  // namespace YAML


### PR DESCRIPTION
A key having an ampersand in it does not trigger quoting in the emit,
when auto-quoting is enabled.

The first commit adds a testcase showing the issue.