### PR TITLE
Add whitespace in tag match regex

### DIFF
--- a/src/exp.h
+++ b/src/exp.h
@@ -139,7 +139,7 @@ inline const RegEx& URI() {
   return e;
 }
 inline const RegEx& Tag() {
-  static const RegEx e = Word() | RegEx("#;/?:@&=+$_.~*'()", REGEX_OR) |
+  static const RegEx e = Word() | RegEx(" #;/?:@&=+$_.~*'()", REGEX_OR) |
                          (RegEx('%') + Hex() + Hex());
   return e;
 }


### PR DESCRIPTION
I'm not sure if this fix matches YAML standard, but sometimes these is whitespace in tag suffix, for example, it is widely used in Unity Engine's meta file, like this:
```
%YAML 1.1
%TAG !u! tag:unity3d.com,2011:
--- !u!1 &29818312667802682
GameObject:
  m_ObjectHideFlags: 0
  m_CorrespondingSourceObject: {fileID: 0}
  m_PrefabInstance: {fileID: 0}
  m_PrefabAsset: {fileID: 0}
  serializedVersion: 6
```
Without the patch, we'll only get `unity3d.com,2011:1` for the tag, but what I need is `unity3d.com,2011:1 &29818312667802682`.
Or are there some better ways to achieve this?