### PR TITLE
node/convert: relax the check for string_view

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -17,8 +17,9 @@
 #include <type_traits>
 #include <valarray>
 #include <vector>
+#include <version>
 
-#if __cplusplus >= 201703L
+#ifdef __cpp_lib_string_view
 #include <string_view>
 #endif
 
@@ -93,7 +94,7 @@ struct convert<char[N]> {
   static Node encode(const char* rhs) { return Node(rhs); }
 };
 
-#if __cplusplus >= 201703L
+#ifdef __cpp_lib_string_view
 template <>
 struct convert<std::string_view> {
   static Node encode(std::string_view rhs) { return Node(std::string(rhs)); }


### PR DESCRIPTION
in 35b44980, the conversion for `std::string_view` was added, but it enables it only if C++17 is used. but the availability of `std::string_view` does not depends on C++17. in this change, we use the more specific language feature macro to check the availability of `std::string_view` instead of checking for the C++ standard.

Refs #1148
Signed-off-by: Kefu Chai <tchaikov@gmail.com>