### PR TITLE
CI: define read-only permission for GitHub Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: [ master ]
   workflow_dispatch:
+permissions: read-all
 jobs:
   cmake-build:
       strategy:


### PR DESCRIPTION
It secures the repo against erroneous or malicious actions from external jobs you call from your workflow. It's specially important for the case they get compromised, for example.

Closes #1174