### PR TITLE
doc: stop directing users to stackoverflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
 
 See [Tutorial](https://github.com/jbeder/yaml-cpp/wiki/Tutorial) and [How to Emit YAML](https://github.com/jbeder/yaml-cpp/wiki/How-To-Emit-YAML) for reference. For the old API (until 0.5.0), see [How To Parse A Document](https://github.com/jbeder/yaml-cpp/wiki/How-To-Parse-A-Document-(Old-API)).
 
-## Any Problems?
-
-If you find a bug, post an [issue](https://github.com/jbeder/yaml-cpp/issues)! If you have questions about how to use yaml-cpp, please post it on http://stackoverflow.com and tag it [`yaml-cpp`](http://stackoverflow.com/questions/tagged/yaml-cpp).
-
 ## How to Build
 
 `yaml-cpp` uses [CMake](http://www.cmake.org) to support cross-platform building. Install [CMake](http://www.cmake.org) _(Resources -> Download)_ before proceeding. The basic steps to build are:


### PR DESCRIPTION
TLDR: Removing the `## Any Problems` section from the README.

People on stackoverflow are not as active as they used to be. Not sure if they even get help there. So I would like to remove that link.
And having a explicit statement to open a ticket on github is not necessary. 
I think the shorter the README the better.


