### PR TITLE
Avoid including <iostream> in library code

### DIFF
--- a/src/indentation.h
+++ b/src/indentation.h
@@ -7,7 +7,6 @@
 #pragma once
 #endif
 
-#include <iostream>
 #include <cstddef>
 
 #include "yaml-cpp/ostream_wrapper.h"

--- a/src/ostream_wrapper.cpp
+++ b/src/ostream_wrapper.cpp
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 #include <cstring>
-#include <iostream>
+#include <ostream>
 
 namespace YAML {
 ostream_wrapper::ostream_wrapper()

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1,4 +1,4 @@
-#include <iostream>
+#include <istream>
 
 #include "stream.h"
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -11,7 +11,7 @@
 #include <cstddef>
 #include <deque>
 #include <ios>
-#include <iostream>
+#include <istream>
 #include <set>
 #include <string>
 

--- a/src/token.h
+++ b/src/token.h
@@ -8,7 +8,7 @@
 #endif
 
 #include "yaml-cpp/mark.h"
-#include <iostream>
+#include <ostream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Including iostream means introducing the static (global) constructors and destructors for std::cin, std::cerr, and std::cout. That extra init and fini code is undesirable when those streams are not actually used.

Instead, we'll use the narrower includes for exactly what's needed, i.e., `<istream>` or `<ostream>`.