### PR TITLE
Exclude ubuntu/C++ 11/googletest system from the test matrix since it doesn't compile.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ jobs:
           googletest: [build, system]
           generator: ["Default Generator", "MinGW Makefiles"]
           exclude:
+          - os: ubuntu-latest
+            cxx_standard: 11
+            googletest: system
           - os: macos-latest
             build: shared
           - os: macos-latest


### PR DESCRIPTION
Example failure: https://github.com/jbeder/yaml-cpp/actions/runs/12381182090/job/34559170580