### PR TITLE
fix: reject trailing scalar in block mapping at end of document

### DIFF
--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -280,6 +280,7 @@ void Scanner::EndStream() {
     INPUT.ResetColumn();
   }
 
+  InvalidateSimpleKey();
   PopAllIndents();
   PopAllSimpleKeys();
 

--- a/src/simplekey.cpp
+++ b/src/simplekey.cpp
@@ -126,7 +126,10 @@ bool Scanner::VerifySimpleKey() {
 }
 
 void Scanner::PopAllSimpleKeys() {
-  while (!m_simpleKeys.empty())
+  while (!m_simpleKeys.empty()) {
+    if (m_simpleKeys.top().flowLevel == 0)
+      m_simpleKeys.top().Invalidate();
     m_simpleKeys.pop();
+  }
 }
 }  // namespace YAML

--- a/src/simplekey.cpp
+++ b/src/simplekey.cpp
@@ -126,10 +126,7 @@ bool Scanner::VerifySimpleKey() {
 }
 
 void Scanner::PopAllSimpleKeys() {
-  while (!m_simpleKeys.empty()) {
-    if (m_simpleKeys.top().flowLevel == 0)
-      m_simpleKeys.top().Invalidate();
+  while (!m_simpleKeys.empty())
     m_simpleKeys.pop();
-  }
 }
 }  // namespace YAML

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -271,6 +271,41 @@ struct ParserExceptionTestCase {
   std::string expected_exception;
 };
 
+TEST(LoadNodeTest, RejectTrailingScalarInBlockMap) {
+  const std::vector<std::string> inputs = {
+      "---\nfoo: bar\nnot-a-key\n",
+      "---\nfoo: bar\nnot-a-key\n# A comment",
+  };
+
+  for (const std::string& input : inputs) {
+    try {
+      Load(input);
+      FAIL() << "Expected trailing scalar to be rejected, input: " << input;
+    } catch (const ParserException& e) {
+      EXPECT_EQ(ErrorMsg::END_OF_MAP, e.msg);
+      EXPECT_EQ(2, e.mark.line);
+      EXPECT_EQ(0, e.mark.column);
+    }
+  }
+}
+
+TEST(LoadNodeTest, AcceptValidDocumentsWhenPoppingSimpleKeys) {
+  Node scalar = Load("not-a-key");
+  EXPECT_TRUE(scalar.IsScalar());
+  EXPECT_EQ("not-a-key", scalar.as<std::string>());
+
+  Node explicit_key = Load("? key");
+  ASSERT_TRUE(explicit_key.IsMap());
+  ASSERT_EQ(1, explicit_key.size());
+  EXPECT_TRUE(explicit_key["key"].IsNull());
+
+  Node map = Load("foo: bar\nbaz: qux\n...");
+  ASSERT_TRUE(map.IsMap());
+  ASSERT_EQ(2, map.size());
+  EXPECT_EQ("bar", map["foo"].as<std::string>());
+  EXPECT_EQ("qux", map["baz"].as<std::string>());
+}
+
 TEST(NodeTest, IncompleteJson) {
   std::vector<ParserExceptionTestCase> tests = {
       {"JSON map without value", "{\"access\"", ErrorMsg::END_OF_MAP_FLOW},

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -273,6 +273,7 @@ struct ParserExceptionTestCase {
 
 TEST(LoadNodeTest, RejectTrailingScalarInBlockMap) {
   const std::vector<std::string> inputs = {
+      "---\nfoo: bar\nnot-a-key",
       "---\nfoo: bar\nnot-a-key\n",
       "---\nfoo: bar\nnot-a-key\n# A comment",
   };


### PR DESCRIPTION
## Summary
When the scanner sees a plain scalar in block context it speculatively pushes a KEY token with status UNVERIFIED (`Scanner::InsertPotentialSimpleKey` in src/simplekey.cpp) and only validates it when a later `:` triggers `VerifySimpleKey`. At end of stream (and at doc start/end and directives), `Scanner::PopAllSimpleKeys` pops the pending simple keys WITHOUT calling `Invalidate()`, so the still-UNVERIFIED KEY token survives in the token queue and the parser treats the dangling scalar as a valid key with a null value. The fix is to invalidate unverified pending simple keys in `PopAllSimpleKeys` (src/simplekey.cpp) before popping, so the leftover KEY token is discarded; `SingleDocParser::HandleBlockMap` then sees a bare SCALAR token where it expects KEY/VALUE/BLOCK_MAP_END and throws ParserException END_OF_MAP, matching the behavior already seen when a comment follows.

## Why this matters
Parsing the document `foo: bar` followed by a bare line `not-a-key` (with no colon) at the end of the document succeeds, treating `not-a-key` as a map key with a null value, when it should be a parse error. If anything follows the dangling scalar (for example a comment), a ParserException "end of map not found" is correctly thrown, so the bug only manifests when the dangling scalar is the last content before end of stream. A collaborator (SGSSGene) confirmed on 2026-04-26 that this is a bug that must be fixed. The issue is labeled bug and help wanted, is unassigned, and has no PRs referencing it.

See https://github.com/jbeder/yaml-cpp/issues/819.

## Testing
- Happy path: `foo: bar` alone still parses to a one-entry map; `foo: bar\nbaz: qux` parses to a two-entry map (verified keys unaffected). - Bug case: `---\nfoo: bar\nnot-a-key\n` at end of document now throws ParserException (end of map not found) instead of silently producing a null-valued key. - Existing error path unchanged: `---\nfoo: bar\nnot-a-key\n# A comment` still throws ParserException at line 3, column 1. - Edge cases: dangling scalar as the only document content (`not-a-key` with no prior map) still parses as a plain scalar document; explicit-key form `?

Fixes #819
