### PR TITLE
emitter: emit quotes for non-plain scalars

### DIFF
--- a/include/yaml-cpp/emitter.h
+++ b/include/yaml-cpp/emitter.h
@@ -73,7 +73,9 @@ class YAML_CPP_API Emitter {
   Emitter& SetLocalPrecision(const _Precision& precision);
 
   // overloads of write
+  Emitter& Write(const char* str, std::size_t size, EMITTER_MANIP emitterManip);
   Emitter& Write(const char* str, std::size_t size);
+  Emitter& Write(const std::string& str, EMITTER_MANIP emitterManip);
   Emitter& Write(const std::string& str);
   Emitter& Write(bool b);
   Emitter& Write(char ch);

--- a/src/emitfromevents.cpp
+++ b/src/emitfromevents.cpp
@@ -41,7 +41,11 @@ void EmitFromEvents::OnScalar(const Mark&, const std::string& tag,
                               anchor_t anchor, const std::string& value) {
   BeginNode();
   EmitProps(tag, anchor);
-  m_emitter << value;
+  if (tag != "!") {
+    m_emitter << value;
+  } else {
+    m_emitter.Write(value, EMITTER_MANIP::DoubleQuoted);
+  }
 }
 
 void EmitFromEvents::OnSequenceStart(const Mark&, const std::string& tag,

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -716,15 +716,17 @@ StringEscaping::value GetStringEscapingStyle(const EMITTER_MANIP emitterManip) {
   }
 }
 
-Emitter& Emitter::Write(const char* str, std::size_t size) {
+Emitter& Emitter::Write(const char* str, std::size_t size,
+                        EMITTER_MANIP emitterManip) {
   if (!good())
     return *this;
 
-  StringEscaping::value stringEscaping = GetStringEscapingStyle(m_pState->GetOutputCharset());
+  StringEscaping::value stringEscaping =
+      GetStringEscapingStyle(m_pState->GetOutputCharset());
 
-  const StringFormat::value strFormat =
-      Utils::ComputeStringFormat(str, size, m_pState->GetStringFormat(),
-                                 m_pState->CurGroupFlowType(), stringEscaping == StringEscaping::NonAscii);
+  const StringFormat::value strFormat = Utils::ComputeStringFormat(
+      str, size, emitterManip, m_pState->CurGroupFlowType(),
+      stringEscaping == StringEscaping::NonAscii);
 
   if (strFormat == StringFormat::Literal || size > 1024)
     m_pState->SetMapKeyFormat(YAML::LongKey, FmtScope::Local);
@@ -750,6 +752,14 @@ Emitter& Emitter::Write(const char* str, std::size_t size) {
   StartedScalar();
 
   return *this;
+}
+
+Emitter& Emitter::Write(const char* str, std::size_t size) {
+  return Write(str, size, m_pState->GetStringFormat());
+}
+
+Emitter& Emitter::Write(const std::string& str, EMITTER_MANIP emitterManip) {
+  return Write(str.data(), str.size(), emitterManip);
 }
 
 Emitter& Emitter::Write(const std::string& str) {

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -67,9 +67,31 @@ TEST_F(EmitterTest, UnterminatedStdStringViewScalar) {
 #endif
 
 TEST_F(EmitterTest, SimpleQuotedScalar) {
-  Node n(Load("\"test\""));
+  const std::string quoted = "\"test\"";
+  Node n(Load(quoted));
   out << n;
-  ExpectEmit("test");
+  ExpectEmit(quoted);
+}
+
+TEST_F(EmitterTest, QuotedScalarFalse) {
+  const std::string quoted = "\"false\"";
+  Node n(Load(quoted));
+  out << n;
+  ExpectEmit(quoted);
+}
+
+TEST_F(EmitterTest, QuotedScalarTrue) {
+  const std::string quoted = "\"true\"";
+  Node n(Load(quoted));
+  out << n;
+  ExpectEmit(quoted);
+}
+
+TEST_F(EmitterTest, QuotedScalarInt) {
+  const std::string quoted = "\"3\"";
+  Node n(Load(quoted));
+  out << n;
+  ExpectEmit(quoted);
 }
 
 TEST_F(EmitterTest, DumpAndSize) {


### PR DESCRIPTION
Use the "!" tag to detect scalars that are not plain scalars and pass EMITTER_MANIP::DoubleQuoted to Emitter::Write() to ensure they are quoted.

This preserves quotes on quoted items that do not strictly need quotes. The alternative of detecting and quoting only the values that need quotes seemed error-prone and brittle.

Fixes #1362.