### PR TITLE
Move CTest to the test entry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ include(CMakePackageConfigHelpers)
 include(CMakeDependentOption)
 include(CheckCXXCompilerFlag)
 include(GNUInstallDirs)
-include(CTest)
 
 option(YAML_CPP_BUILD_CONTRIB "Enable yaml-cpp contrib in library" ON)
 option(YAML_CPP_BUILD_TOOLS "Enable parse tools" ON)
@@ -179,6 +178,7 @@ endif()
 unset(CONFIG_EXPORT_DIR)
 
 if(YAML_CPP_BUILD_TESTS)
+  include(CTest)
   add_subdirectory(test)
 endif()
 


### PR DESCRIPTION

If `CTest` is a global reference, then `YAML_CPP_BUILD_TESTS` will be called and the compilation product will be generated regardless of whether `YAML_CPP_BUILD_TESTS` is enabled or not. So it makes more sense to put `include(CTest)` inside the `if (YAML_CPP_BUILD_TESTS)` statement.

```cmake
if(YAML_CPP_BUILD_TESTS)
  include(CTest)
  add_subdirectory(test)
endif()

```