### PR TITLE
[ci] Update GitHub Action checkout to version 6

### DIFF
--- a/.github/workflows/bzlmod-archive.yml
+++ b/.github/workflows/bzlmod-archive.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.1.1
+      - uses: actions/checkout@v6
       - run: git archive $GITHUB_REF -o "yaml-cpp-${GITHUB_REF:10}.tar.gz"
       - run: gh release upload ${GITHUB_REF:10} "yaml-cpp-${GITHUB_REF:10}.tar.gz"
         env:


### PR DESCRIPTION
Fixes deprecation warning for Node20.js