### PR TITLE
Avoid production source glob checks in no-op builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,7 @@ if (NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
     MultiThreaded$<$<CONFIG:Debug>:Debug>$<${msvc-shared_rt}:DLL>)
 endif()
 
-file(GLOB yaml-cpp-contrib-sources CONFIGURE_DEPENDS "src/contrib/*.cpp")
-file(GLOB yaml-cpp-sources CONFIGURE_DEPENDS "src/*.cpp")
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/yaml-cpp-sources.cmake")
 
 set(msvc-rt $<TARGET_PROPERTY:MSVC_RUNTIME_LIBRARY>)
 

--- a/cmake/yaml-cpp-sources.cmake
+++ b/cmake/yaml-cpp-sources.cmake
@@ -1,0 +1,35 @@
+set(yaml-cpp-contrib-sources
+  src/contrib/graphbuilder.cpp
+  src/contrib/graphbuilderadapter.cpp)
+
+set(yaml-cpp-sources
+  src/binary.cpp
+  src/convert.cpp
+  src/depthguard.cpp
+  src/directives.cpp
+  src/emit.cpp
+  src/emitfromevents.cpp
+  src/emitter.cpp
+  src/emitterstate.cpp
+  src/emitterutils.cpp
+  src/exceptions.cpp
+  src/exp.cpp
+  src/fptostring.cpp
+  src/memory.cpp
+  src/node.cpp
+  src/node_data.cpp
+  src/nodebuilder.cpp
+  src/nodeevents.cpp
+  src/null.cpp
+  src/ostream_wrapper.cpp
+  src/parse.cpp
+  src/parser.cpp
+  src/regex_yaml.cpp
+  src/scanner.cpp
+  src/scanscalar.cpp
+  src/scantag.cpp
+  src/scantoken.cpp
+  src/simplekey.cpp
+  src/singledocparser.cpp
+  src/stream.cpp
+  src/tag.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,11 @@ endif()
 
 
 add_test(NAME yaml-cpp::test COMMAND yaml-cpp-tests)
+add_test(
+  NAME yaml-cpp::source-list
+  COMMAND ${CMAKE_COMMAND}
+    -D YAML_CPP_SOURCE_DIR=${PROJECT_SOURCE_DIR}
+    -P ${PROJECT_SOURCE_DIR}/test/cmake/verify-source-list.cmake)
 
 if (build-windows-dll)
   add_custom_command(

--- a/test/cmake/verify-source-list.cmake
+++ b/test/cmake/verify-source-list.cmake
@@ -1,0 +1,21 @@
+include("${YAML_CPP_SOURCE_DIR}/cmake/yaml-cpp-sources.cmake")
+
+file(GLOB actual_sources
+  LIST_DIRECTORIES false
+  RELATIVE "${YAML_CPP_SOURCE_DIR}"
+  "${YAML_CPP_SOURCE_DIR}/src/*.cpp"
+  "${YAML_CPP_SOURCE_DIR}/src/contrib/*.cpp")
+
+set(expected_sources
+  ${yaml-cpp-contrib-sources}
+  ${yaml-cpp-sources})
+
+list(SORT actual_sources)
+list(SORT expected_sources)
+
+if(NOT "${actual_sources}" STREQUAL "${expected_sources}")
+  message(FATAL_ERROR
+    "yaml-cpp source list is out of date.\n"
+    "Expected: ${expected_sources}\n"
+    "Actual: ${actual_sources}")
+endif()


### PR DESCRIPTION
## Summary

- replace the production `CONFIGURE_DEPENDS` source globs with an explicit source list
- add a CTest check that compares the explicit list with the C++ files under `src/`
- keep test source discovery unchanged

This prevents consumers that use `add_subdirectory` from running CMake's glob verification on every no-op build, while the regression test catches newly added production sources that are missing from the explicit list.

Fixes #1463.

## Validation

- Ubuntu 24.04, GCC 13, CMake, and Ninja: configured with `YAML_CPP_BUILD_TESTS=ON`, built all targets, and passed both CTest tests
- configured with tests and tools disabled: the second Ninja build reported `ninja: no work to do.` and generated no `VerifyGlobs.cmake`
- external `add_subdirectory` consumer with `YAML_CPP_BUILD_CONTRIB=OFF`: built successfully and had a clean second no-op build
- negative regression check: an unlisted temporary `src/forgotten.cpp` caused `yaml-cpp::source-list` to fail as intended

## AI assistance disclosure

OpenAI Codex was used as a coding tool to inspect the repository, implement this change, and run validation. The patch was checked with the validation listed above.