### PR TITLE
Add IWYU export pragmas.

### DIFF
--- a/include/yaml-cpp/yaml.h
+++ b/include/yaml-cpp/yaml.h
@@ -7,6 +7,8 @@
 #pragma once
 #endif
 
+// IWYU pragma: begin_exports
+
 #include "yaml-cpp/parser.h"
 #include "yaml-cpp/emitter.h"
 #include "yaml-cpp/emitterstyle.h"
@@ -20,5 +22,7 @@
 #include "yaml-cpp/node/detail/impl.h"
 #include "yaml-cpp/node/parse.h"
 #include "yaml-cpp/node/emit.h"
+
+// IWYU pragma: end_exports
 
 #endif  // YAML_H_62B23520_7C8E_11DE_8A39_0800200C9A66


### PR DESCRIPTION
If a project is using the facade-header yaml-cpp/yaml.h it might get `misc-include-cleaner` warnings from the `clangd` language server and `clang-tidy` that this header is not providing directly the symbols used.

The annotation with IWYU pragmas fixes that and tells the tools that it should consider all the includes as if they directly provided the symbol

Documentation clangd and clang-tidy
https://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html points to https://clangd.llvm.org/design/include-cleaner#iwyu-pragmas

This has been first implemented and docuemnted in the include-what-you-use project https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-begin_exportsend_exports