### PR TITLE
CMake: hide all symbols by default in shared lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,12 @@ set_property(TARGET yaml-cpp
   PROPERTY
     CXX_STANDARD_REQUIRED ON)
 
-if (NOT YAML_BUILD_SHARED_LIBS)
+if(YAML_BUILD_SHARED_LIBS)
+  set_target_properties(yaml-cpp PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+  )
+else()
   set_property(TARGET yaml-cpp PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 

--- a/include/yaml-cpp/dll.h
+++ b/include/yaml-cpp/dll.h
@@ -7,55 +7,22 @@
 // Definition yaml_cpp_EXPORTS using to building YAML-CPP as dll/so library
 // (definition created by CMake or defined manually)
 
-#ifdef YAML_CPP_STATIC_DEFINE
-#  define YAML_CPP_API
-#  define YAML_CPP_NO_EXPORT
-#else
-#  if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
-#    ifndef YAML_CPP_API
+#ifndef YAML_CPP_API
+#  ifdef YAML_CPP_STATIC_DEFINE
+#    define YAML_CPP_API
+#  else
+#    ifdef _WIN32
 #      ifdef yaml_cpp_EXPORTS
          /* We are building this library */
-#        pragma message( "Defining YAML_CPP_API for DLL export" )
 #        define YAML_CPP_API __declspec(dllexport)
 #      else
          /* We are using this library */
-#        pragma message( "Defining YAML_CPP_API for DLL import" )
 #        define YAML_CPP_API __declspec(dllimport)
 #      endif
-#    endif
-#    ifndef YAML_CPP_NO_EXPORT
-#      define YAML_CPP_NO_EXPORT
-#    endif
-#  else /* No _MSC_VER */
-#    ifndef YAML_CPP_API
-#      ifdef yaml_cpp_EXPORTS
-         /* We are building this library */
-#        define YAML_CPP_API __attribute__((visibility("default")))
-#      else
-         /* We are using this library */
-#        define YAML_CPP_API __attribute__((visibility("default")))
-#      endif
-#    endif
-#    ifndef YAML_CPP_NO_EXPORT
-#      define YAML_CPP_NO_EXPORT __attribute__((visibility("hidden")))
-#    endif
-#  endif /* _MSC_VER */
-#endif   /* YAML_CPP_STATIC_DEFINE */
-
-#ifndef YAML_CPP_DEPRECATED
-#  ifdef _MSC_VER
-#    define YAML_CPP_DEPRECATED __declspec(deprecated)
-#  else
-#    define YAML_CPP_DEPRECATED __attribute__ ((__deprecated__))
-#  endif
-#endif
-
-#ifndef YAML_CPP_DEPRECATED_EXPORT
-#  define YAML_CPP_DEPRECATED_EXPORT YAML_CPP_API YAML_CPP_DEPRECATED
-#endif
-
-#ifndef YAML_CPP_DEPRECATED_NO_EXPORT
-#  define YAML_CPP_DEPRECATED_NO_EXPORT YAML_CPP_NO_EXPORT YAML_CPP_DEPRECATED
+#    else
+#      define YAML_CPP_API __attribute__((visibility("default")))
+#    endif /* _WIN32 */
+#  endif /* YAML_CPP_STATIC_DEFINE */
 #endif
 
 #endif /* DLL_H_62B23520_7C8E_11DE_8A39_0800200C9A66 */


### PR DESCRIPTION
Hide private symbols irrespective of compiler when yaml-cpp shared is built with CMake.
This PR is similar to https://github.com/jbeder/yaml-cpp/pull/984, but it does not remove `dll.h` (which was the reason why it has been reverted in https://github.com/jbeder/yaml-cpp/pull/1038). So it doesn't break users not relying on CMake to build yaml-cpp.

Also simplify `dll.h`, which had lot of dead code, and weird logic for entering in delcspec branch (actually it's windows specific, so `_WIN32` is fine).