### PR TITLE
Throw on already-failed input streams in Load and LoadAll

### DIFF
--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -296,9 +296,10 @@ class YAML_CPP_API EmitterException : public Exception {
 
 class YAML_CPP_API BadFile : public Exception {
  public:
-  explicit BadFile(const std::string& filename)
+  explicit BadFile(const std::string& filename = "")
       : Exception(Mark::null_mark(),
-                  std::string(ErrorMsg::BAD_FILE) + ": " + filename) {}
+                  std::string(ErrorMsg::BAD_FILE) +
+                      (filename.empty() ? "" : (": " + filename))) {}
   BadFile(const BadFile&) = default;
   ~BadFile() YAML_CPP_NOEXCEPT override;
 };

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -20,6 +20,9 @@ Node Load(const char* input) {
 }
 
 Node Load(std::istream& input) {
+  if (!input) {
+    throw BadFile();
+  }
   Parser parser(input);
   NodeBuilder builder;
   if (!parser.HandleNextDocument(builder)) {
@@ -49,6 +52,10 @@ std::vector<Node> LoadAll(const char* input) {
 
 std::vector<Node> LoadAll(std::istream& input) {
   std::vector<Node> docs;
+
+  if (!input) {
+    throw BadFile();
+  }
 
   Parser parser(input);
   while (true) {

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -1,5 +1,7 @@
 #include "yaml-cpp/yaml.h"  // IWYU pragma: keep
 
+#include <sstream>
+
 #include "gtest/gtest.h"
 
 namespace YAML {
@@ -8,6 +10,24 @@ TEST(LoadNodeTest, Reassign) {
   Node node = Load("foo");
   node = Node();
   EXPECT_TRUE(node.IsNull());
+}
+
+TEST(LoadNodeTest, LoadFailedStreamThrows) {
+  std::istringstream stream;
+  stream.setstate(std::ios_base::failbit);
+  EXPECT_THROW(Load(stream), BadFile);
+}
+
+TEST(LoadNodeTest, LoadBadStreamThrows) {
+  std::istringstream stream;
+  stream.setstate(std::ios_base::badbit);
+  EXPECT_THROW(Load(stream), BadFile);
+}
+
+TEST(LoadNodeTest, LoadAllFailedStreamThrows) {
+  std::istringstream stream;
+  stream.setstate(std::ios_base::failbit);
+  EXPECT_THROW(LoadAll(stream), BadFile);
 }
 
 TEST(LoadNodeTest, FallbackValues) {


### PR DESCRIPTION
# Throw on already-failed input streams in Load / LoadAll

Fixes #408

## Problem

`YAML::Load(std::istream&)` and `YAML::LoadAll(std::istream&)` never checked
whether the stream handed to them was already in a failed (`failbit`) or bad
(`badbit`) state. A broken stream was silently treated as empty/valid, so
`Load()` returned a null `Node` and `LoadAll()` returned an empty vector
instead of signalling the error:

```cpp
std::istringstream s;
s.setstate(std::ios_base::failbit);
YAML::Node n = YAML::Load(s);  // does not throw
assert(n.IsNull());            // passes -- but should have errored
```

The same silent behavior reached every entry point that funnels through these
two functions: `Load(const std::string&)`, `Load(const char*)`, the `LoadAll`
string overloads, `LoadFile`, and `LoadAllFromFile`.

## Root cause

`src/parse.cpp` — `Load(std::istream&)` (line 22) and `LoadAll(std::istream&)`
(line 50) constructed a `Parser` and called `HandleNextDocument` unconditionally,
with no check of `input.fail()` / `input.bad()`. `LoadFile` already guarded the
*open* failure with `if (!fin) throw BadFile(filename);`, but a caller passing an
externally-created stream that was already in an error state hit no such guard.

## Fix

Add the same idiomatic stream-state guard the rest of the file already uses
(`if (!fin)`) to the two stream entry points, throwing `BadFile` when the
incoming stream is not in a good state:

```cpp
Node Load(std::istream& input) {
  if (!input) {
    throw BadFile();
  }
  ...
}
```

`if (!input)` is `std::ios::operator!`, i.e. `input.fail()`, which covers both
`failbit` and `badbit` (the two states in the report) while leaving a benign
end-of-file-only stream to parse to a null document as before.

`BadFile` is reused because it is already the exception `LoadFile` throws for an
unusable input source, so `catch` sites do not need to learn a new type. Its
constructor gains a defaulted `filename = ""` argument so it can describe a
generic stream that has no filename; the message stays `"bad file"` (no trailing
`": "`) in that case and remains exactly `"bad file: <name>"` when a filename is
supplied.

## Tests

Added three cases to `test/integration/load_node_test.cpp`:

- `LoadFailedStreamThrows` — `Load` on a `failbit` stream throws `BadFile`
- `LoadBadStreamThrows` — `Load` on a `badbit` stream throws `BadFile`
- `LoadAllFailedStreamThrows` — `LoadAll` on a `failbit` stream throws `BadFile`

## Verification

```
cmake -S . -B build -DYAML_CPP_BUILD_TESTS=ON
cmake --build build --target yaml-cpp-tests
./build/test/yaml-cpp-tests
```

- Before the fix: the three new tests FAIL — "Expected: Load(stream) throws an
  exception of type BadFile. Actual: it throws nothing."
- After the fix: full suite green — `1034 tests from 17 test suites` passed
  (3 new + 1031 pre-existing), no regressions.

## Compatibility

- Behavioral change is limited to the previously-buggy path: a stream that is
  already failed/bad now throws `BadFile` instead of silently yielding a null
  `Node` / empty vector. Valid streams (including empty and EOF-only streams)
  are unaffected.
- `BadFile` derives from `YAML::Exception` (a `std::runtime_error`), like every
  other load-time error, so existing `catch (const YAML::Exception&)` /
  `catch (const std::exception&)` handlers keep working.
- Giving `BadFile`'s `filename` parameter a default value is source- and
  ABI-compatible: existing `BadFile(name)` calls are unchanged and the
  constructor symbol is unaffected.

## AI disclosure

This change was AI-authored and AI-reviewed; it has not yet been human-reviewed.
(Per this repository's contribution guidelines, AI is treated as a tool, not a
co-author, so it is not listed as a commit co-author.)
