### PR TITLE
feat: CI tests windows-11-arm platform for bazel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
   bazel-build:
       strategy:
         matrix:
-          os: [ubuntu-latest, windows-latest, macos-latest]
+          os: [ubuntu-latest, windows-latest, macos-latest, windows-11-arm]
       runs-on: ${{ matrix.os }}
       steps:
         - uses: actions/checkout@v6.0.2
@@ -125,7 +125,7 @@ jobs:
   bzlmod-build:
       strategy:
         matrix:
-          os: [ubuntu-latest, windows-latest, macos-latest]
+          os: [ubuntu-latest, windows-latest, macos-latest, windows-11-arm]
       runs-on: ${{ matrix.os }}
       steps:
         - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
Fixes #1416 

This PR is ready when ever bazel is ready to run properly on windows-11-arm.