### PR TITLE
fix: unittests sets locale before testing

### DIFF
--- a/test/fptostring_test.cpp
+++ b/test/fptostring_test.cpp
@@ -10,6 +10,7 @@ namespace {
 template <typename T>
 static std::string convert_with_stringstream(T v, size_t precision = 0) {
   std::stringstream ss;
+  ss.imbue(std::locale::classic());
   if (precision > 0) {
     ss << std::setprecision(precision);
   }


### PR DESCRIPTION
the convert_with_stringstream seems to be missing a .imbue() call to set the locale independent of the global state. Not setting this, can in some settings lead to errors, see Issue #1366.