### PR TITLE
fix: use C locale by default

### DIFF
--- a/include/yaml-cpp/emitter.h
+++ b/include/yaml-cpp/emitter.h
@@ -141,6 +141,7 @@ inline Emitter& Emitter::WriteIntegralType(T value) {
   PrepareNode(EmitterNodeType::Scalar);
 
   std::stringstream stream;
+  stream.imbue(std::locale("C"));
   PrepareIntegralStream(stream);
   stream << value;
   m_stream << stream.str();
@@ -158,6 +159,7 @@ inline Emitter& Emitter::WriteStreamable(T value) {
   PrepareNode(EmitterNodeType::Scalar);
 
   std::stringstream stream;
+  stream.imbue(std::locale("C"));
   SetStreamablePrecision<T>(stream);
 
   bool special = false;

--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -171,6 +171,7 @@ ConvertStreamTo(std::stringstream& stream, T& rhs) {
                                                                            \
     static Node encode(const type& rhs) {                                  \
       std::stringstream stream;                                            \
+      stream.imbue(std::locale("C"));                                       \
       stream.precision(std::numeric_limits<type>::max_digits10);           \
       conversion::inner_encode(rhs, stream);                               \
       return Node(stream.str());                                           \
@@ -182,6 +183,7 @@ ConvertStreamTo(std::stringstream& stream, T& rhs) {
       }                                                                    \
       const std::string& input = node.Scalar();                            \
       std::stringstream stream(input);                                     \
+      stream.imbue(std::locale("C"));                                       \
       stream.unsetf(std::ios::dec);                                        \
       if ((stream.peek() == '-') && std::is_unsigned<type>::value) {       \
         return false;                                                      \

--- a/include/yaml-cpp/traits.h
+++ b/include/yaml-cpp/traits.h
@@ -121,6 +121,7 @@ template<typename Key, bool Streamable>
 struct streamable_to_string {
   static std::string impl(const Key& key) {
     std::stringstream ss;
+    ss.imbue(std::locale("C"));
     ss << key;
     return ss.str();
   }

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -310,6 +310,7 @@ void node_data::convert_sequence_to_map(const shared_memory_holder& pMemory) {
   reset_map();
   for (std::size_t i = 0; i < m_sequence.size(); i++) {
     std::stringstream stream;
+    stream.imbue(std::locale("C"));
     stream << i;
 
     node& key = pMemory->create_node();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -77,6 +77,7 @@ void Parser::HandleYamlDirective(const Token& token) {
   }
 
   std::stringstream str(token.params[0]);
+  str.imbue(std::locale("C"));
   str >> m_pDirectives->version.major;
   str.get();
   str >> m_pDirectives->version.minor;

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -849,5 +849,17 @@ TEST_F(NodeEmitterTest, NestFlowMapListNode) {
 
   ExpectOutput("{position: [1.5, 2.25, 3.125]}", mapNode);
 }
+
+TEST_F(NodeEmitterTest, RobustAgainstLocale) {
+  std::locale::global(std::locale(""));
+  Node node;
+  node.push_back(1.5);
+  node.push_back(2.25);
+  node.push_back(3.125);
+  node.push_back(123456789);
+
+  ExpectOutput("- 1.5\n- 2.25\n- 3.125\n- 123456789", node);
+}
+
 }
 }


### PR DESCRIPTION
fix #1282

This explicitly sets locale 'C' to all `std::stringstream` objects that output YAML.
