### PR TITLE
fix: UB when calling empty YAML::Binary::data()

### DIFF
--- a/include/yaml-cpp/binary.h
+++ b/include/yaml-cpp/binary.h
@@ -30,7 +30,7 @@ class YAML_CPP_API Binary {
   bool owned() const { return !m_unownedData; }
   std::size_t size() const { return owned() ? m_data.size() : m_unownedSize; }
   const unsigned char *data() const {
-    return owned() ? &m_data[0] : m_unownedData;
+    return owned() ? m_data.data() : m_unownedData;
   }
 
   void swap(std::vector<unsigned char> &rhs) {

--- a/test/binary_test.cpp
+++ b/test/binary_test.cpp
@@ -18,3 +18,9 @@ TEST(BinaryTest, DecodingTooShort) {
   const std::vector<unsigned char> &result = YAML::DecodeBase64(input);
   EXPECT_TRUE(result.empty());
 }
+
+TEST(BinaryTest, EmptyBinary) {
+    YAML::Binary b;
+    EXPECT_TRUE(b.size() == 0);
+    EXPECT_TRUE(b.data() == b.data()); // caused UB in the past
+}


### PR DESCRIPTION
fix #1248 

calling `YAML::Binary::data()` on binary data of length zero caused undefined behavior. This PR fixes this.