### PR TITLE
Disable `format` Target When Not Building as the Main Project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,14 +25,14 @@ option(YAML_CPP_BUILD_CONTRIB "Enable yaml-cpp contrib in library" ON)
 option(YAML_CPP_BUILD_TOOLS "Enable parse tools" ON)
 option(YAML_BUILD_SHARED_LIBS "Build yaml-cpp shared library" ${BUILD_SHARED_LIBS})
 option(YAML_CPP_INSTALL "Enable generation of yaml-cpp install targets" ${YAML_CPP_MAIN_PROJECT})
-option(YAML_CPP_FORMAT_SOURCE "Format source" ON)
+option(YAML_CPP_FORMAT_SOURCE "Format source" ${YAML_CPP_MAIN_PROJECT})
 cmake_dependent_option(YAML_CPP_BUILD_TESTS
   "Enable yaml-cpp tests" OFF
   "BUILD_TESTING;YAML_CPP_MAIN_PROJECT" OFF)
 cmake_dependent_option(YAML_MSVC_SHARED_RT
   "MSVC: Build yaml-cpp with shared runtime libs (/MD)" ON
   "CMAKE_SYSTEM_NAME MATCHES Windows" OFF)
- 
+
 if (YAML_CPP_FORMAT_SOURCE)
     find_program(YAML_CPP_CLANG_FORMAT_EXE NAMES clang-format)
 endif()


### PR DESCRIPTION
This pull request modifies the `YAML_CPP_FORMAT_SOURCE` option to default to enabled only when building as the main project. This change prevents conflicts with the `format` target if this project is included by another project that already has its own `format` target. Previously, `YAML_CPP_FORMAT_SOURCE` needed to be manually set to `false` to avoid this issue.