### PR TITLE
Forbid incorrect document start (---)

### DIFF
--- a/src/exp.h
+++ b/src/exp.h
@@ -82,7 +82,7 @@ inline const RegEx& Utf8_ByteOrderMark() {
 // actual tags
 
 inline const RegEx& DocStart() {
-  static const RegEx e = RegEx("---") + (BlankOrBreak() | RegEx());
+  static const RegEx e = RegEx("---");
   return e;
 }
 inline const RegEx& DocEnd() {

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1682,5 +1682,15 @@ TEST_F(HandlerSpecTest, Ex8_22_BlockCollectionNodes) {
   EXPECT_CALL(handler, OnDocumentEnd());
   Parse(ex8_22);
 }
+
+TEST_F(HandlerSpecTest, InvalidDocStart1) {
+  EXPECT_THROW_PARSER_EXCEPTION(IgnoreParse("----\nbaz: 1"),
+                                ErrorMsg::BLOCK_ENTRY);
+}
+TEST_F(HandlerSpecTest, InvalidDocStart2) {
+  EXPECT_THROW_PARSER_EXCEPTION(IgnoreParse("----\n# foo\nbaz: 1"),
+                                ErrorMsg::BLOCK_ENTRY);
+}
+
 }  // namespace
 }  // namespace YAML


### PR DESCRIPTION
Previously documents like the following was simply ignored:

    ----
    # foo
    bar: bam