### PR TITLE
fix orphaned utf-16 high surrogate dropping the next code unit

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -395,7 +395,7 @@ void Stream::StreamInUtf16() const {
         // Deal with the next UTF-16 unit
         if (chLow < 0xD800 || chLow >= 0xE000) {
           // Easiest case: queue the codepoint and return
-          QueueUnicodeCodepoint(m_readahead, ch);
+          QueueUnicodeCodepoint(m_readahead, chLow);
           return;
         }
         // Start the loop over with the new high surrogate

--- a/test/integration/encoding_test.cpp
+++ b/test/integration/encoding_test.cpp
@@ -179,10 +179,10 @@ TEST_F(EncodingTest, UTF32BE_BOM) {
   Run();
 }
 
-// An orphaned UTF-16 high surrogate must decode to a single replacement
-// character, and the code unit after it must still be decoded. Previously the
-// high surrogate was re-emitted as an ill-formed UTF-8 sequence and the
-// following character was dropped.
+// An orphaned UTF-16 high surrogate must decode to a single U+FFFD
+// (REPLACEMENT CHARACTER), and the code unit after it must still be decoded.
+// Previously the high surrogate was re-emitted as an ill-formed UTF-8 sequence
+// and the following character was dropped.
 TEST(Utf16SurrogateTest, OrphanHighSurrogateKeepsFollowingChar) {
   auto put = [](std::string& s, int unit) {
     s += Byte(unit & 0xFF);
@@ -199,6 +199,10 @@ TEST(Utf16SurrogateTest, OrphanHighSurrogateKeepsFollowingChar) {
 
   std::stringstream stream(input);
   Node node = Load(stream);
+  // "\xEF\xBF\xBD" is U+FFFD encoded as UTF-8; it stands in for the orphaned
+  // 0xD800. Before the fix the scalar was "\xEF\xBF\xBD\xED\xA0\x80": the
+  // replacement followed by 0xD800 itself encoded as (invalid) UTF-8, and 'A'
+  // was lost.
   EXPECT_EQ(node["x"].as<std::string>(), "\xEF\xBF\xBD" "A");
 }
 }

--- a/test/integration/encoding_test.cpp
+++ b/test/integration/encoding_test.cpp
@@ -178,5 +178,28 @@ TEST_F(EncodingTest, UTF32BE_BOM) {
   SetUpEncoding(&EncodeToUtf32BE, true);
   Run();
 }
+
+// An orphaned UTF-16 high surrogate must decode to a single replacement
+// character, and the code unit after it must still be decoded. Previously the
+// high surrogate was re-emitted as an ill-formed UTF-8 sequence and the
+// following character was dropped.
+TEST(Utf16SurrogateTest, OrphanHighSurrogateKeepsFollowingChar) {
+  auto put = [](std::string& s, int unit) {
+    s += Byte(unit & 0xFF);
+    s += Byte((unit >> 8) & 0xFF);
+  };
+
+  std::string input;
+  put(input, 0xFEFF);  // UTF-16LE BOM
+  put(input, 'x');
+  put(input, ':');
+  put(input, ' ');
+  put(input, 0xD800);  // high surrogate with no trailing low surrogate
+  put(input, 'A');
+
+  std::stringstream stream(input);
+  Node node = Load(stream);
+  EXPECT_EQ(node["x"].as<std::string>(), "\xEF\xBF\xBD" "A");
+}
 }
 }


### PR DESCRIPTION
StreamInUtf16 handles a high surrogate that isn't followed by a low surrogate by queuing a replacement character, but when the following unit is an ordinary BMP code unit it then queues `ch` (the orphaned high surrogate) instead of `chLow` (the unit that actually followed). That encodes a lone surrogate as ill-formed UTF-8 (U+D800 becomes ED A0 80) and drops the real character. It only shows up on malformed UTF-16 input, so the parser silently corrupts the scalar instead of substituting U+FFFD the way the replacement path intends.

Queue `chLow` so the orphan collapses to a single U+FFFD and the following character is still decoded. The bug lives in the decoder because that is where the replacement-character contract is enforced; callers only see the already-decoded UTF-8. Added a regression test next to the existing encoding tests covering a high surrogate followed by a plain character.