### PR TITLE
Add LICENSE file to Bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
+exports_files(["LICENSE"])
+
 yaml_cpp_defines = select({
     # On Windows, ensure static linking is used.
     "@platforms//os:windows": ["YAML_CPP_STATIC_DEFINE", "YAML_CPP_NO_CONTRIB"],


### PR DESCRIPTION
Bazel users cannot access this file (e.g., to redistribute it) unless it's explicitly marked public.