### PR TITLE
fix: floating point conversion on x86 (32bit)

### DIFF
--- a/src/fptostring.cpp
+++ b/src/fptostring.cpp
@@ -28,7 +28,7 @@ namespace fp_formatting {
  * assert(buffer[1] == '2');
  * assert(buffer[2] == '3');
  */
-int ConvertToChars(char* begin, char* end, size_t value, int width=1) {
+int ConvertToChars(char* begin, char* end, uint64_t value, int width=1) {
   // precondition of this function (will trigger in debug build)
   assert(width >= 1);
   assert(end >= begin);       // end must be after begin


### PR DESCRIPTION
Fixes floating point conversion on 32bit system as mentioned in #1399.
dragonbox function `to_decimal` returns a unsigned 64bit number for the significand.
This is stored in a `size_t` which is a uint32_t on 32 bit system those causes loose of precision.
This PR simply replaces the `size_t` with an `uint64_t` type.