### PR TITLE
Fix indentation of empty flow sequences and add test

### DIFF
--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -213,7 +213,8 @@ void Emitter::EmitEndSeq() {
   if (m_pState->CurGroupFlowType() == FlowType::Flow) {
     if (m_stream.comment())
       m_stream << "\n";
-    m_stream << IndentTo(m_pState->CurIndent());
+    if (originalType == FlowType::Block || m_pState->HasBegunNode())
+      m_stream << IndentTo(m_pState->CurIndent());
     if (originalType == FlowType::Block) {
       m_stream << "[";
     } else {

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -176,6 +176,17 @@ TEST_F(EmitterTest, EmptyFlowSeqWithBegunContent) {
   ]])");
 }
 
+TEST_F(EmitterTest, EmptyFlowSeqInMap) {
+  out << BeginMap;
+  out << Key << Flow << BeginSeq << EndSeq;
+  out << Value << 1;
+  out << Key << 2;
+  out << Value << Flow << BeginSeq << EndSeq;
+  out << EndMap;
+
+  ExpectEmit("[]: 1\n2: []");
+}
+
 TEST_F(EmitterTest, EmptyFlowMapWithBegunContent) {
   out << Flow;
   out << BeginSeq;


### PR DESCRIPTION
Fixes jbeder/yaml-cpp#1263