### PR TITLE
Emitter: produce string with trailing '.0' for floating point value with only integral part

### DIFF
--- a/src/fptostring.cpp
+++ b/src/fptostring.cpp
@@ -4,6 +4,8 @@
 #include <array>
 #include <cassert>
 #include <cmath>
+#include <iomanip>
+#include <ios>
 #include <limits>
 #include <sstream>
 #include <tuple>
@@ -86,7 +88,8 @@ std::string FpToString(T v, int precision = 0) {
   if (v == 0 || std::isinf(v) || std::isnan(v)) {
     std::stringstream ss;
     ss.imbue(std::locale::classic());
-    ss << v;
+    // force the presecence of one decimal digit for 0
+    ss << std::fixed << std::setprecision(1) << v;
     return ss.str();
   }
 
@@ -204,6 +207,11 @@ std::string FpToString(T v, int precision = 0) {
       for (;digits_iter < digits_end; ++digits_iter) {
          *(output_ptr++) = *digits_iter;
       }
+    } else {
+        // if no digits after decimal point, print .0
+        // to make sure it is recognized as a floating point number
+        *(output_ptr++) = '.';
+        *(output_ptr++) = '0';
     }
   }
   *output_ptr = '\0';

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -121,14 +121,17 @@ TEST_F(EmitterTest, NumberPrecision) {
   out.SetFloatPrecision(3);
   out.SetDoublePrecision(2);
   out << BeginSeq;
+  out << 1.0f;
   out << 3.1425926f;
+  out << 0.0;
+  out << 1.0;
   out << 53.5893;
   out << 2384626.4338;
   out << 1999926.4338;
   out << 9999926.4338;
   out << EndSeq;
 
-  ExpectEmit("- 3.14\n- 54\n- 2.4e+06\n- 2e+06\n- 1e+07");
+  ExpectEmit("- 1.0\n- 3.14\n- 0.0\n- 1.0\n- 54.0\n- 2.4e+06\n- 2e+06\n- 1e+07");
 }
 
 TEST_F(EmitterTest, SimpleSeq) {

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -765,7 +765,7 @@ TEST_F(NodeEmitterTest, SimpleFlowSeqNode) {
   node.push_back(4000.);
   node.push_back(1.5474251e+26f);
 
-  ExpectOutput("[1.5, 2.25, 3.125, 34.34, 56.56, 12.12, 78.78, 0.0003, 4000, 1.5474251e+26]", node);
+  ExpectOutput("[1.5, 2.25, 3.125, 34.34, 56.56, 12.12, 78.78, 0.0003, 4000.0, 1.5474251e+26]", node);
 }
 
 TEST_F(NodeEmitterTest, NestFlowSeqNode) {


### PR DESCRIPTION
For example the number 1.0 will be converted to "1.0" instead of "1".
This allows to keep the correct type information when parsing back the YAML.

This is an attempt to Fix #226 #412 #1016