### PR TITLE
docs: note YAML_CPP_INSTALL for FetchContent embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
   GIT_TAG <tag_name> # Can be a tag (yaml-cpp-x.x.x), a commit hash, or a branch name (master)
 )
+# Install rules (CMake package config, headers, etc.) are enabled only when yaml-cpp is
+# the top-level CMake project. When embedding via FetchContent, set this before
+# FetchContent_MakeAvailable if you need install targets in your build tree:
+# set(YAML_CPP_INSTALL ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(yaml-cpp)
 
 target_link_libraries(YOUR_LIBRARY PUBLIC yaml-cpp::yaml-cpp) # The library or executable that require yaml-cpp library


### PR DESCRIPTION
## Summary

When yaml-cpp is pulled in with `FetchContent`, it is not the top-level CMake project, so `YAML_CPP_INSTALL` defaults to `OFF` and install targets are not generated (see #1007). This adds a short README note under the CMake integration section.

Fixes #1381

## Test plan

- [x] README-only change

Made with [Cursor](https://cursor.com)