### PR TITLE
workflows/build.yml: Use debug std C++ library on Ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
           ${{format(matrix.generator != 'Default Generator' && '-G "{0}"' || '', matrix.generator)}}
         CMAKE_INSTALL_PREFIX: "${{ github.workspace }}/install-prefix"
         CMAKE_BUILD_TYPE: Debug
+        CMAKE_CXX_FLAGS_DEBUG: ${{ matrix.googletest == 'build' && '-g -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC' || '-g' }} 
       runs-on: ${{ matrix.os }}
       steps:
 
@@ -57,6 +58,7 @@ jobs:
               -D CMAKE_CXX_STANDARD=${{ matrix.cxx_standard }} \
               -D CMAKE_INSTALL_PREFIX="${{ env.CMAKE_INSTALL_PREFIX }}" \
               -D CMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
+              -D CMAKE_CXX_FLAGS_DEBUG="${{ env.CMAKE_CXX_FLAGS_DEBUG }}" \
               -D YAML_BUILD_SHARED_LIBS=${{ env.YAML_BUILD_SHARED_LIBS }} \
               -D YAML_USE_SYSTEM_GTEST=${{ env.YAML_USE_SYSTEM_GTEST }} \
               -D YAML_CPP_BUILD_TESTS=ON

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ cmake [-G generator] [-DYAML_BUILD_SHARED_LIBS=on|OFF] ..
 
   * `yaml-cpp` builds a static library by default, you may want to build a shared library by specifying `-DYAML_BUILD_SHARED_LIBS=ON`.
 
+  * [Debug mode of the GNU standard C++
+    library](https://gcc.gnu.org/onlinedocs/libstdc++/manual/debug_mode.html)
+    can be used when both `yaml-cpp` and client code is compiled with the
+    `_GLIBCXX_DEBUG` flag (e.g. by calling CMake with `-D
+    CMAKE_CXX_FLAGS_DEBUG='-g -D_GLIBCXX_DEBUG'` option).
+
+    Note that for `yaml-cpp` unit tests to run successfully, the _GoogleTest_
+    library also must be built with this flag, i.e. the system one cannot be
+    used (the _YAML_USE_SYSTEM_GTEST_ CMake option must be _OFF_, which is the
+    default).
+
   * For more options on customizing the build, see the [CMakeLists.txt](https://github.com/jbeder/yaml-cpp/blob/master/CMakeLists.txt) file.
 
 #### 2. Build it!


### PR DESCRIPTION
Protect from regressions due to use of undefined or
implementation-specific behavior when using `std::` containers and smart
pointers.

This only has effect on platforms with the GNU standard C++ library.

Refer to https://gcc.gnu.org/onlinedocs/libstdc++/manual/debug_mode.html.
