### PR TITLE
fix: multiple documents starting with a tag

### DIFF
--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -309,8 +309,10 @@ void Emitter::PrepareTopNode(EmitterNodeType::value child) {
   if (child == EmitterNodeType::NoType)
     return;
 
-  if (m_pState->CurGroupChildCount() > 0 && m_stream.col() > 0)
+  if (m_pState->CurGroupChildCount() > 0 && m_stream.col() > 0
+    && !m_pState->HasBegunContent()) {
     EmitBeginDoc();
+  }
 
   switch (child) {
     case EmitterNodeType::NoType:

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -2059,5 +2059,32 @@ TEST_F(EmitterTest, EmitSetLocalTagInNameHandle) {
   ExpectEmit("num: !a!foo 42");
 }
 
+TEST_F(EmitterTest, EmitMultiDocsWithTags) {
+   out << YAML::BeginDoc
+       << YAML::LocalTag("The_Tag")
+       << YAML::BeginSeq
+       << "Some Value"
+       << YAML::EndSeq
+       << YAML::EndDoc;
+
+   out << YAML::BeginDoc
+       << YAML::LocalTag("The_Tag")
+       << YAML::BeginSeq
+       << "Some Value"
+       << YAML::EndSeq
+       << YAML::EndDoc;
+
+  ExpectEmit(
+        "---\n"
+        "!The_Tag\n"
+        "- Some Value\n"
+        "...\n"
+        "---\n"
+        "!The_Tag\n"
+        "- Some Value\n"
+        "...\n");
+}
+
+
 }  // namespace
 }  // namespace YAML


### PR DESCRIPTION
fixes #321 

When emitting multiple documents and the documents start with a tag, this caused the emitter state to go into an invalid state, stopping to emit any data.
Even though a tag was emitter, the next value (e.g.: a scalar) trigger another start of the document.

This is fixed by tightening the constraints when to emit the start of the document.