### PR TITLE
fix: missing token enum name

### DIFF
--- a/src/token.h
+++ b/src/token.h
@@ -18,7 +18,8 @@ constexpr const char* TokenNames[] = {
     "BLOCK_MAP_START",  "BLOCK_SEQ_END",  "BLOCK_MAP_END", "BLOCK_ENTRY",
     "FLOW_SEQ_START",   "FLOW_MAP_START", "FLOW_SEQ_END",  "FLOW_MAP_END",
     "FLOW_MAP_COMPACT", "FLOW_ENTRY",     "KEY",           "VALUE",
-    "ANCHOR",           "ALIAS",          "TAG",           "SCALAR"};
+    "ANCHOR",           "ALIAS",          "TAG",           "SCALAR",
+    "NON_PLAIN_SCALAR"};
 
 struct Token {
   // enums


### PR DESCRIPTION
This is fixing a potential out of bound access, when using `PrintTokens` (which is not used anywhere).

The array of `TokenNames` must match the elements of `enum Token::TYPE`.