### PR TITLE
Reject failed input streams

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,9 @@ jobs:
         - name: Run Tests
           shell: bash
           run: |
+            if [[ "${{ matrix.os }}" == "windows-latest" && "${{ matrix.generator }}" == "MinGW Makefiles" ]]; then
+              export PATH="/c/mingw64/bin:$PATH"
+            fi
             ctest \
               --test-dir build \
               --build-config ${{ env.CMAKE_BUILD_TYPE }} \

--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -98,6 +98,7 @@ const char* const INVALID_ANCHOR = "invalid anchor";
 const char* const INVALID_ALIAS = "invalid alias";
 const char* const INVALID_TAG = "invalid tag";
 const char* const BAD_FILE = "bad file";
+const char* const BAD_STREAM = "bad stream";
 const char* const UNEXPECTED_TOKEN_AFTER_DOC = "unexpected token after end of document";
 const char* const NON_UNIQUE_MAP_KEY = "map keys must be unique";
 
@@ -303,6 +304,13 @@ class YAML_CPP_API EmitterException : public Exception {
       : Exception(Mark::null_mark(), msg_) {}
   EmitterException(const EmitterException&) = default;
   ~EmitterException() YAML_CPP_NOEXCEPT override;
+};
+
+class YAML_CPP_API BadStream : public Exception {
+ public:
+  BadStream() : Exception(Mark::null_mark(), ErrorMsg::BAD_STREAM) {}
+  BadStream(const BadStream&) = default;
+  ~BadStream() YAML_CPP_NOEXCEPT override;
 };
 
 class YAML_CPP_API BadFile : public Exception {

--- a/src/exceptions.cpp
+++ b/src/exceptions.cpp
@@ -16,6 +16,7 @@ BadSubscript::~BadSubscript() YAML_CPP_NOEXCEPT = default;
 BadPushback::~BadPushback() YAML_CPP_NOEXCEPT = default;
 BadInsert::~BadInsert() YAML_CPP_NOEXCEPT = default;
 EmitterException::~EmitterException() YAML_CPP_NOEXCEPT = default;
+BadStream::~BadStream() YAML_CPP_NOEXCEPT = default;
 BadFile::~BadFile() YAML_CPP_NOEXCEPT = default;
 NonUniqueMapKey::~NonUniqueMapKey() YAML_CPP_NOEXCEPT = default;
 }  // namespace YAML

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -425,12 +425,21 @@ inline char* ReadBuffer(unsigned char* pBuffer) {
 
 unsigned char Stream::GetNextByte() const {
   if (m_nPrefetchedUsed >= m_nPrefetchedAvailable) {
-    std::streambuf* pBuf = m_input.rdbuf();
-    m_nPrefetchedAvailable = static_cast<std::size_t>(
-        pBuf->sgetn(ReadBuffer(m_pPrefetched.get()), YAML_PREFETCH_SIZE));
+    try {
+      m_input.read(ReadBuffer(m_pPrefetched.get()), YAML_PREFETCH_SIZE);
+    } catch (const std::ios_base::failure&) {
+      if (m_input.bad() || !m_input.eof()) {
+        throw BadStream();
+      }
+    }
+    m_nPrefetchedAvailable = static_cast<std::size_t>(m_input.gcount());
     m_nPrefetchedUsed = 0;
-    if (m_input.fail()) {
+    if (m_input.bad() || (m_input.fail() && !m_input.eof())) {
       throw BadStream();
+    }
+    if (m_input.eof()) {
+      m_input.clear(m_nPrefetchedAvailable ? std::ios_base::goodbit
+                                           : std::ios_base::eofbit);
     }
     if (!m_nPrefetchedAvailable) {
       m_input.setstate(std::ios_base::eofbit);

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1,6 +1,7 @@
 #include <istream>
 
 #include "stream.h"
+#include "yaml-cpp/exceptions.h"
 
 #ifndef YAML_PREFETCH_SIZE
 #define YAML_PREFETCH_SIZE 2048
@@ -192,8 +193,8 @@ Stream::Stream(std::istream& input)
       m_nPrefetchedUsed(0) {
   using char_traits = std::istream::traits_type;
 
-  if (!input)
-    return;
+  if (input.fail())
+    throw BadStream();
 
   // Determine (or guess) the character-set by reading the BOM, if any.  See
   // the YAML specification for the determination algorithm.
@@ -202,6 +203,8 @@ Stream::Stream(std::istream& input)
   UtfIntroState state = uis_start;
   for (; !s_introFinalState[state];) {
     std::istream::int_type ch = input.get();
+    if (input.bad() || (input.fail() && !input.eof()))
+      throw BadStream();
     intro[nIntroUsed++] = ch;
     UtfIntroCharType charType = IntroCharTypeOf(ch);
     UtfIntroState newState = s_introTransitions[state][charType];
@@ -240,7 +243,7 @@ Stream::Stream(std::istream& input)
   ReadAheadTo(0);
 }
 
-Stream::~Stream() { delete[] m_pPrefetched; }
+Stream::~Stream() = default;
 
 char Stream::peek() const {
   if (m_readahead.empty()) {
@@ -424,8 +427,11 @@ unsigned char Stream::GetNextByte() const {
   if (m_nPrefetchedUsed >= m_nPrefetchedAvailable) {
     std::streambuf* pBuf = m_input.rdbuf();
     m_nPrefetchedAvailable = static_cast<std::size_t>(
-        pBuf->sgetn(ReadBuffer(m_pPrefetched), YAML_PREFETCH_SIZE));
+        pBuf->sgetn(ReadBuffer(m_pPrefetched.get()), YAML_PREFETCH_SIZE));
     m_nPrefetchedUsed = 0;
+    if (m_input.fail()) {
+      throw BadStream();
+    }
     if (!m_nPrefetchedAvailable) {
       m_input.setstate(std::ios_base::eofbit);
     }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -425,21 +425,16 @@ inline char* ReadBuffer(unsigned char* pBuffer) {
 
 unsigned char Stream::GetNextByte() const {
   if (m_nPrefetchedUsed >= m_nPrefetchedAvailable) {
+    std::streambuf* pBuf = m_input.rdbuf();
     try {
-      m_input.read(ReadBuffer(m_pPrefetched.get()), YAML_PREFETCH_SIZE);
+      m_nPrefetchedAvailable = static_cast<std::size_t>(
+          pBuf->sgetn(ReadBuffer(m_pPrefetched.get()), YAML_PREFETCH_SIZE));
     } catch (const std::ios_base::failure&) {
-      if (m_input.bad() || !m_input.eof()) {
-        throw BadStream();
-      }
-    }
-    m_nPrefetchedAvailable = static_cast<std::size_t>(m_input.gcount());
-    m_nPrefetchedUsed = 0;
-    if (m_input.bad() || (m_input.fail() && !m_input.eof())) {
       throw BadStream();
     }
-    if (m_input.eof()) {
-      m_input.clear(m_nPrefetchedAvailable ? std::ios_base::goodbit
-                                           : std::ios_base::eofbit);
+    m_nPrefetchedUsed = 0;
+    if (m_input.fail()) {
+      throw BadStream();
     }
     if (!m_nPrefetchedAvailable) {
       m_input.setstate(std::ios_base::eofbit);

--- a/src/stream.h
+++ b/src/stream.h
@@ -12,6 +12,7 @@
 #include <deque>
 #include <ios>
 #include <istream>
+#include <memory>
 #include <set>
 #include <string>
 
@@ -55,7 +56,7 @@ class Stream {
   CharacterSet m_charSet;
   char m_lineEndingSymbol{}; // 0 means it is not determined yet, must be '\n' or '\r'
   mutable std::deque<char> m_readahead;
-  unsigned char* const m_pPrefetched;
+  std::unique_ptr<unsigned char[]> m_pPrefetched;
   mutable size_t m_nPrefetchedAvailable;
   mutable size_t m_nPrefetchedUsed;
 

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -10,9 +10,7 @@ namespace {
 class FailingStreamBuf : public std::stringbuf {
  public:
   explicit FailingStreamBuf(const std::string& input)
-      : std::stringbuf(input), stream_(nullptr), first_read_(true) {}
-
-  void Bind(std::istream& stream) { stream_ = &stream; }
+      : std::stringbuf(input), first_read_(true) {}
 
  protected:
   std::streamsize xsgetn(char* output, std::streamsize count) override {
@@ -20,12 +18,10 @@ class FailingStreamBuf : public std::stringbuf {
       first_read_ = false;
       return std::stringbuf::xsgetn(output, count > 32 ? 32 : count);
     }
-    stream_->setstate(std::ios_base::badbit);
-    return 0;
+    throw std::ios_base::failure("simulated read failure");
   }
 
  private:
-  std::istream* stream_;
   bool first_read_;
 };
 
@@ -56,7 +52,6 @@ TEST(LoadNodeTest, LoadAllRejectsFailedInputStream) {
 TEST(LoadNodeTest, RejectsInputStreamFailureWhileReading) {
   FailingStreamBuf buffer("value: " + std::string(128, 'a'));
   std::istream stream(&buffer);
-  buffer.Bind(stream);
   EXPECT_THROW(Load(stream), BadStream);
 }
 

--- a/test/integration/load_node_test.cpp
+++ b/test/integration/load_node_test.cpp
@@ -1,13 +1,74 @@
 #include "yaml-cpp/yaml.h"  // IWYU pragma: keep
 
+#include <sstream>
+#include <string>
+
 #include "gtest/gtest.h"
 
 namespace YAML {
 namespace {
+class FailingStreamBuf : public std::stringbuf {
+ public:
+  explicit FailingStreamBuf(const std::string& input)
+      : std::stringbuf(input), stream_(nullptr), first_read_(true) {}
+
+  void Bind(std::istream& stream) { stream_ = &stream; }
+
+ protected:
+  std::streamsize xsgetn(char* output, std::streamsize count) override {
+    if (first_read_) {
+      first_read_ = false;
+      return std::stringbuf::xsgetn(output, count > 32 ? 32 : count);
+    }
+    stream_->setstate(std::ios_base::badbit);
+    return 0;
+  }
+
+ private:
+  std::istream* stream_;
+  bool first_read_;
+};
+
 TEST(LoadNodeTest, Reassign) {
   Node node = Load("foo");
   node = Node();
   EXPECT_TRUE(node.IsNull());
+}
+
+TEST(LoadNodeTest, RejectsFailedInputStream) {
+  std::istringstream stream("key: value");
+  stream.setstate(std::ios_base::failbit);
+  EXPECT_THROW(Load(stream), BadStream);
+}
+
+TEST(LoadNodeTest, RejectsBadInputStream) {
+  std::istringstream stream("key: value");
+  stream.setstate(std::ios_base::badbit);
+  EXPECT_THROW(Load(stream), BadStream);
+}
+
+TEST(LoadNodeTest, LoadAllRejectsFailedInputStream) {
+  std::istringstream stream("---\nfirst\n---\nsecond\n");
+  stream.setstate(std::ios_base::failbit);
+  EXPECT_THROW(LoadAll(stream), BadStream);
+}
+
+TEST(LoadNodeTest, RejectsInputStreamFailureWhileReading) {
+  FailingStreamBuf buffer("value: " + std::string(128, 'a'));
+  std::istream stream(&buffer);
+  buffer.Bind(stream);
+  EXPECT_THROW(Load(stream), BadStream);
+}
+
+TEST(LoadNodeTest, EmptyInputStreamRemainsNull) {
+  std::istringstream stream;
+  EXPECT_TRUE(Load(stream).IsNull());
+}
+
+TEST(LoadNodeTest, EofInputStreamRemainsNull) {
+  std::istringstream stream;
+  stream.setstate(std::ios_base::eofbit);
+  EXPECT_TRUE(Load(stream).IsNull());
 }
 
 TEST(LoadNodeTest, FallbackValues) {


### PR DESCRIPTION
Fixes #408

- reject failed input streams before and during parsing
- preserve empty and EOF-only streams
- add regression coverage for `Load` and `LoadAll`

Tests:
- CMake C++11 static build and full test suite
- Clang C++23 shared build and full CTest
- GCC C++20 ASan/UBSan suite
- Bazel `build :all` and `test test`
