### PR TITLE
Use std::locale::classic() instead of creating new C locales on demand

### DIFF
--- a/include/yaml-cpp/emitter.h
+++ b/include/yaml-cpp/emitter.h
@@ -148,7 +148,7 @@ inline Emitter& Emitter::WriteIntegralType(T value) {
   PrepareNode(EmitterNodeType::Scalar);
 
   std::stringstream stream;
-  stream.imbue(std::locale("C"));
+  stream.imbue(std::locale::classic());
   PrepareIntegralStream(stream);
   stream << value;
   m_stream << stream.str();
@@ -166,7 +166,7 @@ inline Emitter& Emitter::WriteStreamable(T value) {
   PrepareNode(EmitterNodeType::Scalar);
 
   std::stringstream stream;
-  stream.imbue(std::locale("C"));
+  stream.imbue(std::locale::classic());
   SetStreamablePrecision<T>(stream);
 
   bool special = false;

--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -172,7 +172,7 @@ ConvertStreamTo(std::stringstream& stream, T& rhs) {
                                                                            \
     static Node encode(const type& rhs) {                                  \
       std::stringstream stream;                                            \
-      stream.imbue(std::locale("C"));                                       \
+      stream.imbue(std::locale::classic());                                \
       stream.precision(std::numeric_limits<type>::max_digits10);           \
       conversion::inner_encode(rhs, stream);                               \
       return Node(stream.str());                                           \
@@ -184,7 +184,7 @@ ConvertStreamTo(std::stringstream& stream, T& rhs) {
       }                                                                    \
       const std::string& input = node.Scalar();                            \
       std::stringstream stream(input);                                     \
-      stream.imbue(std::locale("C"));                                       \
+      stream.imbue(std::locale::classic());                                \
       stream.unsetf(std::ios::dec);                                        \
       if ((stream.peek() == '-') && std::is_unsigned<type>::value) {       \
         return false;                                                      \

--- a/include/yaml-cpp/traits.h
+++ b/include/yaml-cpp/traits.h
@@ -121,7 +121,7 @@ template<typename Key, bool Streamable>
 struct streamable_to_string {
   static std::string impl(const Key& key) {
     std::stringstream ss;
-    ss.imbue(std::locale("C"));
+    ss.imbue(std::locale::classic());
     ss << key;
     return ss.str();
   }

--- a/src/fptostring.cpp
+++ b/src/fptostring.cpp
@@ -85,7 +85,7 @@ std::string FpToString(T v, int precision = 0) {
   // dragonbox/to_decimal does not handle value 0, inf, NaN
   if (v == 0 || std::isinf(v) || std::isnan(v)) {
     std::stringstream ss;
-    ss.imbue(std::locale("C"));
+    ss.imbue(std::locale::classic());
     ss << v;
     return ss.str();
   }
@@ -98,7 +98,7 @@ std::string FpToString(T v, int precision = 0) {
   // defensive programming, ConvertToChars arguments are invalid
   if (digits_ct == -1) {
     std::stringstream ss;
-    ss.imbue(std::locale("C"));
+    ss.imbue(std::locale::classic());
     ss << v;
     return ss.str();
   }
@@ -161,7 +161,7 @@ std::string FpToString(T v, int precision = 0) {
     // defensive programming, ConvertToChars arguments are invalid
     if (exp_digits_ct == -1) {
       std::stringstream ss;
-      ss.imbue(std::locale("C"));
+      ss.imbue(std::locale::classic());
       ss << v;
       return ss.str();
     }
@@ -226,7 +226,7 @@ std::string FpToString(double v, size_t precision) {
  */
 std::string FpToString(long double v, size_t precision) {
   std::stringstream ss;
-  ss.imbue(std::locale("C"));
+  ss.imbue(std::locale::classic());
   if (precision == 0) {
      precision = std::numeric_limits<long double>::max_digits10;
   }

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -310,7 +310,7 @@ void node_data::convert_sequence_to_map(const shared_memory_holder& pMemory) {
   reset_map();
   for (std::size_t i = 0; i < m_sequence.size(); i++) {
     std::stringstream stream;
-    stream.imbue(std::locale("C"));
+    stream.imbue(std::locale::classic());
     stream << i;
 
     node& key = pMemory->create_node();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -77,7 +77,7 @@ void Parser::HandleYamlDirective(const Token& token) {
   }
 
   std::stringstream str(token.params[0]);
-  str.imbue(std::locale("C"));
+  str.imbue(std::locale::classic());
   str >> m_pDirectives->version.major;
   str.get();
   str >> m_pDirectives->version.minor;


### PR DESCRIPTION
I noticed that parsing yaml documents with floats is quite slow when compiling for wasm with emscripten. It turns out that the calls to `std::locale("C")` that are used in `convert<float>` take more than 1ms each in emscripten. To fix this I replaced the creation of the locale with a call to `std::locale::classic()` which returns a static reference to an already initialized C locale ([see documentation](https://en.cppreference.com/w/cpp/locale/locale/classic.html)). This reduces the parsing time by 85% for me.