### PR TITLE
Use c-strings to constant initialize token array

### DIFF
--- a/src/token.h
+++ b/src/token.h
@@ -13,7 +13,7 @@
 #include <vector>
 
 namespace YAML {
-const std::string TokenNames[] = {
+constexpr const char* TokenNames[] = {
     "DIRECTIVE",        "DOC_START",      "DOC_END",       "BLOCK_SEQ_START",
     "BLOCK_MAP_START",  "BLOCK_SEQ_END",  "BLOCK_MAP_END", "BLOCK_ENTRY",
     "FLOW_SEQ_START",   "FLOW_MAP_START", "FLOW_SEQ_END",  "FLOW_MAP_END",


### PR DESCRIPTION
Since `std::string` has to be dynamically constructed and destructed, it could be accessed before initialization or after destruction in a multithreaded context. By using constant c-strings instead, we guarantee that the array will be valid for the whole lifetime of the program. The use of `constexpr` also enforces this requirement.

I have run clang-format on the file to format my changes according to CONTRIBUTING.md.