### PR TITLE
Fix warning -Wconstexpr-not-const

### DIFF
--- a/src/contrib/dragonbox.h
+++ b/src/contrib/dragonbox.h
@@ -4023,44 +4023,44 @@ namespace jkj {
 
             // Policy kind detectors.
             struct is_sign_policy {
-                constexpr bool operator()(...) noexcept { return false; }
+                constexpr bool operator()(...) const noexcept { return false; }
                 template <class Policy, class = typename Policy::sign_policy>
-                constexpr bool operator()(dummy<Policy>) noexcept {
+                constexpr bool operator()(dummy<Policy>) const noexcept {
                     return true;
                 }
             };
             struct is_trailing_zero_policy {
-                constexpr bool operator()(...) noexcept { return false; }
+                constexpr bool operator()(...) const noexcept { return false; }
                 template <class Policy, class = typename Policy::trailing_zero_policy>
-                constexpr bool operator()(dummy<Policy>) noexcept {
+                constexpr bool operator()(dummy<Policy>) const noexcept {
                     return true;
                 }
             };
             struct is_decimal_to_binary_rounding_policy {
-                constexpr bool operator()(...) noexcept { return false; }
+                constexpr bool operator()(...) const noexcept { return false; }
                 template <class Policy, class = typename Policy::decimal_to_binary_rounding_policy>
-                constexpr bool operator()(dummy<Policy>) noexcept {
+                constexpr bool operator()(dummy<Policy>) const noexcept {
                     return true;
                 }
             };
             struct is_binary_to_decimal_rounding_policy {
-                constexpr bool operator()(...) noexcept { return false; }
+                constexpr bool operator()(...) const noexcept { return false; }
                 template <class Policy, class = typename Policy::binary_to_decimal_rounding_policy>
-                constexpr bool operator()(dummy<Policy>) noexcept {
+                constexpr bool operator()(dummy<Policy>) const noexcept {
                     return true;
                 }
             };
             struct is_cache_policy {
-                constexpr bool operator()(...) noexcept { return false; }
+                constexpr bool operator()(...) const noexcept { return false; }
                 template <class Policy, class = typename Policy::cache_policy>
-                constexpr bool operator()(dummy<Policy>) noexcept {
+                constexpr bool operator()(dummy<Policy>) const noexcept {
                     return true;
                 }
             };
             struct is_preferred_integer_types_policy {
-                constexpr bool operator()(...) noexcept { return false; }
+                constexpr bool operator()(...) const noexcept { return false; }
                 template <class Policy, class = typename Policy::preferred_integer_types_policy>
-                constexpr bool operator()(dummy<Policy>) noexcept {
+                constexpr bool operator()(dummy<Policy>) const noexcept {
                     return true;
                 }
             };


### PR DESCRIPTION
When compile with Intel LLVM 2025.2.1, I got following warnings:
```
In file included from .../yaml-cpp-0.8.1/src/fptostring.cpp:2:
.../yaml-cpp-0.8.1/src/contrib/dragonbox.h:4026:32: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
 4026 |                 constexpr bool operator()(...) noexcept { return false; }
      |                                ^
      |                                                const
.../yaml-cpp-0.8.1/src/contrib/dragonbox.h:4028:32: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
 4028 |                 constexpr bool operator()(dummy<Policy>) noexcept {
      |                                ^
      |                                                          const
.../yaml-cpp-0.8.1/src/contrib/dragonbox.h:4033:32: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
 4033 |                 constexpr bool operator()(...) noexcept { return false; }
      |                                ^
      |                                                const
.../yaml-cpp-0.8.1/src/contrib/dragonbox.h:4035:32: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
 4035 |                 constexpr bool operator()(dummy<Policy>) noexcept {
      |                                ^
      |                                                          const
.../yaml-cpp-0.8.1/src/contrib/dragonbox.h:4040:32: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
 4040 |                 constexpr bool operator()(...) noexcept { return false; }
      |                                ^
      |                                                const
.../yaml-cpp-0.8.1/src/contrib/dragonbox.h:4042:32: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
 4042 |                 constexpr bool operator()(dummy<Policy>) noexcept {
      |                                ^
      |                                                          const
.../yaml-cpp-0.8.1/src/contrib/dragonbox.h:4047:32: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
 4047 |                 constexpr bool operator()(...) noexcept { return false; }
      |                                ^
      |                                                const
.../yaml-cpp-0.8.1/src/contrib/dragonbox.h:4049:32: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
 4049 |                 constexpr bool operator()(dummy<Policy>) noexcept {
      |                                ^
      |                                                          const
.../yaml-cpp-0.8.1/src/contrib/dragonbox.h:4054:32: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
 4054 |                 constexpr bool operator()(...) noexcept { return false; }
      |                                ^
      |                                                const
.../yaml-cpp-0.8.1/src/contrib/dragonbox.h:4056:32: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
 4056 |                 constexpr bool operator()(dummy<Policy>) noexcept {
      |                                ^
      |                                                          const
.../yaml-cpp-0.8.1/src/contrib/dragonbox.h:4061:32: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
 4061 |                 constexpr bool operator()(...) noexcept { return false; }
      |                                ^
      |                                                const
.../yaml-cpp-0.8.1/src/contrib/dragonbox.h:4063:32: warning: 'constexpr' non-static member function will not be implicitly 'const' in C++14; add 'const' to avoid a change in behavior [-Wconstexpr-not-const]
 4063 |                 constexpr bool operator()(dummy<Policy>) noexcept {
      |                                ^
      |                                                          const
```
Since Intel LLVM is based on Clang 21, it very likely that Clang 21 will issue the same warnings (but I've not tested).

I fixed this by simply adding const qualifiers to them.