### PR TITLE
Fix build with NVHPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,9 @@ endif()
 
 set(build-shared $<BOOL:${YAML_BUILD_SHARED_LIBS}>)
 set(build-windows-dll $<AND:$<BOOL:${CMAKE_HOST_WIN32}>,${build-shared}>)
-set(not-msvc $<NOT:$<CXX_COMPILER_ID:MSVC>>)
 set(msvc-shared_rt $<BOOL:${YAML_MSVC_SHARED_RT}>)
+
+set(print-warnings $<NOT:$<OR:$<CXX_COMPILER_ID:MSVC>,$<CXX_COMPILER_ID:NVHPC>>>)
 
 if (NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
   set(CMAKE_MSVC_RUNTIME_LIBRARY
@@ -111,8 +112,8 @@ endif()
 if(YAML_CPP_MAIN_PROJECT)
   target_compile_options(yaml-cpp
     PRIVATE
-      $<${not-msvc}:-Wall -Wextra -Wshadow -Weffc++ -Wno-long-long>
-      $<${not-msvc}:-pedantic -pedantic-errors>)
+      $<${print-warnings}:-Wall -Wextra -Wshadow -Weffc++ -Wno-long-long>
+      $<${print-warnings}:-pedantic -pedantic-errors>)
 endif()
 
 target_compile_options(yaml-cpp


### PR DESCRIPTION
Exclude all warning-emitting flags if building as main project with the NVHPC compiler (effectively making it take the same exception as for MSVC there).

Otherwise, the build will fail right now, due to NVHPC not recognizing all the specified compiler options. Cf. the following snippet which runs CMake and attempts to build yaml-cpp 0.8.0:
```
$ cmake ..
-- The CXX compiler identification is NVHPC 24.7.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /[...]/24.7/compilers/bin/nvc++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (0.8s)
-- Generating done (1.1s)
-- Build files have been written to: /[...]/yaml-cpp/build
$ make
[  2%] Building CXX object CMakeFiles/yaml-cpp.dir/src/contrib/graphbuilder.cpp.o
nvc++-Error-Unknown switch: -Weffc++
nvc++-Error-Unknown switch: -pedantic-errors
make[2]: *** [CMakeFiles/yaml-cpp.dir/build.make:76: CMakeFiles/yaml-cpp.dir/src/contrib/graphbuilder.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:861: CMakeFiles/yaml-cpp.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```