### PR TITLE
Avoid static reference to temporary

### DIFF
--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -173,11 +173,11 @@ bool IsValidPlainScalar(const std::string& str, FlowType::value flowType,
   }
 
   // then check until something is disallowed
-  static const RegEx& disallowed_flow =
+  static const RegEx disallowed_flow =
       Exp::EndScalarInFlow() | (Exp::BlankOrBreak() + Exp::Comment()) |
       Exp::NotPrintable() | Exp::Utf8_ByteOrderMark() | Exp::Break() |
       Exp::Tab() | Exp::Ampersand();
-  static const RegEx& disallowed_block =
+  static const RegEx disallowed_block =
       Exp::EndScalar() | (Exp::BlankOrBreak() + Exp::Comment()) |
       Exp::NotPrintable() | Exp::Utf8_ByteOrderMark() | Exp::Break() |
       Exp::Tab() | Exp::Ampersand();


### PR DESCRIPTION
These caused issues when used in a wasm project.

Seen in https://github.com/fair-acc/graph-prototype/pull/308, where it failed on exit when executing the wasm unit test)
