### PR TITLE
Fix compilation errors in build for Oracle Solaris OS

### DIFF
--- a/include/yaml-cpp/traits.h
+++ b/include/yaml-cpp/traits.h
@@ -107,9 +107,9 @@ struct disable_if : public disable_if_c<Cond::value, T> {};
 
 template <typename S, typename T>
 struct is_streamable {
-  template <typename SS, typename TT>
+  template <typename StreamT, typename ValueT>
   static auto test(int)
-      -> decltype(std::declval<SS&>() << std::declval<TT>(), std::true_type());
+      -> decltype(std::declval<StreamT&>() << std::declval<ValueT>(), std::true_type());
 
   template <typename, typename>
   static auto test(...) -> std::false_type;


### PR DESCRIPTION
On Oracle Solaris the following statement is declared in file /usr/include/sys/regset.h:
`#define SS         18      /* only stored on a privilege transition */`

Because of this template type name `SS` is substituted by numeric literal, which results in a compilation error:
`error: expected nested-name-specifier before numeric constant`

Fixed by renaming template type names.