### PR TITLE
Fix static pkg-config compile flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,11 @@ write_basic_package_version_file(
   "${PROJECT_BINARY_DIR}/yaml-cpp-config-version.cmake"
   COMPATIBILITY AnyNewerVersion)
 
+if (YAML_BUILD_SHARED_LIBS)
+  set(YAML_CPP_PKG_CONFIG_CFLAGS_PRIVATE "")
+else()
+  set(YAML_CPP_PKG_CONFIG_CFLAGS_PRIVATE "-DYAML_CPP_STATIC_DEFINE")
+endif()
 configure_file(yaml-cpp.pc.in yaml-cpp.pc @ONLY)
 
 if (YAML_CPP_INSTALL)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,12 @@ add_test(
   COMMAND ${CMAKE_COMMAND}
     -D YAML_CPP_SOURCE_DIR=${PROJECT_SOURCE_DIR}
     -P ${PROJECT_SOURCE_DIR}/test/cmake/verify-source-list.cmake)
+add_test(
+  NAME yaml-cpp::pkg-config
+  COMMAND ${CMAKE_COMMAND}
+    -D YAML_CPP_PC_FILE=${PROJECT_BINARY_DIR}/yaml-cpp.pc
+    -D YAML_BUILD_SHARED_LIBS=${YAML_BUILD_SHARED_LIBS}
+    -P ${PROJECT_SOURCE_DIR}/test/cmake/verify-pkg-config.cmake)
 
 if (build-windows-dll)
   add_custom_command(

--- a/test/cmake/verify-pkg-config.cmake
+++ b/test/cmake/verify-pkg-config.cmake
@@ -1,0 +1,17 @@
+if(NOT DEFINED YAML_CPP_PC_FILE)
+  message(FATAL_ERROR "YAML_CPP_PC_FILE is required")
+endif()
+
+file(READ "${YAML_CPP_PC_FILE}" yaml_cpp_pc)
+set(static_define "Cflags.private: -DYAML_CPP_STATIC_DEFINE")
+string(FIND "${yaml_cpp_pc}" "${static_define}" static_define_pos)
+
+if(YAML_BUILD_SHARED_LIBS)
+  if(NOT static_define_pos EQUAL -1)
+    message(FATAL_ERROR
+      "Shared-library pkg-config metadata contains ${static_define}")
+  endif()
+elseif(static_define_pos EQUAL -1)
+  message(FATAL_ERROR
+    "Static-library pkg-config metadata does not contain ${static_define}")
+endif()

--- a/yaml-cpp.pc.in
+++ b/yaml-cpp.pc.in
@@ -9,3 +9,4 @@ Version: @YAML_CPP_VERSION@
 Requires:
 Libs: -L${libdir} -lyaml-cpp
 Cflags: -I${includedir}
+Cflags.private: @YAML_CPP_PKG_CONFIG_CFLAGS_PRIVATE@


### PR DESCRIPTION
## Summary
- emit `YAML_CPP_STATIC_DEFINE` through `Cflags.private` for static pkg-config metadata
- keep shared-library metadata free of the static definition
- add a CTest regression check for both build modes

Fixes #1345

## Testing
- static and shared CMake/Ninja Release builds
- `ctest` (3/3 in each build)
- install and CMake package consumers in both modes
- install and pkg-config consumers, including `--static --cflags`
