### PR TITLE
fix(src,include,test): fixed multiple cases where a bad yaml was accepted

### DIFF
--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -48,6 +48,8 @@ const char* const UNKNOWN_TOKEN = "unknown token";
 const char* const DOC_IN_SCALAR = "illegal document indicator in scalar";
 const char* const EOF_IN_SCALAR = "illegal EOF in scalar";
 const char* const CHAR_IN_SCALAR = "illegal character in scalar";
+const char* const UNEXPECTED_SCALAR = "unexpected scalar";
+const char* const UNEXPECTED_FLOW = "plain value cannot start with flow indicator character";
 const char* const TAB_IN_INDENTATION =
     "illegal tab when looking for indentation";
 const char* const FLOW_END = "illegal flow end";

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -177,6 +177,7 @@ class Scanner {
   // state info
   bool m_startedStream, m_endedStream;
   bool m_simpleKeyAllowed;
+  bool m_scalarValueAllowed;
   bool m_canBeJSONFlow;
   std::stack<SimpleKey> m_simpleKeys;
   std::stack<IndentMarker *> m_indents;

--- a/src/scantoken.cpp
+++ b/src/scantoken.cpp
@@ -211,6 +211,9 @@ void Scanner::ScanValue() {
     m_simpleKeyAllowed = InBlockContext();
   }
 
+  // we are parsing a `key: value` pair; scalars are always allowed
+  m_scalarValueAllowed = true;
+
   // eat
   Mark mark = INPUT.mark();
   INPUT.eat(1);
@@ -360,6 +363,10 @@ void Scanner::ScanQuotedScalar() {
   // and scan
   scalar = ScanScalar(INPUT, params);
   m_simpleKeyAllowed = false;
+  // we just scanned a quoted scalar;
+  // we can only have another scalar in this line
+  // if we are in a flow, eg: `[ "foo", "bar" ]` is ok, but `"foo", "bar"` isn't.
+  m_scalarValueAllowed = InFlowContext();
   m_canBeJSONFlow = true;
 
   Token token(Token::NON_PLAIN_SCALAR, mark);


### PR DESCRIPTION
Also, i added test cases.

The yaml parser did not catch some strings related yaml issues, like:
```yaml
"foo","bar"
```
This is linked to the discussion here: https://github.com/falcosecurity/falco/issues/3281

Note: i am not an expert therefore please let me know if i can do anything better (or if the fix makes no sense at all :D )
