### PR TITLE
Fix/multiple documents

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -53,7 +53,7 @@ std::vector<Node> LoadAll(std::istream& input) {
   Parser parser(input);
   while (true) {
     NodeBuilder builder;
-    if (!parser.HandleNextDocument(builder) || builder.Root().IsNull()) {
+    if (!parser.HandleNextDocument(builder)) {
       break;
     }
     docs.push_back(builder.Root());

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -33,9 +33,24 @@ bool Parser::HandleNextDocument(EventHandler& eventHandler) {
     return false;
   }
 
+  auto oldPos = m_pScanner->peek().mark.pos;
+
   SingleDocParser sdp(*m_pScanner, *m_pDirectives);
   sdp.HandleDocument(eventHandler);
-  return true;
+
+  // checks if progress was made
+  // 1. if scanner has no more tokens, progress was made
+  if (m_pScanner->empty()) {
+    return true;
+  }
+
+  // 2. if token position has changed, progress was made
+  auto newPos = m_pScanner->peek().mark.pos;
+  if (newPos != oldPos) {
+    return true;
+  }
+  // No progress was made, no further processing
+  return false;
 }
 
 void Parser::ParseDirectives() {

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -368,11 +368,16 @@ TEST(NodeTest, LoadCommaSeparatedStrings) {
   EXPECT_THROW(Load(R"(,foo)"), ParserException);
 }
 
-TEST(NodeSpecTest, InfiniteLoopNodes) {
+TEST(NodeTest, InfiniteLoopNodes) {
   // Until yaml-cpp <= 0.8.0 this caused an infinite loop;
   // After, it triggers an exception (but LoadAll is smart enough to avoid
   // the infinite loop in any case).
   EXPECT_THROW(LoadAll(R"(,)"), ParserException);
+}
+
+TEST(NodeTest, MultipleDocuments) {
+  std::vector<Node> docs = LoadAll("\n---\n---\nA\n");
+  EXPECT_EQ(docs.size(), 2);
 }
 
 struct NewLineStringsTestCase {


### PR DESCRIPTION
Fixes the parsing of empty document in `LoadAll` function as described in PR #1319.

Two commits:
1. demonstration of bug as described in Issue #1402 . (and some minor naming cleanup)
2. replaces fixes from PR #1319 with a different mechanism.

Open question: Is checking for the reported position in a token a valid strategy?
Also the fixes of PR #1319 seem more of precaution are difficult to test. Simply reverting the fixes from PR #1319 would also not fail any unit tests.