### PR TITLE
feat: make iterators bidirectional

### DIFF
--- a/include/yaml-cpp/node/detail/iterator.h
+++ b/include/yaml-cpp/node/detail/iterator.h
@@ -41,7 +41,7 @@ class iterator_base {
   };
 
  public:
-  using iterator_category = std::forward_iterator_tag;
+  using iterator_category = std::bidirectional_iterator_tag;
   using value_type = V;
   using difference_type = std::ptrdiff_t;
   using pointer = V*;
@@ -66,6 +66,17 @@ class iterator_base {
   iterator_base<V> operator++(int) {
     iterator_base<V> iterator_pre(*this);
     ++(*this);
+    return iterator_pre;
+  }
+  
+  iterator_base<V>& operator--() {
+    --m_iterator;
+    return *this;
+  }
+
+  iterator_base<V> operator--(int) {
+    iterator_base<V> iterator_pre(*this);
+    --(*this);
     return iterator_pre;
   }
 

--- a/include/yaml-cpp/node/detail/node_iterator.h
+++ b/include/yaml-cpp/node/detail/node_iterator.h
@@ -69,7 +69,7 @@ class node_iterator_base {
   };
 
  public:
-  using iterator_category = std::forward_iterator_tag;
+  using iterator_category = std::bidirectional_iterator_tag;
   using value_type = node_iterator_value<V>;
   using difference_type = std::ptrdiff_t;
   using pointer = node_iterator_value<V>*;
@@ -140,9 +140,30 @@ class node_iterator_base {
     return *this;
   }
 
+  node_iterator_base<V>& operator--() {
+    switch (m_type) {
+      case iterator_type::NoneType:
+        break;
+      case iterator_type::Sequence:
+        --m_seqIt;
+        break;
+      case iterator_type::Map:
+        --m_mapIt;
+        m_mapIt = decrement_until_defined(m_mapIt);
+        break;
+    }
+    return *this;
+  }
+
   node_iterator_base<V> operator++(int) {
     node_iterator_base<V> iterator_pre(*this);
     ++(*this);
+    return iterator_pre;
+  }
+
+  node_iterator_base<V> operator--(int) {
+    node_iterator_base<V> iterator_pre(*this);
+    --(*this);
     return iterator_pre;
   }
 
@@ -163,6 +184,12 @@ class node_iterator_base {
   MapIter increment_until_defined(MapIter it) {
     while (it != m_mapEnd && !is_defined(it))
       ++it;
+    return it;
+  }
+
+  MapIter decrement_until_defined(MapIter it) {
+    while (!is_defined(it))
+      --it;
     return it;
   }
 

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -343,6 +343,17 @@ TEST(NodeTest, MapIteratorWithUndefinedValues) {
   EXPECT_EQ(1, count);
 }
 
+TEST(NodeTest, MapIteratorWithUndefinedValuesBackward) {
+  Node node;
+  node["key"] = "value";
+  node["undefined"];
+
+  std::size_t count = 0;
+  for (const_iterator it = node.end(); it != node.begin(); --it)
+    count++;
+  EXPECT_EQ(1, count);
+}
+
 TEST(NodeTest, DestroyedMapIterator) {
   Node node;
   node["key"] = "value";
@@ -390,6 +401,22 @@ TEST(NodeTest, InteratorOnSequence) {
   for (iterator it = node.begin(); it != node.end(); ++it)
   {
     EXPECT_FALSE(it->IsNull());
+    count++;
+  }
+  EXPECT_EQ(3, count);
+}
+  
+TEST(NodeTest, InteratorOnSequenceBackward) {
+  Node node;
+  node[0] = "a";
+  node[1] = "b";
+  node[2] = "c";
+  EXPECT_TRUE(node.IsSequence());
+  
+  std::size_t count = 0;
+  for (iterator it = node.end(); it != node.begin(); --it)
+  {
+    EXPECT_FALSE(prev(it)->IsNull());
     count++;
   }
   EXPECT_EQ(3, count);


### PR DESCRIPTION
Makes YAML::detail::node_iterator_base and YAML::detail::iterator_base bidirectional.
Closes #1192 .