### PR TITLE
Minimize warnings when not the top-level project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if (NOT DEFINED CMAKE_CXX_STANDARD)
       CXX_STANDARD 11)
 endif()
 
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+if(YAML_CPP_MAIN_PROJECT)
   target_compile_options(yaml-cpp
     PRIVATE
       $<${not-msvc}:-Wall -Wextra -Wshadow -Weffc++ -Wno-long-long>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,11 +106,15 @@ if (NOT DEFINED CMAKE_CXX_STANDARD)
       CXX_STANDARD 11)
 endif()
 
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+  target_compile_options(yaml-cpp
+    PRIVATE
+      $<${not-msvc}:-Wall -Wextra -Wshadow -Weffc++ -Wno-long-long>
+      $<${not-msvc}:-pedantic -pedantic-errors>)
+endif()
+
 target_compile_options(yaml-cpp
   PRIVATE
-    $<${not-msvc}:-Wall -Wextra -Wshadow -Weffc++ -Wno-long-long>
-    $<${not-msvc}:-pedantic -pedantic-errors>
-
     $<$<AND:${backport-msvc-runtime},${msvc-rt-mtd-static}>:-MTd>
     $<$<AND:${backport-msvc-runtime},${msvc-rt-mt-static}>:-MT>
     $<$<AND:${backport-msvc-runtime},${msvc-rt-mtd-dll}>:-MDd>


### PR DESCRIPTION
Should fix #970 and #764 when trying to add yaml-cpp to other project