### PR TITLE
fix: remove unverified potential simple key when beginning parsing a literal scalar

### DIFF
--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -168,6 +168,17 @@ void Scanner::ScanNextToken() {
   // special scalars
   if (InBlockContext() && (INPUT.peek() == Keys::LiteralScalar ||
                            INPUT.peek() == Keys::FoldedScalar)) {
+    // if we begin parsing a literal scalar with an unverified potential 
+    // simple key pushed, that may be a tag to the literal scalar, and
+    // should be removed to avoid wrong indentation limit
+    // eg:
+    // - !!str |
+    //  literal
+    //  scalar
+    if (!m_simpleKeys.empty() &&
+      m_simpleKeys.top().pKey->status == Token::UNVERIFIED) {
+        PopIndent();
+    }
     return ScanBlockScalar();
   }
 

--- a/test/integration/handler_test.cpp
+++ b/test/integration/handler_test.cpp
@@ -72,5 +72,53 @@ TEST_F(HandlerTest, CommentOnNewlineOfMapValueWithManySpace) {
   EXPECT_CALL(handler, OnDocumentEnd());
   Parse("key: value\n    # comment");
 }
+
+// examples from issue #1163
+TEST_F(HandlerTest, LiteralScalarWithTagAndLargeIndentation) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "key"));
+  EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:str", 0, "multiple\nwords"));
+  EXPECT_CALL(handler, OnSequenceEnd());
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse("key:\n- !!str |\n   multiple\n   words");
+}
+
+TEST_F(HandlerTest, LiteralScalarWithTagAndSmallIndentation_NotBlockSequence) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "key"));
+  EXPECT_CALL(handler, OnScalar(_, "!t", 0, "multiple\nwords"));
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse("key: !t |\n multiple\n words");
+}
+
+TEST_F(HandlerTest, LiteralScalarWithTagAndSmallIndentation_ApplicationTag) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "key"));
+  EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "!t", 0, "multiple\nwords"));
+  EXPECT_CALL(handler, OnSequenceEnd());
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse("key:\n- !t |\n multiple\n words");
+}
+
+TEST_F(HandlerTest, LiteralScalarWithTagAndSmallIndentation_StandardTag) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "key"));
+  EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:str", 0, "multiple\nwords"));
+  EXPECT_CALL(handler, OnSequenceEnd());
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse("key:\n- !!str |\n  multiple\n  words");
+}
+
 }  // namespace
 }  // namespace YAML


### PR DESCRIPTION
fixes #1163 