### PR TITLE
Revert "Move CTest to the test entry"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include(CMakePackageConfigHelpers)
 include(CMakeDependentOption)
 include(CheckCXXCompilerFlag)
 include(GNUInstallDirs)
+include(CTest)
 
 option(YAML_CPP_BUILD_CONTRIB "Enable yaml-cpp contrib in library" ON)
 option(YAML_CPP_BUILD_TOOLS "Enable parse tools" ON)
@@ -178,7 +179,6 @@ endif()
 unset(CONFIG_EXPORT_DIR)
 
 if(YAML_CPP_BUILD_TESTS)
-  include(CTest)
   add_subdirectory(test)
 endif()
 


### PR DESCRIPTION
Reverts jbeder/yaml-cpp#1181

It broke the CI by somehow not surfacing any tests to run.