### PR TITLE
Specify CMake policy range to avoid deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-# 3.5 is actually available almost everywhere, but this a good minimum
-cmake_minimum_required(VERSION 3.4)
+# 3.5 is actually available almost everywhere, but this a good minimum.
+# 3.14 as the upper policy limit avoids CMake deprecation warnings.
+cmake_minimum_required(VERSION 3.4...3.14)
 
 # enable MSVC_RUNTIME_LIBRARY target property
 # see https://cmake.org/cmake/help/latest/policy/CMP0091.html


### PR DESCRIPTION
CMake 3.27 started issuing a deprecation warning for any
cmake_minimum_required() call that specified a minimum
version older than 3.5. Specifying a version range instead of
a simple minimum version avoids that warning without
raising the minimum supported CMake version. The NEW
policy behavior will be used for all policies introduced up to
CMake 3.14 with this change.

I checked the effects of the policies between CMake 3.4 and 3.14,
and I believe the NEW behavior of all those policies should be fine
for the CMakeLists.txt files in this project. I didn't go any higher
because policy CMP0092 added by CMake 3.15 would need further
checking (that policy affects the default compiler warning flags).