### PR TITLE
fix: overflow buffer with large precision values

### DIFF
--- a/test/fptostring_test.cpp
+++ b/test/fptostring_test.cpp
@@ -238,5 +238,9 @@ TEST(FpToStringTest, conversion_float) {
   EXPECT_EQ("-1.3e-05", FpToString(-1.299e-5f, 2));
 }
 
+TEST(FpToStringTest, vulnerability_stack_buffer_overflow) {
+  EXPECT_EQ(FpToString(1.0e100, 200), "10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+}
+
 }  // namespace
 }  // namespace YAML


### PR DESCRIPTION
Issue #1385 demonstrates how a large 'precision' value can cause buffer overflows. Originally, the buffer was designed to fit any scientific notation. But the precision changes at which point large floating point numbers are displayed in scientific notation or default notation. In case of the default notation many extra zeros have to be printed, this was not reflected in the output_buffer and an overflow could occur.

This PR computes the number of zero that do not fit into the static buffer and appends them at the end of the function triggering potential a second dynamic allocation. (The first allocation is the std::string allocation).