### PR TITLE
Need to set CMAKE_COMPILE_PDB_OUTPUT_DIRECTORY to lib folder in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ else()
   set(yaml-cpp-label-postfix "static")
 endif()
 
+set(CMAKE_COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_INSTALL_LIBDIR}/../")
+
 set(build-shared $<BOOL:${YAML_BUILD_SHARED_LIBS}>)
 set(build-windows-dll $<AND:$<BOOL:${CMAKE_HOST_WIN32}>,${build-shared}>)
 set(not-msvc $<NOT:$<CXX_COMPILER_ID:MSVC>>)


### PR DESCRIPTION
There's currently a warning message when using YAML-CPP as static library in debug mode because the library yaml-cppd.lib is expecting / missing pdb information. By setting the pdb generation folder to the lib folder, the compiler is no longer complaining.

It now looks like this:
```
.\RootBuildFolder\Release
- yaml-cpp.lib

.\RootBuildFolder\Debug
- yaml-cpp static.pdb
- yaml-cppd.lib
```

See more about the problem:
https://stackoverflow.com/questions/25843883/how-to-remove-warning-lnk4099-pdb-lib-pdb-was-not-found