### PR TITLE
node/convert: support conversion for std::string_view

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -18,6 +18,10 @@
 #include <valarray>
 #include <vector>
 
+#if __cplusplus >= 201703L
+#include <string_view>
+#endif
+
 #include "yaml-cpp/binary.h"
 #include "yaml-cpp/node/impl.h"
 #include "yaml-cpp/node/iterator.h"
@@ -88,6 +92,20 @@ template <std::size_t N>
 struct convert<char[N]> {
   static Node encode(const char* rhs) { return Node(rhs); }
 };
+
+#if __cplusplus >= 201703L
+template <>
+struct convert<std::string_view> {
+  static Node encode(std::string_view rhs) { return Node(std::string(rhs)); }
+
+  static bool decode(const Node& node, std::string_view& rhs) {
+    if (!node.IsScalar())
+      return false;
+    rhs = node.Scalar();
+    return true;
+  }
+};
+#endif
 
 template <>
 struct convert<_Null> {

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -356,6 +356,15 @@ TEST(NodeTest, ConstInteratorOnSequence) {
   EXPECT_EQ(3, count);
 }
 
+#if __cplusplus >= 201703L
+TEST(NodeTest, StdStringViewAsKey) {
+  Node node;
+  std::string_view key = "username";
+  node[key] = "monkey";
+  EXPECT_EQ("monkey", node[key].as<std::string>());
+}
+#endif
+
 TEST(NodeTest, SimpleSubkeys) {
   Node node;
   node["device"]["udid"] = "12345";


### PR DESCRIPTION
as the key is not always nul terminated, it'd be handy to use
a `std::string_view` when a key is expected.

before this change, we would have FTBFS if the key is a `string_view`
when looking up a node in a map:
```
/usr/include/yaml-cpp/node/detail/impl.h: In instantiation of ‘bool YAML::detail::node::equals(const T&, YAML::detail::shared_memory_holder) [with T = std::basic_string_view<char>; YAML::detail::shared_memory_holder = std::shared_ptr<YAML::detail::memory_holder>]’:
/usr/include/yaml-cpp/node/detail/impl.h:122:26:   required from ‘YAML::detail::node* YAML::detail::node_data::get(const Key&, YAML::detail::shared_memory_holder) const [with Key = std::basic_string_view<char>; YAML::detail::shared_memory_holder = std::shared_ptr<YAML::detail::memory_holder>]’
/usr/include/yaml-cpp/node/detail/node_ref.h:64:55:   required from ‘YAML::detail::node* YAML::detail::node_ref::get(const Key&, YAML::detail::shared_memory_holder) const [with Key = std::basic_string_view<char>; YAML::detail::shared_memory_holder = std::shared_ptr<YAML::detail::memory_holder>]’
/usr/include/yaml-cpp/node/detail/node.h:125:53:   required from ‘YAML::detail::node* YAML::detail::node::get(const Key&, YAML::detail::shared_memory_holder) const [with Key = std::basic_string_view<char>; YAML::detail::shared_memory_holder = std::shared_ptr<YAML::detail::memory_holder>]’
/usr/include/yaml-cpp/node/impl.h:392:71:   required from ‘const YAML::Node YAML::Node::operator[](const Key&) const [with Key = std::basic_string_view<char>]’
../../src/config/base_config.cc:20:23:   required from here
/usr/include/yaml-cpp/node/detail/impl.h:93:25: error: incomplete type ‘YAML::convert<std::basic_string_view<char> >’ used in nested name specifier
   93 |   if (convert<T>::decode(Node(*this, pMemory), lhs)) {
      |       ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
```
after this change, a full specialization for `convert<std::string_view`
is added so that we can lookup a node using key of `std::string_view`, like
```c++
string_view key = "yet_another_key";
auto value = node[key];
```

tested with
```console
$ cmake -B build -D CMAKE_CXX_STANDARD=20 -D YAML_CPP_BUILD_TESTS=ON -G Ninja
$ cmake --build build yaml-cpp-tests
$ ctest --test-dir build --output-on-failure
```

Signed-off-by: Kefu Chai <tchaikov@gmail.com>