### PR TITLE
fix: preserve original scalar text for null nodes so as<string> returns the source text

### DIFF
--- a/include/yaml-cpp/eventhandler.h
+++ b/include/yaml-cpp/eventhandler.h
@@ -23,6 +23,10 @@ class EventHandler {
   virtual void OnDocumentEnd() = 0;
 
   virtual void OnNull(const Mark& mark, anchor_t anchor) = 0;
+  virtual void OnNull(const Mark& mark, anchor_t anchor,
+                      const std::string& /*value*/) {
+    OnNull(mark, anchor);
+  }
   virtual void OnAlias(const Mark& mark, anchor_t anchor) = 0;
   virtual void OnScalar(const Mark& mark, const std::string& tag,
                         anchor_t anchor, const std::string& value) = 0;

--- a/include/yaml-cpp/node/detail/node.h
+++ b/include/yaml-cpp/node/detail/node.h
@@ -82,6 +82,10 @@ class node {
     mark_defined();
     m_pRef->set_null();
   }
+  void set_null(const std::string& scalar) {
+    mark_defined();
+    m_pRef->set_null(scalar);
+  }
   void set_scalar(const std::string& scalar) {
     mark_defined();
     m_pRef->set_scalar(scalar);

--- a/include/yaml-cpp/node/detail/node_data.h
+++ b/include/yaml-cpp/node/detail/node_data.h
@@ -38,6 +38,7 @@ class YAML_CPP_API node_data {
   void set_type(NodeType::value type);
   void set_tag(const std::string& tag);
   void set_null();
+  void set_null(const std::string& scalar);
   void set_scalar(const std::string& scalar);
   void set_style(EmitterStyle::value style);
 

--- a/include/yaml-cpp/node/detail/node_ref.h
+++ b/include/yaml-cpp/node/detail/node_ref.h
@@ -34,6 +34,7 @@ class node_ref {
   void set_type(NodeType::value type) { m_pData->set_type(type); }
   void set_tag(const std::string& tag) { m_pData->set_tag(tag); }
   void set_null() { m_pData->set_null(); }
+  void set_null(const std::string& scalar) { m_pData->set_null(scalar); }
   void set_scalar(const std::string& scalar) { m_pData->set_scalar(scalar); }
   void set_style(EmitterStyle::value style) { m_pData->set_style(style); }
 

--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -117,7 +117,7 @@ struct as_if<std::string, S> {
 
   std::string operator()(const S& fallback) const {
     if (node.Type() == NodeType::Null)
-      return "null";
+      return node.Scalar();
     if (node.Type() != NodeType::Scalar)
       return fallback;
     return node.Scalar();
@@ -149,7 +149,7 @@ struct as_if<std::string, void> {
     if (node.Type() == NodeType::Undefined) // no fallback
       throw InvalidNode(node.m_invalidKey);
     if (node.Type() == NodeType::Null)
-      return "null";
+      return node.Scalar();
     if (node.Type() != NodeType::Scalar)
       throw TypedBadConversion<std::string>(node.Mark());
     return node.Scalar();

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -75,9 +75,12 @@ void node_data::set_tag(const std::string& tag) { m_tag = tag; }
 
 void node_data::set_style(EmitterStyle::value style) { m_style = style; }
 
-void node_data::set_null() {
+void node_data::set_null() { set_null(""); }
+
+void node_data::set_null(const std::string& scalar) {
   m_isDefined = true;
   m_type = NodeType::Null;
+  m_scalar = scalar;
 }
 
 void node_data::set_scalar(const std::string& scalar) {

--- a/src/nodebuilder.cpp
+++ b/src/nodebuilder.cpp
@@ -38,6 +38,13 @@ void NodeBuilder::OnNull(const Mark& mark, anchor_t anchor) {
   Pop();
 }
 
+void NodeBuilder::OnNull(const Mark& mark, anchor_t anchor,
+                         const std::string& value) {
+  detail::node& node = Push(mark, anchor);
+  node.set_null(value);
+  Pop();
+}
+
 void NodeBuilder::OnAlias(const Mark& /* mark */, anchor_t anchor) {
   detail::node& node = *m_anchors[anchor];
   Push(node);

--- a/src/nodebuilder.h
+++ b/src/nodebuilder.h
@@ -39,6 +39,8 @@ class NodeBuilder : public EventHandler {
   void OnDocumentEnd() override;
 
   void OnNull(const Mark& mark, anchor_t anchor) override;
+  void OnNull(const Mark& mark, anchor_t anchor,
+              const std::string& value) override;
   void OnAlias(const Mark& mark, anchor_t anchor) override;
   void OnScalar(const Mark& mark, const std::string& tag,
                         anchor_t anchor, const std::string& value) override;

--- a/src/singledocparser.cpp
+++ b/src/singledocparser.cpp
@@ -100,7 +100,7 @@ void SingleDocParser::HandleNode(EventHandler& eventHandler) {
 
   if (token.type == Token::PLAIN_SCALAR
       && tag.compare("?") == 0 && IsNullString(token.value.data(), token.value.size())) {
-    eventHandler.OnNull(mark, anchor);
+    eventHandler.OnNull(mark, anchor, token.value);
     m_scanner.pop();
     return;
   }

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -18,6 +18,13 @@ TEST(LoadNodeTest, FallbackValues) {
   EXPECT_EQ(2, node["x"].as<int>());
   EXPECT_EQ(2, node["x"].as<int>(5));
   EXPECT_EQ(5, node["y"].as<int>(5));
+
+  Node map = Load("{foo: bar}");
+  Node sequence = Load("[foo]");
+  EXPECT_THROW(map.as<std::string>(), TypedBadConversion<std::string>);
+  EXPECT_THROW(sequence.as<std::string>(), TypedBadConversion<std::string>);
+  EXPECT_EQ("fallback", map.as<std::string>("fallback"));
+  EXPECT_EQ("fallback", sequence.as<std::string>("fallback"));
 }
 
 TEST(LoadNodeTest, NumericConversion) {
@@ -346,8 +353,50 @@ TEST(NodeTest, IncorrectFlow) {
 TEST(NodeTest, LoadTildeAsNull) {
   Node node = Load("~");
   ASSERT_TRUE(node.IsNull());
-  EXPECT_EQ(node.as<std::string>(), "null");
-  EXPECT_EQ(node.as<std::string>("~"), "null");
+  EXPECT_EQ(node.Scalar(), "~");
+  EXPECT_EQ(node.as<std::string>(), "~");
+  EXPECT_EQ(node.as<std::string>("fallback"), "~");
+}
+
+TEST(NodeTest, LoadNullPreservesSourceText) {
+  Node node = Load(
+      "empty:\n"
+      "lowercase: null\n"
+      "capitalized: Null\n"
+      "uppercase: NULL\n"
+      "quoted: \"null\"");
+
+  EXPECT_TRUE(node["empty"].IsNull());
+  EXPECT_EQ(node["empty"].Scalar(), "");
+  EXPECT_EQ(node["empty"].as<std::string>(), "");
+
+  EXPECT_TRUE(node["lowercase"].IsNull());
+  EXPECT_EQ(node["lowercase"].Scalar(), "null");
+  EXPECT_EQ(node["lowercase"].as<std::string>(), "null");
+
+  EXPECT_TRUE(node["capitalized"].IsNull());
+  EXPECT_EQ(node["capitalized"].Scalar(), "Null");
+  EXPECT_EQ(node["capitalized"].as<std::string>(), "Null");
+
+  EXPECT_TRUE(node["uppercase"].IsNull());
+  EXPECT_EQ(node["uppercase"].Scalar(), "NULL");
+  EXPECT_EQ(node["uppercase"].as<std::string>(), "NULL");
+
+  EXPECT_TRUE(node["quoted"].IsScalar());
+  EXPECT_EQ(node["quoted"].Scalar(), "null");
+  EXPECT_EQ(node["quoted"].as<std::string>(), "null");
+}
+
+TEST(NodeTest, LoadStructuralNullsHaveEmptyScalar) {
+  Node flowMap = Load("{key:}");
+  ASSERT_TRUE(flowMap["key"].IsNull());
+  EXPECT_EQ(flowMap["key"].Scalar(), "");
+  EXPECT_EQ(flowMap["key"].as<std::string>(), "");
+
+  Node blockSequence = Load("-\n");
+  ASSERT_TRUE(blockSequence[0].IsNull());
+  EXPECT_EQ(blockSequence[0].Scalar(), "");
+  EXPECT_EQ(blockSequence[0].as<std::string>(), "");
 }
 
 TEST(NodeTest, LoadNullWithStrTag) {

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -64,6 +64,13 @@ TEST(NodeTest, SimpleScalar) {
   EXPECT_EQ("Hello, World!", node.as<std::string>());
 }
 
+TEST(NodeTest, DefaultNodeHasEmptyNullScalar) {
+  Node node;
+  EXPECT_TRUE(node.IsNull());
+  EXPECT_EQ("", node.Scalar());
+  EXPECT_EQ("", node.as<std::string>());
+}
+
 TEST(NodeTest, IntScalar) {
   Node node = Node(15);
   EXPECT_TRUE(node.IsScalar());


### PR DESCRIPTION
## Summary
Plumb the original token text through the null path without breaking the public EventHandler API: add a non-pure virtual `OnNull(const Mark&, anchor_t, const std::string& value)` overload to include/yaml-cpp/eventhandler.h whose default implementation delegates to the existing two-arg `OnNull`, so third-party handlers and the emitter/graphbuilder adapters keep working unchanged. `SingleDocParser::HandleNode` passes `token.value` at the null-plain-scalar site; `NodeBuilder` overrides the three-arg `OnNull` and calls a new `node_data::set_null(const std::string& scalar)` overload (include/yaml-cpp/node/detail/node_data.h + src/node_data.cpp) that sets `m_type = NodeType::Null` while storing the source text in `m_scalar`, exposed via the existing `Scalar()` accessor. Finally, the two `as_if<std::string>` specializations in include/yaml-cpp/node/impl.h return `node.Scalar()` for Null nodes instead of the literal `"null"`, so `key:` yields `""`, `key: ~` yields `"~"`, and `key: null` yields `"null"`, while `IsNull()` stays true for all of them.

## Why this matters
Since yaml-cpp 0.8.0, any null-like plain scalar (`<empty>`, `~`, `null`, `Null`, `NULL`) loses its original text: `SingleDocParser::HandleNode` (src/singledocparser.cpp, ~line 101) detects `IsNullString(token.value...)` and emits `OnNull(mark, anchor)`, discarding `token.value`. `NodeBuilder::OnNull` then calls `node.set_null()`, which leaves `m_scalar` empty, and `as_if<std::string>` in include/yaml-cpp/node/impl.h (~lines 119 and 151) hard-codes the return value `"null"` for `NodeType::Null`. The reporter cannot distinguish `message:` (empty) from `message: null` because both `Scalar()` and `as<std::string>()` return fabricated values. Owner jbeder agreed the original text representation should be kept in `Scalar()` and returned by `as<std::string>()` ("Yeah that's reasonable").

See https://github.com/jbeder/yaml-cpp/issues/1290.

## Testing
- Happy path: load `message: null` and assert `IsNull()` is true, `Scalar() == "null"`, and `as<std::string>() == "null"` (test/integration/load_node_test.cpp). - Variants: `key:` yields `""`, `key: ~` yields `"~"`, `key: Null` / `key: NULL` yield their exact source text; quoted `"null"` remains a plain string scalar unaffected. - Edge cases: flow-map and block-seq missing values (structural nulls with no token) return `""` from `as<std::string>()` and stay `IsNull()`; a default-constructed `Node()` still reports Null with empty scalar (test/node/node_test.cpp). - Error paths: `as<std::string>()` on a map/sequence still throws `TypedBadConversion`; `as<std::string>(fallback)` on non-scalar non-null still returns the fallback.

Fixes #1290
