### PR TITLE
feat/fix: support literal and single-quoted style for YAML::Binary emitting

### DIFF
--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -976,8 +976,34 @@ Emitter& Emitter::Write(const Binary& binary) {
   if (!good())
     return *this;
 
+  const StringFormat::value strFormat = binary.size() == 0 ? 
+      Utils::ComputeStringFormat("", 0, m_pState->GetStringFormat(),
+                                 m_pState->CurGroupFlowType(), false) : 
+      Utils::ComputeStringFormat("a", 1, m_pState->GetStringFormat(),
+                                 m_pState->CurGroupFlowType(), false);
+
+  if (strFormat == StringFormat::Literal) 
+    m_pState->SetMapKeyFormat(YAML::LongKey, FmtScope::Local);
+  
   PrepareNode(EmitterNodeType::Scalar);
-  Utils::WriteBinary(m_stream, binary);
+
+  switch (strFormat) {
+    // case StringFormat::Plain:		// to avoid changing the default behavior
+    //   m_stream.write(EncodeBase64(binary.data(), binary.size()));
+    //   break;
+    case StringFormat::SingleQuoted:
+      Utils::WriteSingleQuotedBinary(m_stream, binary);
+      break;
+    case StringFormat::Plain:
+    case StringFormat::DoubleQuoted:
+      Utils::WriteBinary(m_stream, binary);
+      break;
+    case StringFormat::Literal:
+      Utils::WriteLiteralBinary(m_stream, binary, 
+                                m_pState->CurIndent() + m_pState->GetIndent());
+      break;
+  }
+
   StartedScalar();
 
   return *this;

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -976,11 +976,9 @@ Emitter& Emitter::Write(const Binary& binary) {
   if (!good())
     return *this;
 
-  const StringFormat::value strFormat = binary.size() == 0 ? 
-      Utils::ComputeStringFormat("", 0, m_pState->GetStringFormat(),
-                                 m_pState->CurGroupFlowType(), false) : 
-      Utils::ComputeStringFormat("a", 1, m_pState->GetStringFormat(),
-                                 m_pState->CurGroupFlowType(), false);
+  const StringFormat::value strFormat = 
+      Utils::ComputeBinaryFormat(binary, m_pState->GetStringFormat(),
+                                 m_pState->CurGroupFlowType());
 
   if (strFormat == StringFormat::Literal) 
     m_pState->SetMapKeyFormat(YAML::LongKey, FmtScope::Local);
@@ -988,12 +986,12 @@ Emitter& Emitter::Write(const Binary& binary) {
   PrepareNode(EmitterNodeType::Scalar);
 
   switch (strFormat) {
-    // case StringFormat::Plain:		// to avoid changing the default behavior
-    //   m_stream.write(EncodeBase64(binary.data(), binary.size()));
-    //   break;
     case StringFormat::SingleQuoted:
       Utils::WriteSingleQuotedBinary(m_stream, binary);
       break;
+    // For a long period of time, this function outputed the DoubleQuoted form
+    // regardless of the options. In order not to change the default behavior,
+    // when strFormat is Plain, it is still treated as DoubleQuoted.
     case StringFormat::Plain:
     case StringFormat::DoubleQuoted:
       Utils::WriteBinary(m_stream, binary);

--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -516,5 +516,18 @@ bool WriteBinary(ostream_wrapper& out, const Binary& binary) {
                           StringEscaping::None);
   return true;
 }
+
+bool WriteLiteralBinary(ostream_wrapper& out, const Binary& binary, std::size_t indent) {
+  std::string encoded = EncodeBase64(binary.data(), binary.size());
+  WriteLiteralString(out, encoded.data(), encoded.size(), indent);
+  return true;
+}
+
+bool WriteSingleQuotedBinary(ostream_wrapper& out, const Binary& binary) {
+  std::string encoded = EncodeBase64(binary.data(), binary.size());
+  WriteSingleQuotedString(out, encoded.data(), encoded.size());
+  return true;
+}
+
 }  // namespace Utils
 }  // namespace YAML

--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -297,6 +297,33 @@ StringFormat::value ComputeStringFormat(const char* str, std::size_t size,
   return StringFormat::DoubleQuoted;
 }
 
+StringFormat::value ComputeBinaryFormat(const Binary &bin,
+                                        EMITTER_MANIP strFormat,
+                                        FlowType::value flowType) {
+  // Equivalent to calling ComputeStringFormat with the base64
+  // encoded form of 'bin'.
+  switch (strFormat) {
+    case Auto:
+      if (bin.size() > 0u) {
+        return StringFormat::Plain; 
+      }
+      return StringFormat::DoubleQuoted;
+    case SingleQuoted:
+      return StringFormat::SingleQuoted;
+    case DoubleQuoted:
+      return StringFormat::DoubleQuoted;
+    case Literal:
+      if (flowType == FlowType::Flow) {
+        return StringFormat::DoubleQuoted;
+      }
+      return StringFormat::Literal;
+    default:
+      break;
+  }
+
+  return StringFormat::DoubleQuoted;
+}
+
 bool WriteSingleQuotedString(ostream_wrapper& out, const char* str, std::size_t size) {
   out << "'";
   int codePoint;

--- a/src/emitterutils.h
+++ b/src/emitterutils.h
@@ -49,6 +49,8 @@ bool WriteTag(ostream_wrapper& out, const std::string& str, bool verbatim);
 bool WriteTagWithPrefix(ostream_wrapper& out, const std::string& prefix,
                         const std::string& tag);
 bool WriteBinary(ostream_wrapper& out, const Binary& binary);
+bool WriteSingleQuotedBinary(ostream_wrapper& out, const Binary& binary);
+bool WriteLiteralBinary(ostream_wrapper& out, const Binary& binary, std::size_t indent);
 }
 }
 

--- a/src/emitterutils.h
+++ b/src/emitterutils.h
@@ -33,6 +33,9 @@ StringFormat::value ComputeStringFormat(const char* str, std::size_t size,
                                         EMITTER_MANIP strFormat,
                                         FlowType::value flowType,
                                         bool escapeNonAscii);
+StringFormat::value ComputeBinaryFormat(const Binary &bin,
+                                        EMITTER_MANIP strFormat,
+                                        FlowType::value flowType);
 
 bool WriteSingleQuotedString(ostream_wrapper& out, const char* str, std::size_t size);
 bool WriteDoubleQuotedString(ostream_wrapper& out, const char* str, std::size_t size,

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -1191,6 +1191,34 @@ TEST_F(EmitterTest, EmptyBinary) {
   ExpectEmit("!!binary \"\"");
 }
 
+TEST_F(EmitterTest, BinaryStyles) {
+  Binary binary(reinterpret_cast<const unsigned char*>("Hello, World!"), 13);
+  out << BeginMap;
+  out << Key << "auto";
+  out << Value << Auto << binary;
+  out << Key << "single";
+  out << Value << SingleQuoted << binary;
+  out << Key << "double";
+  out << Value << DoubleQuoted << binary;
+  out << Key << "literal";
+  out << Value << Literal << binary;
+  out << Key << "literal_empty";
+  out << Value << Literal << Binary(reinterpret_cast<const unsigned char*>(""), 0);
+  out << Key << "literal_indented";
+  out << Value << Literal << Indent(8) << binary;
+  ExpectEmit(
+      "auto: !!binary \"SGVsbG8sIFdvcmxkIQ==\"\n"
+      "single: !!binary \'SGVsbG8sIFdvcmxkIQ==\'\n"
+      "double: !!binary \"SGVsbG8sIFdvcmxkIQ==\"\n"
+      "literal: !!binary |-\n"
+      "  SGVsbG8sIFdvcmxkIQ==\n"
+      "literal_empty: !!binary |-\n"
+      "\n"
+      "literal_indented: !!binary |-\n"
+      "        SGVsbG8sIFdvcmxkIQ=="
+  );
+}
+
 TEST_F(EmitterTest, ColonAtEndOfScalar) {
   out << "a:";
   ExpectEmit("\"a:\"");
@@ -1468,8 +1496,8 @@ TEST_F(EmitterTest, Infinity) {
   out << YAML::EndMap;
 
   ExpectEmit(
-	  "foo: .inf\n"
-	  "bar: .inf");
+      "foo: .inf\n"
+      "bar: .inf");
 }
 
 TEST_F(EmitterTest, NegInfinity) {
@@ -1481,8 +1509,8 @@ TEST_F(EmitterTest, NegInfinity) {
   out << YAML::EndMap;
 
   ExpectEmit(
-	  "foo: -.inf\n"
-	  "bar: -.inf");
+      "foo: -.inf\n"
+      "bar: -.inf");
 }
 
 TEST_F(EmitterTest, NaN) {
@@ -1494,8 +1522,8 @@ TEST_F(EmitterTest, NaN) {
   out << YAML::EndMap;
 
   ExpectEmit(
-	  "foo: .nan\n"
-	  "bar: .nan");
+      "foo: .nan\n"
+      "bar: .nan");
 }
 
 TEST_F(EmitterTest, ComplexFlowSeqEmbeddingAMapWithNewLine) { 


### PR DESCRIPTION
Fixes #1445 and a part of issue #1287. 
Support literal and single-quoted style for YAML::Binary emitting. Attempts to support plain form may change the default behavior, so are not applied.
Related tests are added to `EmitterTest.BinaryStyles` in test/integration/emitter_test.cpp.