### PR TITLE
fix: parse YAML 1.2 octal scalars (0o prefix) as integers

### DIFF
--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -164,6 +164,15 @@ ConvertStreamTo(std::stringstream& stream, T& rhs) {
   }
   return false;
 }
+
+// Rewrite a valid YAML 1.2 octal scalar ("0o14") to the stream-parseable "014".
+inline std::string NormalizeOctalPrefix(std::string s) {
+  if (s.size() > 2 && s[0] == '0' && (s[1] == 'o' || s[1] == 'O') &&
+      s.find_first_not_of("01234567", 2) == std::string::npos) {
+    s.erase(1, 1);
+  }
+  return s;
+}
 }
 
 #define YAML_DEFINE_CONVERT_STREAMABLE(type, negative_op)                  \
@@ -183,7 +192,7 @@ ConvertStreamTo(std::stringstream& stream, T& rhs) {
         return false;                                                      \
       }                                                                    \
       const std::string& input = node.Scalar();                            \
-      std::stringstream stream(input);                                     \
+      std::stringstream stream(conversion::NormalizeOctalPrefix(input));   \
       stream.imbue(std::locale::classic());                                \
       stream.unsetf(std::ios::dec);                                        \
       if ((stream.peek() == '-') && std::is_unsigned<type>::value) {       \

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -69,6 +69,18 @@ TEST(NodeTest, IntScalar) {
   EXPECT_EQ(15, node.as<int>());
 }
 
+TEST(NodeTest, OctalScalar) {
+  // YAML 1.2 octal prefix "0o..." (#1251)
+  EXPECT_EQ(83, Node("0o123").as<int>());
+  EXPECT_EQ(7u, Node("0o7").as<unsigned>());
+  // Legacy leading-zero octal and other bases still work
+  EXPECT_EQ(83, Node("0123").as<int>());
+  EXPECT_EQ(255, Node("0xff").as<int>());
+  EXPECT_EQ(123, Node("123").as<int>());
+  // "0o" followed by non-octal digits must not be reinterpreted as hex
+  EXPECT_EQ(-1, Node("0oxff").as<int>(-1));
+}
+
 TEST(NodeTest, SimpleAppendSequence) {
   Node node;
   node.push_back(10);


### PR DESCRIPTION
Fixes #1251.

YAML 1.2 writes octal as `0o17`, but `as<int>()` failed on it because std::stringstream's octal parsing only understands the C-style `0` prefix.

Normalize `0o`/`0O` to a leading `0` before the stream conversion, so both the 1.1 (`0123`) and 1.2 (`0o123`) spellings decode. Hex and decimal are unchanged. As per the discussion in the issue, adding a function `NormalizeOctalPrefix` that should help to  support backward compatibility. Added a test covering octal, signed/unsigned, hex and decimal.

Do let me know if i misinterpreted the behavior required!