### PR TITLE
CMake: Attach YAML_CPP_STATIC_DEFINE to yaml-cpp target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,6 @@ if (YAML_BUILD_SHARED_LIBS)
 else()
   set(yaml-cpp-type STATIC)
   set(yaml-cpp-label-postfix "static")
-  add_definitions(-DYAML_CPP_STATIC_DEFINE)
 endif()
 
 set(build-shared $<BOOL:${YAML_BUILD_SHARED_LIBS}>)
@@ -123,6 +122,8 @@ target_compile_options(yaml-cpp
     $<$<CXX_COMPILER_ID:MSVC>:/W3 /wd4127 /wd4355>)
 
 target_compile_definitions(yaml-cpp
+  PUBLIC
+    $<$<NOT:$<BOOL:${YAML_BUILD_SHARED_LIBS}>>:YAML_CPP_STATIC_DEFINE>
   PRIVATE
     $<${build-windows-dll}:${PROJECT_NAME}_DLL>
     $<$<NOT:$<BOOL:${YAML_CPP_BUILD_CONTRIB}>>:YAML_CPP_NO_CONTRIB>)


### PR DESCRIPTION
I am using yaml-cpp via `add_subdirectory`. When compiling under Windows (with clang) I get the following warning, despite linking statically.

```
C:/Users/w4rh4wk/git/ph3lib/external/yaml-cpp/include\yaml-cpp/dll.h:22:17: warning: Defining YAML_CPP_API for DLL import [-W#pragma-messages]
#        pragma message( "Defining YAML_CPP_API for DLL import" )
```

The problem seems to be that the `YAML_CPP_STATIC_DEFINE` is not attached to the `yaml-cpp` target. Therefore, my code does not have this define set.

This commit attaches the define to the `yaml-cpp` target, such that targets linking against yaml-cpp (using `target_link_libraries`) also have it.