### PR TITLE
missing keys should throw InvalidNode, not BadConversion

### DIFF
--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -124,8 +124,8 @@ struct as_if<T, void> {
   const Node& node;
 
   T operator()() const {
-    if (!node.m_pNode)
-      throw TypedBadConversion<T>(node.Mark());
+    if (!node.m_pNode) // no fallback
+      throw InvalidNode(node.m_invalidKey);
 
     T t;
     if (convert<T>::decode(node, t))
@@ -140,6 +140,8 @@ struct as_if<std::string, void> {
   const Node& node;
 
   std::string operator()() const {
+    if (node.Type() == NodeType::Undefined) // no fallback
+      throw InvalidNode(node.m_invalidKey);
     if (node.Type() == NodeType::Null)
       return "null";
     if (node.Type() != NodeType::Scalar)

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -191,6 +191,14 @@ TEST(NodeTest, MapElementRemoval) {
   EXPECT_TRUE(!node["foo"]);
 }
 
+TEST(NodeTest, MissingKey) {
+  Node node;
+  node["foo"] = "value";
+  EXPECT_TRUE(!node["bar"]);
+  EXPECT_EQ(NodeType::Undefined, node["bar"].Type());
+  EXPECT_THROW(node["bar"].as<std::string>(), InvalidNode);
+}
+
 TEST(NodeTest, MapIntegerElementRemoval) {
   Node node;
   node[1] = "hello";


### PR DESCRIPTION
Fixes GH #1274