### PR TITLE
docs: exclude test/ from CodeDocs API reference

### DIFF
--- a/.codedocs
+++ b/.codedocs
@@ -8,7 +8,7 @@ EXAMPLE_PATH =
 
 # One or more directories and files to exclude from documentation generation.
 # Use relative paths with respect to the repository root directory.
-EXCLUDE = test/googletest-1.16.0/
+EXCLUDE = test/
 
 # One or more wildcard patterns to exclude files and directories from document
 # generation.


### PR DESCRIPTION
## Summary

CodeDocs was indexing files under `test/` (including long generated class names from unit tests). Set `EXCLUDE = test/` in `.codedocs` so only library sources appear in the public API reference.

Fixes #1341

## Test plan

- [x] `.codedocs` config only; CodeDocs will pick this up on next doc rebuild

Made with [Cursor](https://cursor.com)