### PR TITLE
Add stdint.h include to emitterutils.cpp

### DIFF
--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <iomanip>
 #include <sstream>
+#include <stdint.h>
 
 #include "emitterutils.h"
 #include "exp.h"


### PR DESCRIPTION
```bash
...
[406/1335] Building CXX object external/yaml/CMakeFiles/yaml-cpp.dir/src/emitterutils.cpp.o
FAILED: [code=1] external/yaml/CMakeFiles/yaml-cpp.dir/src/emitterutils.cpp.o 
/usr/bin/c++ -DYAML_CPP_NO_CONTRIB -DYAML_CPP_STATIC_DEFINE -I/build/qsoc-git/src/qsoc-git/build/external/yaml -I/build/qsoc-git/src/qsoc-git/external/yaml -I/build/qsoc-git/src/qsoc-git/build/external/yaml/yaml-cpp_autogen/include -I/build/qsoc-git/src/qsoc-git/external/yaml/include -I/build/qsoc-git/src/qsoc-git/external/yaml/src -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection         -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -Wp,-D_GLIBCXX_ASSERTIONS -g -ffile-prefix-map=/build/qsoc-git/src=/usr/src/debug/qsoc-git -flto=auto -O3 -DNDEBUG -std=c++20 -fPIC -MD -MT external/yaml/CMakeFiles/yaml-cpp.dir/src/emitterutils.cpp.o -MF external/yaml/CMakeFiles/yaml-cpp.dir/src/emitterutils.cpp.o.d -o external/yaml/CMakeFiles/yaml-cpp.dir/src/emitterutils.cpp.o -c /build/qsoc-git/src/qsoc-git/external/yaml/src/emitterutils.cpp
/build/qsoc-git/src/qsoc-git/external/yaml/src/emitterutils.cpp:221:11: error: ‘uint16_t’ was not declared in this scope
  221 | std::pair<uint16_t, uint16_t> EncodeUTF16SurrogatePair(int codePoint) {
      |           ^~~~~~~~
/build/qsoc-git/src/qsoc-git/external/yaml/src/emitterutils.cpp:13:1: note: ‘uint16_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   12 | #include "yaml-cpp/null.h"
  +++ |+#include <cstdint>
   13 | #include "yaml-cpp/ostream_wrapper.h"
/build/qsoc-git/src/qsoc-git/external/yaml/src/emitterutils.cpp:221:21: error: ‘uint16_t’ was not declared in this scope
  221 | std::pair<uint16_t, uint16_t> EncodeUTF16SurrogatePair(int codePoint) {
      |                     ^~~~~~~~
/build/qsoc-git/src/qsoc-git/external/yaml/src/emitterutils.cpp:221:21: note: ‘uint16_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/build/qsoc-git/src/qsoc-git/external/yaml/src/emitterutils.cpp:221:29: error: template argument 1 is invalid
  221 | std::pair<uint16_t, uint16_t> EncodeUTF16SurrogatePair(int codePoint) {
      |                             ^
/build/qsoc-git/src/qsoc-git/external/yaml/src/emitterutils.cpp:221:29: error: template argument 2 is invalid
...
```