### PR TITLE
node/convert: Enable the template specialization for `std::string_view` properly when the library is compiled by MSVC on Windows.

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -18,7 +18,7 @@
 #include <valarray>
 #include <vector>
 
-#if __cplusplus >= 201703L
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
 #include <string_view>
 #endif
 
@@ -93,7 +93,7 @@ struct convert<char[N]> {
   static Node encode(const char* rhs) { return Node(rhs); }
 };
 
-#if __cplusplus >= 201703L
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
 template <>
 struct convert<std::string_view> {
   static Node encode(std::string_view rhs) { return Node(std::string(rhs)); }


### PR DESCRIPTION
Please refer to the discussion in https://github.com/jbeder/yaml-cpp/pull/1222 for details.