### PR TITLE
Small perfomance optimization in Directives and Tag methods

### DIFF
--- a/src/directives.cpp
+++ b/src/directives.cpp
@@ -3,7 +3,7 @@
 namespace YAML {
 Directives::Directives() : version{true, 1, 2}, tags{} {}
 
-const std::string Directives::TranslateTagHandle(
+std::string Directives::TranslateTagHandle(
     const std::string& handle) const {
   auto it = tags.find(handle);
   if (it == tags.end()) {

--- a/src/directives.cpp
+++ b/src/directives.cpp
@@ -3,19 +3,15 @@
 namespace YAML {
 Directives::Directives() : version{true, 1, 2}, tags{} {}
 
-std::string Directives::TranslateTagHandle(
+const std::string Directives::TranslateTagHandle(
     const std::string& handle) const {
-  std::string result;
   auto it = tags.find(handle);
   if (it == tags.end()) {
     if (handle == "!!")
-      result = "tag:yaml.org,2002:";
-    else
-      result = handle;
-  } else {
-    result = it->second;
+      return "tag:yaml.org,2002:";
+    return handle;
   }
 
-  return result;
+  return it->second;
 }
 }  // namespace YAML

--- a/src/directives.cpp
+++ b/src/directives.cpp
@@ -3,15 +3,19 @@
 namespace YAML {
 Directives::Directives() : version{true, 1, 2}, tags{} {}
 
-const std::string Directives::TranslateTagHandle(
+std::string Directives::TranslateTagHandle(
     const std::string& handle) const {
+  std::string result;
   auto it = tags.find(handle);
   if (it == tags.end()) {
     if (handle == "!!")
-      return "tag:yaml.org,2002:";
-    return handle;
+      result = "tag:yaml.org,2002:";
+    else
+      result = handle;
+  } else {
+    result = it->second;
   }
 
-  return it->second;
+  return result;
 }
 }  // namespace YAML

--- a/src/directives.h
+++ b/src/directives.h
@@ -19,7 +19,7 @@ struct Version {
 struct Directives {
   Directives();
 
-  const std::string TranslateTagHandle(const std::string& handle) const;
+  std::string TranslateTagHandle(const std::string& handle) const;
 
   Version version;
   std::map<std::string, std::string> tags;

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -29,7 +29,7 @@ Tag::Tag(const Token& token)
   }
 }
 
-const std::string Tag::Translate(const Directives& directives) {
+std::string Tag::Translate(const Directives& directives) {
   switch (type) {
     case VERBATIM:
       return value;

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -29,22 +29,31 @@ Tag::Tag(const Token& token)
   }
 }
 
-const std::string Tag::Translate(const Directives& directives) {
+std::string Tag::Translate(const Directives& directives) {
+  std::string result;
+
   switch (type) {
     case VERBATIM:
-      return value;
+      result = value;
+      break;
     case PRIMARY_HANDLE:
-      return directives.TranslateTagHandle("!") + value;
+      result = directives.TranslateTagHandle("!") + value;
+      break;
     case SECONDARY_HANDLE:
-      return directives.TranslateTagHandle("!!") + value;
+      result = directives.TranslateTagHandle("!!") + value;
+      break;
     case NAMED_HANDLE:
-      return directives.TranslateTagHandle("!" + handle + "!") + value;
+      result = directives.TranslateTagHandle("!" + handle + "!") + value;
+      break;
     case NON_SPECIFIC:
       // TODO:
-      return "!";
+      result = "!";
+      break;
     default:
       assert(false);
+      throw std::runtime_error("yaml-cpp: internal error, bad tag type");
   }
-  throw std::runtime_error("yaml-cpp: internal error, bad tag type");
+
+  return result;
 }
 }  // namespace YAML

--- a/src/tag.cpp
+++ b/src/tag.cpp
@@ -29,31 +29,22 @@ Tag::Tag(const Token& token)
   }
 }
 
-std::string Tag::Translate(const Directives& directives) {
-  std::string result;
-
+const std::string Tag::Translate(const Directives& directives) {
   switch (type) {
     case VERBATIM:
-      result = value;
-      break;
+      return value;
     case PRIMARY_HANDLE:
-      result = directives.TranslateTagHandle("!") + value;
-      break;
+      return directives.TranslateTagHandle("!") + value;
     case SECONDARY_HANDLE:
-      result = directives.TranslateTagHandle("!!") + value;
-      break;
+      return directives.TranslateTagHandle("!!") + value;
     case NAMED_HANDLE:
-      result = directives.TranslateTagHandle("!" + handle + "!") + value;
-      break;
+      return directives.TranslateTagHandle("!" + handle + "!") + value;
     case NON_SPECIFIC:
       // TODO:
-      result = "!";
-      break;
+      return "!";
     default:
       assert(false);
-      throw std::runtime_error("yaml-cpp: internal error, bad tag type");
   }
-
-  return result;
+  throw std::runtime_error("yaml-cpp: internal error, bad tag type");
 }
 }  // namespace YAML

--- a/src/tag.h
+++ b/src/tag.h
@@ -23,7 +23,7 @@ struct Tag {
   };
 
   Tag(const Token& token);
-  const std::string Translate(const Directives& directives);
+  std::string Translate(const Directives& directives);
 
   TYPE type;
   std::string handle, value;


### PR DESCRIPTION
I'm making a small perfomance improvement for `Directives::TranslateTagHandle` and `Tag::Translate` methods. Having `const` in return type forces coping operation instead of moving one. You can read [here](https://stackoverflow.com/questions/57761077/return-const-value-prevent-move-semantics) about it or watch [this](https://www.youtube.com/watch?v=dGCxMmGvocE) video.