### PR TITLE
fix: allow '~' in emitted anchor and alias names

### DIFF
--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -39,7 +39,7 @@ bool IsAnchorChar(int ch) {  // test for ns-anchor-char
     return false;
   }
 
-  if (ch < 0x7E) {
+  if (ch <= 0x7E) {
     return true;
   }
 

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -535,6 +535,15 @@ TEST_F(EmitterTest, AliasAndAnchor) {
   ExpectEmit("- &fred\n  name: Fred\n  age: 42\n- *fred");
 }
 
+TEST_F(EmitterTest, AnchorWithTilde) {
+  out << BeginSeq;
+  out << Anchor("foo~bar") << "value";
+  out << Alias("foo~bar");
+  out << EndSeq;
+
+  ExpectEmit("- &foo~bar value\n- *foo~bar");
+}
+
 TEST_F(EmitterTest, AliasOnKey) {
   out << BeginSeq;
   out << Anchor("name") << "Name";


### PR DESCRIPTION
`IsAnchorChar` (the emitter's `ns-anchor-char` check) rejects `0x7E` (`~`) because of an off-by-one: it tests `ch < 0x7E` before falling through to the DEL/C1 exclusion. But `~` is a valid `ns-char` (YAML 1.2 printable range `0x21–0x7E`) and is not a flow indicator, so it's a legal anchor-name character — and the scanner's anchor rule (`Exp::Anchor()`) already accepts it.

The result is an asymmetry: `&anchor~ x` parses fine but the emitter can't write it back out, failing with `INVALID_ANCHOR` — so yaml-cpp fails to round-trip its own valid input.

Fix: `ch < 0x7E` → `ch <= 0x7E`. DEL (`0x7F`) and the C1 controls (`0x80–0x9F`) remain excluded. Added `EmitterTest.AnchorWithTilde` (fails before, passes after).