### PR TITLE
doc, fix: invalid liquid '{{...}}' tags

### DIFF
--- a/docs/How-To-Emit-YAML.md
+++ b/docs/How-To-Emit-YAML.md
@@ -154,6 +154,7 @@ produces
 # STL Containers, and Other Overloads #
 We overload `operator <<` for `std::vector`, `std::list`, and `std::map`, so you can write stuff like:
 
+{% raw %}
 ```cpp
 std::vector <int> squares = {1, 4, 9, 16};
 
@@ -165,6 +166,7 @@ out << YAML::Flow << squares;
 out << ages;
 out << YAML::EndSeq;
 ```
+{% endraw %}
 
 produces
 


### PR DESCRIPTION
This fixes the failing of [pages build and deployment ](https://github.com/jbeder/yaml-cpp/actions/runs/9979691633/job/27579344971) when deploying the documentation.

jekyll/liquid got hung up on `{{"Daniel", 26}, {"Jesse", 24}}`.

The reason is that `{{...}}` are used as variables that are replaced by there values. In this case we have a YAML object that looks the same. This issue can be fixed by surrounding the block into `{% raw %}...{% endraw %}` tags.