### PR TITLE
Add some missing constexpr on static constants

### DIFF
--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -3,7 +3,7 @@
 #include <cctype>
 
 namespace YAML {
-static const char encoding[] =
+static constexpr char encoding[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 std::string EncodeBase64(const unsigned char *data, std::size_t size) {
@@ -44,7 +44,7 @@ std::string EncodeBase64(const unsigned char *data, std::size_t size) {
   return ret;
 }
 
-static const unsigned char decoding[] = {
+static constexpr unsigned char decoding[] = {
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 62,  255,

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -45,8 +45,8 @@ bool convert<bool>::decode(const Node& node, bool& rhs) {
   // we can't use iostream bool extraction operators as they don't
   // recognize all possible values in the table below (taken from
   // http://yaml.org/type/bool.html)
-  static const struct {
-    std::string truename, falsename;
+  static constexpr struct {
+    const char *truename, *falsename;
   } names[] = {
       {"y", "n"},
       {"yes", "no"},

--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -229,7 +229,7 @@ std::pair<uint16_t, uint16_t> EncodeUTF16SurrogatePair(int codePoint) {
 }
 
 void WriteDoubleQuoteEscapeSequence(ostream_wrapper& out, int codePoint, StringEscaping::value stringEscapingStyle) {
-  static const char hexDigits[] = "0123456789abcdef";
+  static constexpr char hexDigits[] = "0123456789abcdef";
 
   out << "\\";
   int digits = 8;


### PR DESCRIPTION
This avoids the Static Initialization (and Destruction) Order Fiasco.

https://en.cppreference.com/cpp/language/siof
https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables