### PR TITLE
Include property nodes in the long key check

### DIFF
--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -533,7 +533,8 @@ void Emitter::BlockMapPrepareNode(EmitterNodeType::value child) {
     if (m_pState->GetMapKeyFormat() == LongKey)
       m_pState->SetLongKey();
     if (child == EmitterNodeType::BlockSeq ||
-        child == EmitterNodeType::BlockMap)
+        child == EmitterNodeType::BlockMap ||
+        child == EmitterNodeType::Property)
       m_pState->SetLongKey();
 
     if (m_pState->CurGroupLongKey())

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -431,6 +431,38 @@ TEST_F(EmitterTest, BlockMapAsKey) {
   ExpectEmit("? key: value\n  next key: next value\n: total value");
 }
 
+TEST_F(EmitterTest, TaggedBlockMapAsKey) {
+  out << BeginMap;
+  out << Key;
+  out << LocalTag("innerMap");
+  out << BeginMap;
+  out << Key << "key" << Value << "value";
+  out << EndMap;
+  out << Value;
+  out << "outerValue";
+  out << EndMap;
+
+  ExpectEmit(R"(? !innerMap
+  key: value
+: outerValue)");
+}
+
+TEST_F(EmitterTest, TaggedBlockListAsKey) {
+  out << BeginMap;
+  out << Key;
+  out << LocalTag("innerList");
+  out << BeginSeq;
+  out << "listItem";
+  out << EndSeq;
+  out << Value;
+  out << "outerValue";
+  out << EndMap;
+
+  ExpectEmit(R"(? !innerList
+  - listItem
+: outerValue)");
+}
+
 TEST_F(EmitterTest, AliasAndAnchor) {
   out << BeginSeq;
   out << Anchor("fred");
@@ -520,7 +552,7 @@ TEST_F(EmitterTest, VerbatimTagInBlockMap) {
   out << Value << VerbatimTag("!waz") << "baz";
   out << EndMap;
 
-  ExpectEmit("!<!foo> bar: !<!waz> baz");
+  ExpectEmit("? !<!foo> bar\n: !<!waz> baz");
 }
 
 TEST_F(EmitterTest, VerbatimTagInFlowMap) {


### PR DESCRIPTION
This fixes #1139

The existing check for map and sequence node has been expanded to also include property nodes:
- Use the long format for keys with properties
- Add new tests involving tagged map and sequence collections as keys
- Change tagged key tests to expect long keys