### PR TITLE
feat: add IWYU pragmas for public/private headers (#1386)

### DIFF
--- a/include/yaml-cpp/anchor.h
+++ b/include/yaml-cpp/anchor.h
@@ -1,11 +1,20 @@
 #ifndef ANCHOR_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define ANCHOR_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <cstddef>
 

--- a/include/yaml-cpp/binary.h
+++ b/include/yaml-cpp/binary.h
@@ -1,11 +1,20 @@
 #ifndef BASE64_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define BASE64_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <string>
 #include <vector>

--- a/include/yaml-cpp/contrib/anchordict.h
+++ b/include/yaml-cpp/contrib/anchordict.h
@@ -1,11 +1,20 @@
 #ifndef ANCHORDICT_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define ANCHORDICT_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <vector>
 

--- a/include/yaml-cpp/contrib/graphbuilder.h
+++ b/include/yaml-cpp/contrib/graphbuilder.h
@@ -1,11 +1,20 @@
 #ifndef GRAPHBUILDER_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define GRAPHBUILDER_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "yaml-cpp/mark.h"
 #include <string>

--- a/include/yaml-cpp/depthguard.h
+++ b/include/yaml-cpp/depthguard.h
@@ -1,11 +1,20 @@
 #ifndef DEPTH_GUARD_H_00000000000000000000000000000000000000000000000000000000
 #define DEPTH_GUARD_H_00000000000000000000000000000000000000000000000000000000
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "exceptions.h"
 

--- a/include/yaml-cpp/dll.h
+++ b/include/yaml-cpp/dll.h
@@ -1,6 +1,16 @@
 #ifndef DLL_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define DLL_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
+
+
+
+
+
+
 // Definition YAML_CPP_STATIC_DEFINE using to building YAML-CPP as static
 // library (definition created by CMake or defined manually)
 

--- a/include/yaml-cpp/emitfromevents.h
+++ b/include/yaml-cpp/emitfromevents.h
@@ -1,11 +1,20 @@
 #ifndef EMITFROMEVENTS_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define EMITFROMEVENTS_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <stack>
 

--- a/include/yaml-cpp/emitter.h
+++ b/include/yaml-cpp/emitter.h
@@ -1,11 +1,20 @@
 #ifndef EMITTER_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define EMITTER_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <cmath>
 #include <cstddef>

--- a/include/yaml-cpp/emitterdef.h
+++ b/include/yaml-cpp/emitterdef.h
@@ -1,11 +1,20 @@
 #ifndef EMITTERDEF_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define EMITTERDEF_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 namespace YAML {
 struct EmitterNodeType {

--- a/include/yaml-cpp/emittermanip.h
+++ b/include/yaml-cpp/emittermanip.h
@@ -1,11 +1,20 @@
 #ifndef EMITTERMANIP_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define EMITTERMANIP_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <string>
 

--- a/include/yaml-cpp/emitterstyle.h
+++ b/include/yaml-cpp/emitterstyle.h
@@ -1,11 +1,20 @@
 #ifndef EMITTERSTYLE_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define EMITTERSTYLE_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 namespace YAML {
 namespace EmitterStyle {

--- a/include/yaml-cpp/eventhandler.h
+++ b/include/yaml-cpp/eventhandler.h
@@ -1,11 +1,20 @@
 #ifndef EVENTHANDLER_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define EVENTHANDLER_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <string>
 

--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -1,11 +1,20 @@
 #ifndef EXCEPTIONS_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define EXCEPTIONS_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "yaml-cpp/mark.h"
 #include "yaml-cpp/noexcept.h"

--- a/include/yaml-cpp/fptostring.h
+++ b/include/yaml-cpp/fptostring.h
@@ -1,6 +1,16 @@
 #ifndef YAML_H_FPTOSTRING
 #define YAML_H_FPTOSTRING
 
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
+
+
+
+
+
+
 #include "yaml-cpp/dll.h"
 
 #include <string>

--- a/include/yaml-cpp/mark.h
+++ b/include/yaml-cpp/mark.h
@@ -1,11 +1,20 @@
 #ifndef MARK_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define MARK_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "yaml-cpp/dll.h"
 

--- a/include/yaml-cpp/node/convert.h
+++ b/include/yaml-cpp/node/convert.h
@@ -1,11 +1,20 @@
 #ifndef NODE_CONVERT_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define NODE_CONVERT_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <array>
 #include <cmath>

--- a/include/yaml-cpp/node/detail/impl.h
+++ b/include/yaml-cpp/node/detail/impl.h
@@ -1,11 +1,20 @@
 #ifndef NODE_DETAIL_IMPL_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define NODE_DETAIL_IMPL_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "yaml-cpp/node/detail/node.h"
 #include "yaml-cpp/node/detail/node_data.h"

--- a/include/yaml-cpp/node/detail/iterator.h
+++ b/include/yaml-cpp/node/detail/iterator.h
@@ -1,11 +1,20 @@
 #ifndef VALUE_DETAIL_ITERATOR_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define VALUE_DETAIL_ITERATOR_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "yaml-cpp/dll.h"
 #include "yaml-cpp/node/detail/node_iterator.h"

--- a/include/yaml-cpp/node/detail/iterator_fwd.h
+++ b/include/yaml-cpp/node/detail/iterator_fwd.h
@@ -1,11 +1,20 @@
 #ifndef VALUE_DETAIL_ITERATOR_FWD_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define VALUE_DETAIL_ITERATOR_FWD_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "yaml-cpp/dll.h"
 #include <list>

--- a/include/yaml-cpp/node/detail/memory.h
+++ b/include/yaml-cpp/node/detail/memory.h
@@ -1,11 +1,20 @@
 #ifndef VALUE_DETAIL_MEMORY_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define VALUE_DETAIL_MEMORY_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <set>
 

--- a/include/yaml-cpp/node/detail/node.h
+++ b/include/yaml-cpp/node/detail/node.h
@@ -1,11 +1,20 @@
 #ifndef NODE_DETAIL_NODE_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define NODE_DETAIL_NODE_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "yaml-cpp/dll.h"
 #include "yaml-cpp/emitterstyle.h"

--- a/include/yaml-cpp/node/detail/node_data.h
+++ b/include/yaml-cpp/node/detail/node_data.h
@@ -1,11 +1,20 @@
 #ifndef VALUE_DETAIL_NODE_DATA_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define VALUE_DETAIL_NODE_DATA_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <list>
 #include <map>

--- a/include/yaml-cpp/node/detail/node_iterator.h
+++ b/include/yaml-cpp/node/detail/node_iterator.h
@@ -1,11 +1,20 @@
 #ifndef VALUE_DETAIL_NODE_ITERATOR_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define VALUE_DETAIL_NODE_ITERATOR_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "yaml-cpp/dll.h"
 #include "yaml-cpp/node/ptr.h"

--- a/include/yaml-cpp/node/detail/node_ref.h
+++ b/include/yaml-cpp/node/detail/node_ref.h
@@ -1,11 +1,20 @@
 #ifndef VALUE_DETAIL_NODE_REF_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define VALUE_DETAIL_NODE_REF_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "yaml-cpp/dll.h"
 #include "yaml-cpp/node/type.h"

--- a/include/yaml-cpp/node/detail/reverse_iterator.h
+++ b/include/yaml-cpp/node/detail/reverse_iterator.h
@@ -1,11 +1,20 @@
 #ifndef VALUE_DETAIL_REVERSE_ITERATOR_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define VALUE_DETAIL_REVERSE_ITERATOR_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "yaml-cpp/dll.h"
 #include "yaml-cpp/node/ptr.h"

--- a/include/yaml-cpp/node/emit.h
+++ b/include/yaml-cpp/node/emit.h
@@ -1,11 +1,20 @@
 #ifndef NODE_EMIT_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define NODE_EMIT_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <string>
 #include <iosfwd>

--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -1,11 +1,20 @@
 #ifndef NODE_IMPL_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define NODE_IMPL_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "yaml-cpp/exceptions.h"
 #include "yaml-cpp/node/detail/memory.h"

--- a/include/yaml-cpp/node/iterator.h
+++ b/include/yaml-cpp/node/iterator.h
@@ -1,11 +1,20 @@
 #ifndef VALUE_ITERATOR_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define VALUE_ITERATOR_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "yaml-cpp/dll.h"
 #include "yaml-cpp/node/node.h"

--- a/include/yaml-cpp/node/node.h
+++ b/include/yaml-cpp/node/node.h
@@ -1,11 +1,20 @@
 #ifndef NODE_NODE_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define NODE_NODE_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <stdexcept>
 #include <string>

--- a/include/yaml-cpp/node/parse.h
+++ b/include/yaml-cpp/node/parse.h
@@ -1,11 +1,20 @@
 #ifndef VALUE_PARSE_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define VALUE_PARSE_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <iosfwd>
 #include <string>

--- a/include/yaml-cpp/node/ptr.h
+++ b/include/yaml-cpp/node/ptr.h
@@ -1,11 +1,20 @@
 #ifndef VALUE_PTR_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define VALUE_PTR_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <memory>
 

--- a/include/yaml-cpp/node/type.h
+++ b/include/yaml-cpp/node/type.h
@@ -1,11 +1,20 @@
 #ifndef VALUE_TYPE_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define VALUE_TYPE_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 namespace YAML {
 namespace NodeType {

--- a/include/yaml-cpp/noexcept.h
+++ b/include/yaml-cpp/noexcept.h
@@ -1,11 +1,20 @@
 #ifndef NOEXCEPT_H_768872DA_476C_11EA_88B8_90B11C0C0FF8
 #define NOEXCEPT_H_768872DA_476C_11EA_88B8_90B11C0C0FF8
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 // This is here for compatibility with older versions of Visual Studio
 // which don't support noexcept.

--- a/include/yaml-cpp/null.h
+++ b/include/yaml-cpp/null.h
@@ -1,11 +1,20 @@
 #ifndef NULL_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define NULL_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include "yaml-cpp/dll.h"
 #include <cstddef>

--- a/include/yaml-cpp/ostream_wrapper.h
+++ b/include/yaml-cpp/ostream_wrapper.h
@@ -1,11 +1,20 @@
 #ifndef OSTREAM_WRAPPER_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define OSTREAM_WRAPPER_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <ostream>
 #include <string>

--- a/include/yaml-cpp/parser.h
+++ b/include/yaml-cpp/parser.h
@@ -1,11 +1,20 @@
 #ifndef PARSER_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define PARSER_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <istream>
 #include <memory>

--- a/include/yaml-cpp/stlemitter.h
+++ b/include/yaml-cpp/stlemitter.h
@@ -1,11 +1,20 @@
 #ifndef STLEMITTER_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define STLEMITTER_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <vector>
 #include <list>

--- a/include/yaml-cpp/traits.h
+++ b/include/yaml-cpp/traits.h
@@ -1,11 +1,20 @@
 #ifndef TRAITS_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 #define TRAITS_H_62B23520_7C8E_11DE_8A39_0800200C9A66
 
+
+
+
 #if defined(_MSC_VER) ||                                            \
     (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
      (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
 #pragma once
+
+
 #endif
+
+// IWYU pragma: private, include "yaml-cpp/yaml.h"
+// IWYU pragma: friend "yaml-cpp/.*"
+
 
 #include <type_traits>
 #include <utility>

--- a/include/yaml-cpp/yaml.h
+++ b/include/yaml-cpp/yaml.h
@@ -9,19 +9,19 @@
 
 // IWYU pragma: begin_exports
 
-#include "yaml-cpp/parser.h"
-#include "yaml-cpp/emitter.h"
-#include "yaml-cpp/emitterstyle.h"
-#include "yaml-cpp/stlemitter.h"
-#include "yaml-cpp/exceptions.h"
+#include "yaml-cpp/parser.h"  // IWYU pragma: export
+#include "yaml-cpp/emitter.h"  // IWYU pragma: export
+#include "yaml-cpp/emitterstyle.h"  // IWYU pragma: export
+#include "yaml-cpp/stlemitter.h"  // IWYU pragma: export
+#include "yaml-cpp/exceptions.h"  // IWYU pragma: export
 
-#include "yaml-cpp/node/node.h"
-#include "yaml-cpp/node/impl.h"
-#include "yaml-cpp/node/convert.h"
-#include "yaml-cpp/node/iterator.h"
-#include "yaml-cpp/node/detail/impl.h"
-#include "yaml-cpp/node/parse.h"
-#include "yaml-cpp/node/emit.h"
+#include "yaml-cpp/node/node.h"  // IWYU pragma: export
+#include "yaml-cpp/node/impl.h"  // IWYU pragma: export
+#include "yaml-cpp/node/convert.h"  // IWYU pragma: export
+#include "yaml-cpp/node/iterator.h"  // IWYU pragma: export
+#include "yaml-cpp/node/detail/impl.h"  // IWYU pragma: export
+#include "yaml-cpp/node/parse.h"  // IWYU pragma: export
+#include "yaml-cpp/node/emit.h"  // IWYU pragma: export
 
 // IWYU pragma: end_exports
 


### PR DESCRIPTION
## Summary

Adds [Include What You Use](https://include-what-you-use.org/) pragmas across yaml-cpp public headers, following the same pattern as googletest:

- `yaml-cpp/yaml.h` marks its transitive includes with `// IWYU pragma: export`
- Internal headers mark `// IWYU pragma: private, include "yaml-cpp/yaml.h"` plus `friend "yaml-cpp/.*"`

This lets IWYU redirect `#include "yaml-cpp/node/node.h"` to the umbrella header so users get `impl.h` and other required definitions, avoiding link errors.

Fixes #1386.

## Test plan

- [x] Headers compile unchanged (comments only)
- [ ] Run IWYU on a sample TU using `YAML::Node` and confirm it suggests `yaml-cpp/yaml.h`
