### PR TITLE
Revert "node/convert: relax the check for string_view (#1222)"

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -17,9 +17,8 @@
 #include <type_traits>
 #include <valarray>
 #include <vector>
-#include <version>
 
-#ifdef __cpp_lib_string_view
+#if __cplusplus >= 201703L
 #include <string_view>
 #endif
 
@@ -94,7 +93,7 @@ struct convert<char[N]> {
   static Node encode(const char* rhs) { return Node(rhs); }
 };
 
-#ifdef __cpp_lib_string_view
+#if __cplusplus >= 201703L
 template <>
 struct convert<std::string_view> {
   static Node encode(std::string_view rhs) { return Node(std::string(rhs)); }


### PR DESCRIPTION
This reverts commit 6262201182a0ee357d8a456e6d1a8e5984e4c6dd.

in 62622011, we wanted address the needs to use the `string_view` converter in C++98, but that requirement was based on wrong preconditions. `std::string_view` was introduced in C++17, and popular standard libraries like libstdc++ and libc++ both provide `std::string_view` when the source is built with C++17.

furthermore 62622011 is buggy. because it uses `<version>` to tell the feature set provided by the standard library. but `<version>` is a part of C++20. so this defeats the purpose of the change of 62622011.

Fixes #1223