### PR TITLE
feat: option for strict flag usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(YAML_CPP_FORMAT_SOURCE "Format source" ${YAML_CPP_MAIN_PROJECT})
 option(YAML_CPP_DISABLE_UNINSTALL  "Disable uninstallation of yaml-cpp" OFF)
 option(YAML_USE_SYSTEM_GTEST "Use system googletest if found" OFF)
 option(YAML_ENABLE_PIC "Use Position-Independent Code " ON)
+option(YAML_CPP_USE_STRICT_FLAGS "Uses strict compilation flags e.g.: -Wall" ${YAML_CPP_MAIN_PROJECT})
 
 cmake_dependent_option(YAML_CPP_BUILD_TESTS
   "Enable yaml-cpp tests" OFF
@@ -92,7 +93,7 @@ if (NOT DEFINED CMAKE_CXX_STANDARD)
       CXX_STANDARD 11)
 endif()
 
-if(YAML_CPP_MAIN_PROJECT)
+if (YAML_CPP_USE_STRICT_FLAGS)
   target_compile_options(yaml-cpp
     PRIVATE
       $<${print-warnings}:-Wall -Wextra -Wshadow -Weffc++ -Wno-long-long>


### PR DESCRIPTION
When compiling yaml-cpp as a root project flags like -Wall -pedantic or -pedantic-error are being set. Some compilers report false positives and/or are not aware of certain flags.
While having a strict compile policy is nice and hinders people who are using rare compiler or compiler configurations or sometimes just new compiler.

The current workaround is to edit the CMakeLists.txt file and edit out those flags.

This patch provides a new mechanism via the option "YAML_CPP_USE_STRICT_FLAGS". The default value is set to ON if it the root project, otherwise OFF. This allows a user to call `cmake -DYAML_CPP_USE_STRICT_FLAGS=OFF ..` to deactivate any strict flag settings.

This is an alternative fix for PR #945 
Mitigate the issue in Issuse #1428

log: feat: option for strict flag usage