### PR TITLE
CMake: Fixes for generated config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
     branches: [ master ]
   workflow_dispatch:
 permissions: read-all
+defaults:
+  run:
+    shell: bash
 jobs:
   cmake-build:
       strategy:
@@ -26,23 +29,59 @@ jobs:
         YAML_BUILD_SHARED_LIBS: ${{ matrix.build == 'shared' && 'ON' || 'OFF' }}
         CMAKE_GENERATOR: >-
           ${{format(matrix.generator != 'Default Generator' && '-G "{0}"' || '', matrix.generator)}}
+        CMAKE_INSTALL_PREFIX: "${{ github.workspace }}/install-prefix"
+        CMAKE_BUILD_TYPE: Debug
       runs-on: ${{ matrix.os }}
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
 
-        - name: Get number of CPU cores
-          uses: SimenB/github-actions-cpu-cores@v1
-
-        - name: Build Tests
-          shell: bash
+        - name: Configure
           run: |
-            cmake ${{ env.CMAKE_GENERATOR }} -S "${{ github.workspace }}" -B build -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} -DYAML_BUILD_SHARED_LIBS=${{ env.YAML_BUILD_SHARED_LIBS }} -DYAML_CPP_BUILD_TESTS=ON
-            cd build && cmake --build . --parallel ${{ steps.cpu-cores.outputs.count }}
+            cmake \
+              ${{ env.CMAKE_GENERATOR }} \
+              -S "${{ github.workspace }}" \
+              -B build \
+              -D CMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
+              -D CMAKE_INSTALL_PREFIX="${{ env.CMAKE_INSTALL_PREFIX }}" \
+              -D CMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
+              -D YAML_BUILD_SHARED_LIBS=${{ env.YAML_BUILD_SHARED_LIBS }} \
+              -D YAML_CPP_BUILD_TESTS=ON
+
+        - name: Build
+          run: |
+            cmake \
+              --build build \
+              --config ${{ env.CMAKE_BUILD_TYPE }} \
+              --verbose \
+              --parallel
 
         - name: Run Tests
           shell: bash
           run: |
-            cd build && ctest -C Debug --output-on-failure --verbose
+            ctest \
+              --test-dir build \
+              --build-config ${{ env.CMAKE_BUILD_TYPE }} \
+              --output-on-failure \
+              --verbose
+
+        - name: Install
+          run: cmake --install build --config ${{ env.CMAKE_BUILD_TYPE }}
+
+        - name: Configure CMake package test
+          run: |
+            cmake \
+              ${{ env.CMAKE_GENERATOR }} \
+              -S "${{ github.workspace }}/test/cmake" \
+              -B consumer-build \
+              -D CMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
+              -D CMAKE_PREFIX_PATH="${{ env.CMAKE_INSTALL_PREFIX }}"
+
+        - name: Build CMake package test
+          run: |
+            cmake \
+              --build consumer-build \
+              --config ${{ env.CMAKE_BUILD_TYPE }} \
+              --verbose
 
   bazel-build:
       strategy:
@@ -50,16 +89,14 @@ jobs:
           os: [ubuntu-latest, windows-latest, macos-latest]
       runs-on: ${{ matrix.os }}
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
 
         - name: Build
-          shell: bash
           run: |
             cd "${{ github.workspace }}"
             bazel build :all
 
         - name: Test
-          shell: bash
           run: |
             cd "${{ github.workspace }}"
             bazel test test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,12 +146,12 @@ set_target_properties(yaml-cpp PROPERTIES
   PROJECT_LABEL "yaml-cpp ${yaml-cpp-label-postfix}"
   DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
 
-set(EXPORT_TARGETS yaml-cpp)
+set(EXPORT_TARGETS yaml-cpp::yaml-cpp)
 configure_package_config_file(
   "${PROJECT_SOURCE_DIR}/yaml-cpp-config.cmake.in"
   "${PROJECT_BINARY_DIR}/yaml-cpp-config.cmake"
   INSTALL_DESTINATION "${YAML_CPP_INSTALL_CMAKEDIR}"
-  PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR YAML_BUILD_SHARED_LIBS)
+  PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR)
 unset(EXPORT_TARGETS)
 
 write_basic_package_version_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ cmake_dependent_option(YAML_CPP_BUILD_TESTS
 cmake_dependent_option(YAML_MSVC_SHARED_RT
   "MSVC: Build yaml-cpp with shared runtime libs (/MD)" ON
   "CMAKE_SYSTEM_NAME MATCHES Windows" OFF)
+set(YAML_CPP_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/yaml-cpp"
+  CACHE STRING "Path to install the CMake package to")
  
 if (YAML_CPP_FORMAT_SOURCE)
     find_program(YAML_CPP_CLANG_FORMAT_EXE NAMES clang-format)
@@ -144,13 +146,12 @@ set_target_properties(yaml-cpp PROPERTIES
   PROJECT_LABEL "yaml-cpp ${yaml-cpp-label-postfix}"
   DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
 
-set(CONFIG_EXPORT_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/yaml-cpp")
 set(EXPORT_TARGETS yaml-cpp)
 configure_package_config_file(
   "${PROJECT_SOURCE_DIR}/yaml-cpp-config.cmake.in"
   "${PROJECT_BINARY_DIR}/yaml-cpp-config.cmake"
-  INSTALL_DESTINATION "${CONFIG_EXPORT_DIR}"
-  PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR CONFIG_EXPORT_DIR YAML_BUILD_SHARED_LIBS)
+  INSTALL_DESTINATION "${YAML_CPP_INSTALL_CMAKEDIR}"
+  PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR YAML_BUILD_SHARED_LIBS)
 unset(EXPORT_TARGETS)
 
 write_basic_package_version_file(
@@ -170,15 +171,14 @@ if (YAML_CPP_INSTALL)
                 FILES_MATCHING PATTERN "*.h")
   install(EXPORT yaml-cpp-targets
     NAMESPACE yaml-cpp::
-    DESTINATION "${CONFIG_EXPORT_DIR}")
+    DESTINATION "${YAML_CPP_INSTALL_CMAKEDIR}")
   install(FILES
       "${PROJECT_BINARY_DIR}/yaml-cpp-config.cmake"
       "${PROJECT_BINARY_DIR}/yaml-cpp-config-version.cmake"
-    DESTINATION "${CONFIG_EXPORT_DIR}")
+    DESTINATION "${YAML_CPP_INSTALL_CMAKEDIR}")
   install(FILES "${PROJECT_BINARY_DIR}/yaml-cpp.pc"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()
-unset(CONFIG_EXPORT_DIR)
 
 if(YAML_CPP_BUILD_TESTS)
   add_subdirectory(test)

--- a/test/cmake/CMakeLists.txt
+++ b/test/cmake/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.5)
+project(yaml-cpp-consumer LANGUAGES CXX)
+
+find_package(yaml-cpp CONFIG REQUIRED)
+get_target_property(LIBRARY_TYPE yaml-cpp::yaml-cpp TYPE)
+
+if(LIBRARY_TYPE STREQUAL "SHARED_LIBRARY")
+  if(NOT YAML_CPP_SHARED_LIBS_BUILT)
+    message(FATAL_ERROR "Library type (${LIBRARY_TYPE}) contradicts config: ${YAML_CPP_SHARED_LIBS_BUILT}")
+  endif()
+else()
+  if(YAML_CPP_SHARED_LIBS_BUILT)
+    message(FATAL_ERROR "Library type (${LIBRARY_TYPE}) contradicts config: ${YAML_CPP_SHARED_LIBS_BUILT}")
+  endif()
+endif()
+
+add_executable(main main.cpp)
+set_target_properties(main PROPERTIES CXX_STANDARD 11)
+target_link_libraries(main PRIVATE ${YAML_CPP_LIBRARIES})

--- a/test/cmake/main.cpp
+++ b/test/cmake/main.cpp
@@ -1,0 +1,3 @@
+#include "yaml-cpp/yaml.h"
+
+int main(int, char**) { YAML::Parser foo{}; }

--- a/yaml-cpp-config.cmake.in
+++ b/yaml-cpp-config.cmake.in
@@ -19,4 +19,12 @@ include("${CMAKE_CURRENT_LIST_DIR}/yaml-cpp-targets.cmake")
 # These are IMPORTED targets created by yaml-cpp-targets.cmake
 set(YAML_CPP_LIBRARIES "@EXPORT_TARGETS@")
 
+add_library(yaml-cpp INTERFACE)
+target_link_libraries(yaml-cpp INTERFACE yaml-cpp::yaml-cpp)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+  set_target_properties(yaml-cpp PROPERTIES 
+    DEPRECATION "The target yaml-cpp is deprecated and will be removed in version 0.10.0. Use the yaml-cpp::yaml-cpp target instead."
+  )
+endif()
+
 check_required_components(yaml-cpp)

--- a/yaml-cpp-config.cmake.in
+++ b/yaml-cpp-config.cmake.in
@@ -11,12 +11,12 @@ set_and_check(YAML_CPP_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 set_and_check(YAML_CPP_LIBRARY_DIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
 
 # Are we building shared libraries?
-set(YAML_CPP_SHARED_LIBS_BUILT "@PACKAGE_YAML_BUILD_SHARED_LIBS@")
+set(YAML_CPP_SHARED_LIBS_BUILT @YAML_BUILD_SHARED_LIBS@)
 
 # Our library dependencies (contains definitions for IMPORTED targets)
-include(@PACKAGE_CONFIG_EXPORT_DIR@/yaml-cpp-targets.cmake)
+include("${CMAKE_CURRENT_LIST_DIR}/yaml-cpp-targets.cmake")
 
 # These are IMPORTED targets created by yaml-cpp-targets.cmake
 set(YAML_CPP_LIBRARIES "@EXPORT_TARGETS@")
 
-check_required_components(@EXPORT_TARGETS@)
+check_required_components(yaml-cpp)

--- a/yaml-cpp-config.cmake.in
+++ b/yaml-cpp-config.cmake.in
@@ -19,7 +19,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/yaml-cpp-targets.cmake")
 # These are IMPORTED targets created by yaml-cpp-targets.cmake
 set(YAML_CPP_LIBRARIES "@EXPORT_TARGETS@")
 
-add_library(yaml-cpp INTERFACE)
+add_library(yaml-cpp INTERFACE IMPORTED)
 target_link_libraries(yaml-cpp INTERFACE yaml-cpp::yaml-cpp)
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
   set_target_properties(yaml-cpp PROPERTIES 


### PR DESCRIPTION
While packing 0.8.0 in vcpkg, I noticed the following issues with the generated `yaml-cpp-config.cmake`:
- `YAML_CPP_SHARED_LIBS_BUILT` is set with a `PATH_VAR`, expanding to `${PACKAGE_PREFIX}/<actual value>`, which is always true.
- `yaml-cpp-targets.cmake` is loaded using a `PATH_VAR`, which causes an issue with the way vcpkg handles CMake configs.
- `YAML_CPP_LIBRARIES` is set to `yaml-cpp` without the `yaml-cpp::` namespace.

About vcpkg, after the package is installed, it moves all CMake configs to `share/<package name>` and patches the `PACKAGE_PREFIX_DIR` and `_IMPORT_PREFIX`. Using a `PATH_VAR` to include the `targets` file would break this relocation.

---

This PR addresses these issues as such:
- For `YAML_CPP_SHARED_LIBS_BUILT`, use `@YAML_BUILD_SHARED_LIBS@`, this correctly expands to a boolean value.
- For `yaml-cpp-targets.cmake`, instead of relying on the `CONFIG_EXPORT_DIR` `PATH_VAR`, use `${CMAKE_CURRENT_LIST_DIR}/yaml-cpp-targets.cmake`. This is guaranteed to be always true as the config and targets are always installed to the same location.
- For `YAML_CPP_LIBRARIES`, I set `EXPORT_TARGETS` to `yaml-cpp::yaml-cpp` as it is the target name that is actually available to users, and pass to `check_required_components` `yaml-cpp` instead.
- Lastly, I added an option `YAML_CPP_INSTALL_CMAKEDIR` to control which directory to install the CMake configs to. This is a configuration option often wanted by package managers as they sort of all have their own convention.