### PR TITLE
fix: emit uint8_t as an integer

### DIFF
--- a/include/yaml-cpp/emitter.h
+++ b/include/yaml-cpp/emitter.h
@@ -234,7 +234,7 @@ inline Emitter& operator<<(Emitter& emitter, char v) {
   return emitter.Write(v);
 }
 inline Emitter& operator<<(Emitter& emitter, unsigned char v) {
-  return emitter.Write(static_cast<char>(v));
+  return emitter.WriteIntegralType(static_cast<unsigned int>(v));
 }
 inline Emitter& operator<<(Emitter& emitter, const _Alias& v) {
   return emitter.Write(v);

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -119,7 +119,7 @@ TEST_F(EmitterTest, IntBase) {
   ExpectEmit("- 1024\n- 0x400\n- 02000");
 }
 
-TEST_F(EmitterTest, EightBitIntegers) {
+TEST_F(EmitterTest, UnsignedEightBitInteger) {
   out << BeginSeq;
   out << std::uint8_t{16};
   out << EndSeq;

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -3,6 +3,8 @@
 #include "yaml-cpp/yaml.h"  // IWYU pragma: keep
 #include "gtest/gtest.h"
 
+#include <cstdint>
+
 namespace YAML {
 namespace {
 
@@ -115,6 +117,14 @@ TEST_F(EmitterTest, IntBase) {
   out << EndSeq;
 
   ExpectEmit("- 1024\n- 0x400\n- 02000");
+}
+
+TEST_F(EmitterTest, EightBitIntegers) {
+  out << BeginSeq;
+  out << std::uint8_t{16};
+  out << EndSeq;
+
+  ExpectEmit("- 16");
 }
 
 TEST_F(EmitterTest, NumberPrecision) {


### PR DESCRIPTION
## Summary
- Emit `uint8_t`/`unsigned char` through the integral emitter path instead of treating the value as a character.
- Keep the existing plain `char` behavior unchanged and add a regression test for numeric output.

## Reproduction
- Before: `./build/test/yaml-cpp-tests --gtest_filter=EmitterTest.UnsignedEightBitInteger` → expected `- 16`, got `- "\\x10"`.
- After: the same command passes and emits `- 16`.

## Tests
- `./build/test/yaml-cpp-tests --gtest_filter=EmitterTest.UnsignedEightBitInteger`
- `./build/test/yaml-cpp-tests` (1027 tests passed; 8 disabled)

Fixes #1245
