### PR TITLE
Fix MSVC narrowing-conversion warnings (C4244/C4267) under /W3

### DIFF
--- a/src/contrib/dragonbox.h
+++ b/src/contrib/dragonbox.h
@@ -1231,7 +1231,7 @@ namespace jkj {
                     // reason if we just write n / 10.
                     JKJ_IF_CONSTEXPR(stdr::is_same<UInt, stdr::uint_least32_t>::value && N == 1 &&
                                      n_max <= UINT32_C(1073741828)) {
-                        return UInt(wuint::umul64(n, UINT32_C(429496730)) >> 32);
+                        return UInt(wuint::umul64(static_cast<stdr::uint_least32_t>(n), UINT32_C(429496730)) >> 32);
                     }
                     // Specialize for 64-bit division by 10.
                     // Without the bound on n_max (which compilers these days never leverage), the
@@ -1244,7 +1244,7 @@ namespace jkj {
                     // It seems compilers tend to generate mov + mul instead of a single imul for an
                     // unknown reason if we just write n / 100.
                     else JKJ_IF_CONSTEXPR(stdr::is_same<UInt, stdr::uint_least32_t>::value && N == 2) {
-                        return UInt(wuint::umul64(n, UINT32_C(1374389535)) >> 37);
+                        return UInt(wuint::umul64(static_cast<stdr::uint_least32_t>(n), UINT32_C(1374389535)) >> 37);
                     }
                     // Specialize for 64-bit division by 1000.
                     // Without the bound on n_max (which compilers these days never leverage), the
@@ -2956,7 +2956,7 @@ namespace jkj {
                 auto r = detail::bits::rotr<32>(
                     detail::stdr::uint_least32_t(significand * UINT32_C(184254097)), 4);
                 auto b = r < UINT32_C(429497);
-                auto s = detail::stdr::size_t(b);
+                auto s = DecimalExponentType(b);
                 significand = b ? r : significand;
 
                 r = detail::bits::rotr<32>(
@@ -2988,7 +2988,7 @@ namespace jkj {
                 auto r = detail::bits::rotr<64>(
                     detail::stdr::uint_least64_t(significand * UINT64_C(28999941890838049)), 8);
                 auto b = r < UINT64_C(184467440738);
-                auto s = detail::stdr::size_t(b);
+                auto s = DecimalExponentType(b);
                 significand = b ? r : significand;
 
                 r = detail::bits::rotr<64>(

--- a/src/fptostring.cpp
+++ b/src/fptostring.cpp
@@ -192,7 +192,8 @@ std::string FpToString(T v, int precision = 0) {
       int const zero_digits_ct = before_decimal_digits - digits_ct;
 
       // space left in the output_buffer (-1 because we need it for null-termination)
-      int const buffer_empty_space = output_buffer.data() + output_buffer.size() - output_ptr - 1;
+      int const buffer_empty_space = static_cast<int>(
+          output_buffer.data() + output_buffer.size() - output_ptr - 1);
 
       // print all zeros not fitting into the buffer at the end of the function
       overflow_zeros = std::max(0, zero_digits_ct - buffer_empty_space);
@@ -231,11 +232,11 @@ std::string FpToString(T v, int precision = 0) {
 }
 
 std::string FpToString(float v, size_t precision) {
-  return detail::fp_formatting::FpToString(v, precision);
+  return detail::fp_formatting::FpToString(v, static_cast<int>(precision));
 }
 
 std::string FpToString(double v, size_t precision) {
-  return detail::fp_formatting::FpToString(v, precision);
+  return detail::fp_formatting::FpToString(v, static_cast<int>(precision));
 }
 
 /**


### PR DESCRIPTION
Add explicit casts to silence 8 warnings triggered by MSVC /W3:

fptostring.cpp:
- Add static_cast<int>(precision) where public API (size_t) calls internal template (int)
- Add static_cast<int>(...) for pointer-arithmetic result stored in int

dragonbox.h:
- Add static_cast<uint_least32_t>(n) in umul64() calls inside if-constexpr branches guarded by is_same<UInt, uint_least32_t> to silence MSVC warnings on discarded branches when UInt=uint_least64_t
- Change trailing-zero counter 's' from size_t to DecimalExponentType in both remove_trailing_zeros specializations to match exponent type