### PR TITLE
CMake: Allow to disable uninstall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ if (YAML_CPP_FORMAT_SOURCE AND YAML_CPP_CLANG_FORMAT_EXE)
 endif()
 
 # uninstall target
-if(NOT YAML_CPP_DISABLE_UNINSTALL AND NOT TARGET uninstall)
+if(YAML_CPP_INSTALL AND NOT YAML_CPP_DISABLE_UNINSTALL AND NOT TARGET uninstall)
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ option(YAML_CPP_BUILD_TOOLS "Enable parse tools" ON)
 option(YAML_BUILD_SHARED_LIBS "Build yaml-cpp shared library" ${BUILD_SHARED_LIBS})
 option(YAML_CPP_INSTALL "Enable generation of yaml-cpp install targets" ${YAML_CPP_MAIN_PROJECT})
 option(YAML_CPP_FORMAT_SOURCE "Format source" ON)
+option(YAML_CPP_DISABLE_UNINSTALL  "Disable uninstallation of yaml-cpp" OFF)
+
 cmake_dependent_option(YAML_CPP_BUILD_TESTS
   "Enable yaml-cpp tests" OFF
   "BUILD_TESTING;YAML_CPP_MAIN_PROJECT" OFF)
@@ -197,7 +199,7 @@ if (YAML_CPP_FORMAT_SOURCE AND YAML_CPP_CLANG_FORMAT_EXE)
 endif()
 
 # uninstall target
-if(NOT TARGET uninstall)
+if(NOT YAML_CPP_DISABLE_UNINSTALL AND NOT TARGET uninstall)
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"


### PR DESCRIPTION
`add_custom_target(uninstall ...` causes a clash with the same target in rtmidi (https://github.com/thestk/rtmidi). "add_custom_target cannot create target "uninstall" because another target with the same name already exists.  The existing target is a custom target created in source directory"

So it's probably easiest to simply allow to disable the uninstall in the first place.

Also gates the uninstall target unless `YAML_CPP_INSTALL` is set, which fixes #1151.