### PR TITLE
feat: add thread-safe contains() function for Node.

### DIFF
--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -394,6 +394,12 @@ inline void Node::force_insert(const Key& key, const Value& value) {
   m_pNode->force_insert(key, value, m_pMemory);
 }
 
+template <typename Key>
+inline bool Node::contains(const Key& key) const {
+  EnsureNodeExists();
+  return ((const detail::node*)m_pNode)->get(key, m_pMemory) != nullptr;
+}
+
 // free functions
 inline bool operator==(const Node& lhs, const Node& rhs) { return lhs.is(rhs); }
 }  // namespace YAML

--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -396,8 +396,10 @@ inline void Node::force_insert(const Key& key, const Value& value) {
 
 template <typename Key>
 inline bool Node::contains(const Key& key) const {
-  EnsureNodeExists();
-  return ((const detail::node*)m_pNode)->get(key, m_pMemory) != nullptr;
+  if (!m_isValid)
+    throw InvalidNode(m_invalidKey);
+  if (!m_pNode) return false;
+  return (static_cast<const detail::node*>(m_pNode))->get(key, m_pMemory) != nullptr;
 }
 
 // free functions

--- a/include/yaml-cpp/node/node.h
+++ b/include/yaml-cpp/node/node.h
@@ -114,6 +114,9 @@ class YAML_CPP_API Node {
   template <typename Key, typename Value>
   void force_insert(const Key& key, const Value& value);
 
+  template <typename Key>
+  bool contains(const Key& key) const;
+
  private:
   enum Zombie { ZombieNode };
   explicit Node(Zombie);

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -199,6 +199,31 @@ TEST(NodeTest, MissingKey) {
   EXPECT_THROW(node["bar"].as<std::string>(), InvalidNode);
 }
 
+TEST(NodeTest, MapContains) {
+  Node node, key;
+  node["foo"] = "value";
+  node["bar"] = "eulav";
+  node[1] = "hello";
+  key["test"] = "asdf";
+  key["test2"] = "ghjkl";
+  node[key] = 123;
+  EXPECT_TRUE(node.contains("foo"));
+  EXPECT_TRUE(node.contains("bar"));
+  EXPECT_TRUE(node.contains(1));
+  EXPECT_TRUE(node.contains(key));
+  EXPECT_TRUE(!node.contains("baz"));
+  EXPECT_TRUE(!node.contains(2));
+
+  node.remove("foo");
+  node.remove(key);
+  EXPECT_TRUE(!node.contains("foo"));
+  EXPECT_TRUE(node.contains("bar"));
+  EXPECT_TRUE(node.contains(1));
+  EXPECT_TRUE(!node.contains(key));
+  EXPECT_TRUE(!node.contains("baz"));
+  EXPECT_TRUE(!node.contains(2));
+}
+
 TEST(NodeTest, MapIntegerElementRemoval) {
   Node node;
   node[1] = "hello";


### PR DESCRIPTION
Add `contains()` function to check if `node[key]` exists.
Close #1350 and close #1092.