### PR TITLE
DecodeBase64 returns empty string on *all* errors

### DIFF
--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -74,7 +74,8 @@ std::vector<unsigned char> DecodeBase64(const std::string &input) {
   unsigned char *out = &ret[0];
 
   unsigned value = 0;
-  for (std::size_t i = 0, cnt = 0; i < input.size(); i++) {
+  std::size_t cnt = 0;
+  for (std::size_t i = 0; i < input.size(); i++) {
     if (std::isspace(static_cast<unsigned char>(input[i]))) {
       // skip newlines
       continue;
@@ -84,15 +85,20 @@ std::vector<unsigned char> DecodeBase64(const std::string &input) {
       return ret_type();
 
     value = (value << 6) | d;
-    if (cnt % 4 == 3) {
+    if (cnt == 3) {
       *out++ = value >> 16;
       if (i > 0 && input[i - 1] != '=')
         *out++ = value >> 8;
       if (input[i] != '=')
         *out++ = value;
+      cnt = 0;
+    } else {
+      ++cnt;
     }
-    ++cnt;
   }
+  // An invalid number of characters were encountered.
+  if (cnt != 0)
+    return ret_type();
 
   ret.resize(out - &ret[0]);
   return ret;

--- a/test/binary_test.cpp
+++ b/test/binary_test.cpp
@@ -12,3 +12,10 @@ TEST(BinaryTest, DecodingNoCrashOnNegative) {
   const std::vector<unsigned char> &result = YAML::DecodeBase64(input);
   EXPECT_TRUE(result.empty());
 }
+
+TEST(BinaryTest, DecodingIncompleteString) {
+  // Note: the number of bytes is *not* a multiple of four.
+  std::string input{90, 71, 86, 104, 90};
+  const std::vector<unsigned char> &result = YAML::DecodeBase64(input);
+  EXPECT_TRUE(result.empty());
+}


### PR DESCRIPTION
It already returns an empty string if it encounters an invalid character. However, if, instead, it has an incomplete set of characters (no-multiple of four), it currently returns a truncated result. Instead, it detects truncation and returns the empty string.

The only time `DecodeBase64()` returns a *valid* empty return value is if the *input* was likewise empty.