### PR TITLE
emitterutils: Explicitly include <cstdint>

### DIFF
--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 


### PR DESCRIPTION
GCC 15 will no longer include it by default, resulting in build failures in projects that do not explicitly include it.

Error:
```
src/emitterutils.cpp:221:11: error: 'uint16_t' was not declared in this scope
  221 | std::pair<uint16_t, uint16_t> EncodeUTF16SurrogatePair(int codePoint) {
      |           ^~~~~~~~
src/emitterutils.cpp:13:1: note: 'uint16_t' is defined in header '<cstdint>';
this is probably fixable by adding '#include <cstdint>'
   12 | #include "yaml-cpp/null.h"
  +++ |+#include <cstdint>
   13 | #include "yaml-cpp/ostream_wrapper.h"
```

Tests pass.

Closes: https://github.com/jbeder/yaml-cpp/issues/1307
See-also: https://gcc.gnu.org/pipermail/gcc-cvs/2024-August/407124.html
See-also: https://bugs.gentoo.org/937412