### PR TITLE
feat: Allow decoding for types without default constructor (V2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ cmake_dependent_option(YAML_MSVC_SHARED_RT
   "CMAKE_SYSTEM_NAME MATCHES Windows" OFF)
 set(YAML_CPP_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/yaml-cpp"
   CACHE STRING "Path to install the CMake package to")
- 
+
 if (YAML_CPP_FORMAT_SOURCE)
     find_program(YAML_CPP_CLANG_FORMAT_EXE NAMES clang-format)
 endif()
@@ -142,6 +142,16 @@ write_basic_package_version_file(
   COMPATIBILITY AnyNewerVersion)
 
 configure_file(yaml-cpp.pc.in yaml-cpp.pc @ONLY)
+
+set(YAML_CPP_USE_OPTIONAL_DEFAULT OFF)
+get_target_property(YAML_CPP_CXX_STANDARD yaml-cpp CXX_STANDARD)
+if ("${YAML_CPP_CXX_STANDARD}" VERSION_GREATER_EQUAL 17)
+    set(YAML_CPP_USE_OPTIONAL_DEFAULT ON)
+endif()
+option(YAML_CPP_USE_OPTIONAL "Support for non-default constructible 'convert` overloads (requires c++17 and newer)" "${YAML_CPP_USE_OPTIONAL_DEFAULT}")
+if (YAML_CPP_USE_OPTIONAL)
+  target_compile_definitions(yaml-cpp PUBLIC YAML_CPP_USE_OPTIONAL)
+endif()
 
 if (YAML_CPP_INSTALL)
   install(TARGETS yaml-cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,16 +143,6 @@ write_basic_package_version_file(
 
 configure_file(yaml-cpp.pc.in yaml-cpp.pc @ONLY)
 
-set(YAML_CPP_USE_OPTIONAL_DEFAULT OFF)
-get_target_property(YAML_CPP_CXX_STANDARD yaml-cpp CXX_STANDARD)
-if ("${YAML_CPP_CXX_STANDARD}" VERSION_GREATER_EQUAL 17)
-    set(YAML_CPP_USE_OPTIONAL_DEFAULT ON)
-endif()
-option(YAML_CPP_USE_OPTIONAL "Support for non-default constructible 'convert` overloads (requires c++17 and newer)" "${YAML_CPP_USE_OPTIONAL_DEFAULT}")
-if (YAML_CPP_USE_OPTIONAL)
-  target_compile_definitions(yaml-cpp PUBLIC YAML_CPP_USE_OPTIONAL)
-endif()
-
 if (YAML_CPP_INSTALL)
   install(TARGETS yaml-cpp
     EXPORT yaml-cpp-targets

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -200,6 +200,38 @@ Vec3 v = node["start"].as<Vec3>();
 node["end"] = Vec3(2, -1, 0);
 ```
 
+## Non-default constructible types (requires c++17 and newer)
+Yaml-cpp also supports types that are not default constructible. For this one need to specialize `YAML::convert<std::optional<>>`.
+Assuming you have:
+
+```cpp
+class Vec3 {
+  double x, y, z;
+public:
+  Vec3(double x, double y, double z} : x{x}, y{y}, z{z} {}
+};
+```
+
+you could write (for encoding the previous `convert<Vec3>` with the `encode` method is required)
+
+```cpp
+namespace YAML {
+template<>
+struct convert<std::optional<Vec3>> {
+  static bool decode(const Node& node, std::optional<Vec3>& rhs) {
+    if(!node.IsSequence() || node.size() != 3) {
+      return false;
+    }
+    rhs.emplace(
+        node[0].as<double>(),
+        node[1].as<double>(),
+        node[2].as<double>()
+    );
+    return true;
+  }
+};
+}
+
 ## Partial specialization
 
 If you need to specialize the `convert` struct for a set of types instead of just one you can use partial specialization with the help of `std::enable_if` (SFINAE).
@@ -224,7 +256,7 @@ public:
     node["a"] = a;
     return node;
   }
-  
+
   int a;
 };
 
@@ -252,7 +284,7 @@ public:
 
 // Implementation of convert::{encode,decode} for all classes derived from or being A
 namespace YAML {
-  template<typename T> 
+  template<typename T>
   struct convert<T, typename std::enable_if<std::is_base_of<A, T>::value>::type> {
     static Node encode(const T &rhs) {
       Node node = rhs.emit();

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -200,8 +200,8 @@ Vec3 v = node["start"].as<Vec3>();
 node["end"] = Vec3(2, -1, 0);
 ```
 
-## Non-default constructible types (requires c++17 and newer)
-Yaml-cpp also supports types that are not default constructible. For this one need to specialize `YAML::convert<std::optional<>>`.
+## Non-default constructible types
+Yaml-cpp also supports types that are not default constructible. For this we need to return the `YAML::expected` type
 Assuming you have:
 
 ```cpp
@@ -217,17 +217,16 @@ you could write (for encoding the previous `convert<Vec3>` with the `encode` met
 ```cpp
 namespace YAML {
 template<>
-struct convert<std::optional<Vec3>> {
-  static bool decode(const Node& node, std::optional<Vec3>& rhs) {
+struct convert<Vec3> {
+  static bool decode(const Node& node) -> expected<Vec3> {
     if(!node.IsSequence() || node.size() != 3) {
-      return false;
+      return unexpected{};
     }
-    rhs.emplace(
+    return expected<Vec3> {
         node[0].as<double>(),
         node[1].as<double>(),
         node[2].as<double>()
-    );
-    return true;
+    };
   }
 };
 }

--- a/include/yaml-cpp/expected.h
+++ b/include/yaml-cpp/expected.h
@@ -1,0 +1,87 @@
+#ifndef EXPECTED_H_62B23520_7C8E_11DE_8A39_0800200C9A66
+#define EXPECTED_H_62B23520_7C8E_11DE_8A39_0800200C9A66
+
+#if defined(_MSC_VER) ||                                            \
+    (defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || \
+     (__GNUC__ >= 4))  // GCC supports "pragma once" correctly since 3.4
+#pragma once
+#endif
+
+
+#include <cassert>
+#include <cstdint>
+#include <type_traits>
+
+namespace YAML {
+
+struct unexpected {};
+
+template <typename T>
+struct expected {
+    alignas(T) std::array<std::uint8_t, sizeof(T)> storage;
+    T* ptr{};
+
+    expected() = default;
+    expected(expected const& o) = delete;
+    expected(expected&& o) noexcept(std::is_nothrow_move_constructible<T>::value) {
+        if (!o.ptr) return;
+        emplace(*o.ptr);
+    }
+    template <typename... Args>
+    expected(Args&&... args) noexcept(std::is_nothrow_constructible<T, Args...>::value) {
+        emplace(std::forward<Args>(args)...);
+    }
+    expected(unexpected const&) noexcept {}
+    expected(unexpected&&) noexcept {}
+
+
+    ~expected() noexcept {
+        reset();
+    }
+
+    auto operator=(expected const& o) -> expected& = delete;
+    auto operator=(expected&& o) noexcept(std::is_nothrow_move_assignable<T>::value) -> expected& {
+        if (!o.ptr) {
+            reset();
+        } else if (!ptr) {
+            emplace(std::move(*o.ptr));
+        } else {
+            *ptr = std::move(*o.ptr);
+        }
+        return *this;
+    }
+    auto operator=(unexpected const&) noexcept -> expected& {
+        reset();
+        return *this;
+    }
+
+    void reset() noexcept {
+        if (!ptr) return;
+        ptr->~T();
+        ptr = nullptr;
+    }
+
+    template <typename... Args>
+    auto emplace(Args&&... args) noexcept(std::is_nothrow_constructible<T, Args...>::value) -> T& {
+        reset();
+        ptr = new (storage.data()) T(std::forward<Args>(args)...);
+        return *ptr;
+    }
+
+    operator bool() const noexcept {
+        return ptr != nullptr;
+    }
+
+    auto operator*() noexcept -> T& {
+        assert(ptr);
+        return *ptr;
+    }
+    auto operator*() const noexcept -> T const& {
+        assert(ptr);
+        return *ptr;
+    }
+};
+
+}
+
+#endif  // EXPECTED_H_62B23520_7C8E_11DE_8A39_0800200C9A66

--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -15,6 +15,17 @@
 #include <sstream>
 #include <string>
 
+// Check YAML_CPP_USE_OPTIONAL is set and language standard provides supports
+// if available and supported include required header
+// otherwise remove YAML_CPP_USE_OPTIONAL definition
+#ifdef YAML_CPP_USE_OPTIONAL
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#include <optional>
+#else
+#undef YAML_CPP_USE_OPTIONAL
+#endif
+#endif
+
 namespace YAML {
 inline Node::Node()
     : m_isValid(true), m_invalidKey{}, m_pMemory(nullptr), m_pNode(nullptr) {}
@@ -94,6 +105,54 @@ inline NodeType::value Node::Type() const {
 // access
 
 // template helpers
+#ifdef YAML_CPP_USE_OPTIONAL
+template <typename T>
+struct decode_box : std::optional<T> {
+  decode_box() = default;
+  template <typename S>
+  decode_box(S&&) {}
+};
+
+template <typename T>
+struct convert<decode_box<T>> {
+  static bool decode(const Node& node, decode_box<T>& rhs) {
+    return convert<std::optional<T>>::decode(node, rhs);
+  }
+};
+template <typename T>
+struct convert<std::optional<T>> {
+  static bool decode(const Node& node, std::optional<T>& rhs) {
+    if (node.IsNull()) {
+      return false;
+    }
+    rhs.emplace();
+    if (!convert<T>::decode(node, *rhs)) {
+      rhs.reset();
+      return false;
+    }
+    return true;
+  }
+};
+
+
+#else
+
+template <typename T>
+struct decode_box {
+  T t;
+  T& operator*() {
+    return t;
+  }
+};
+template <typename T>
+struct convert<decode_box<T>> {
+  static bool decode(const Node& node, decode_box<T>& rhs) {
+    return convert<T>::decode(node, *rhs);
+  }
+};
+
+#endif
+
 template <typename T, typename S>
 struct as_if {
   explicit as_if(const Node& node_) : node(node_) {}
@@ -103,9 +162,9 @@ struct as_if {
     if (!node.m_pNode)
       return fallback;
 
-    T t = fallback;
-    if (convert<T>::decode(node, t))
-      return t;
+    decode_box<T> t{fallback};
+    if (convert<decltype(t)>::decode(node, t))
+      return *t;
     return fallback;
   }
 };
@@ -133,9 +192,9 @@ struct as_if<T, void> {
     if (!node.m_pNode) // no fallback
       throw InvalidNode(node.m_invalidKey);
 
-    T t;
-    if (convert<T>::decode(node, t))
-      return t;
+    decode_box<T> t;
+    if (convert<decltype(t)>::decode(node, t))
+      return *t;
     throw TypedBadConversion<T>(node.Mark());
   }
 };

--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -12,19 +12,10 @@
 #include "yaml-cpp/node/detail/node.h"
 #include "yaml-cpp/node/iterator.h"
 #include "yaml-cpp/node/node.h"
+#include "yaml-cpp/expected.h"
 #include <sstream>
 #include <string>
-
-// Check YAML_CPP_USE_OPTIONAL is set and language standard provides supports
-// if available and supported include required header
-// otherwise remove YAML_CPP_USE_OPTIONAL definition
-#ifdef YAML_CPP_USE_OPTIONAL
-#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
-#include <optional>
-#else
-#undef YAML_CPP_USE_OPTIONAL
-#endif
-#endif
+#include <utility>
 
 namespace YAML {
 inline Node::Node()
@@ -102,56 +93,33 @@ inline NodeType::value Node::Type() const {
   return m_pNode ? m_pNode->type() : NodeType::Null;
 }
 
-// access
-
-// template helpers
-#ifdef YAML_CPP_USE_OPTIONAL
+// fallback expected converter
 template <typename T>
-struct decode_box : std::optional<T> {
-  decode_box() = default;
-  template <typename S>
-  decode_box(S&&) {}
-};
-
-template <typename T>
-struct convert<decode_box<T>> {
-  static bool decode(const Node& node, decode_box<T>& rhs) {
-    return convert<std::optional<T>>::decode(node, rhs);
+struct convert<expected<T>> {
+  static auto decode(const Node& node) -> expected<T> {
+    return decode_impl<T>(node, 0);
   }
-};
-template <typename T>
-struct convert<std::optional<T>> {
-  static bool decode(const Node& node, std::optional<T>& rhs) {
+
+  template <typename T2 = T>
+  static auto decode_impl(const Node& node, long long x) -> expected<T> {
     if (node.IsNull()) {
-      return false;
+      return unexpected{};
     }
-    rhs.emplace();
-    if (!convert<T>::decode(node, *rhs)) {
-      rhs.reset();
-      return false;
+    T t;
+    if (!convert<T>::decode(node, t)) {
+      return unexpected{};
     }
-    return true;
+    return expected<T>{std::move(t)};
+  }
+
+  template <typename T2 = T>
+  static auto decode_impl(const Node& node, int x) -> decltype(convert<T2>::decode(std::declval<Node>()))  {
+    if (node.IsNull()) {
+      return unexpected{};
+    }
+    return convert<T>::decode(node);
   }
 };
-
-
-#else
-
-template <typename T>
-struct decode_box {
-  T t;
-  T& operator*() {
-    return t;
-  }
-};
-template <typename T>
-struct convert<decode_box<T>> {
-  static bool decode(const Node& node, decode_box<T>& rhs) {
-    return convert<T>::decode(node, *rhs);
-  }
-};
-
-#endif
 
 template <typename T, typename S>
 struct as_if {
@@ -162,10 +130,12 @@ struct as_if {
     if (!node.m_pNode)
       return fallback;
 
-    decode_box<T> t{fallback};
-    if (convert<decltype(t)>::decode(node, t))
-      return *t;
-    return fallback;
+    auto t = convert<expected<T>>::decode(node);
+
+    if (!t) {
+      return fallback;
+    }
+    return *t;
   }
 };
 
@@ -192,10 +162,11 @@ struct as_if<T, void> {
     if (!node.m_pNode) // no fallback
       throw InvalidNode(node.m_invalidKey);
 
-    decode_box<T> t;
-    if (convert<decltype(t)>::decode(node, t))
-      return *t;
-    throw TypedBadConversion<T>(node.Mark());
+    auto t = convert<expected<T>>::decode(node);
+    if (!t) {
+        throw TypedBadConversion<T>(node.Mark());
+    }
+    return *t;
   }
 };
 

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -43,6 +43,23 @@ template <class K, class V, class C=std::less<K>> using CustomMap = std::map<K,V
 template <class K, class V, class H=std::hash<K>, class P=std::equal_to<K>> using CustomUnorderedMap = std::unordered_map<K,V,H,P,CustomAllocator<std::pair<const K,V>>>;
 template <class K, class H=std::hash<K>, class P=std::equal_to<K>> using CustomUnorderedSet = std::unordered_set<K,H,P,CustomAllocator<K>>;
 
+struct Vec3 {
+  double x, y, z;
+  bool operator==(const Vec3& rhs) const {
+    return x == rhs.x && y == rhs.y && z == rhs.z;
+  }
+};
+
+#ifdef YAML_CPP_USE_OPTIONAL
+struct NonDefCtorVec3 {
+  double x, y, z;
+  NonDefCtorVec3(double x, double y, double z) : x(x), y(y), z(z) {}
+  bool operator==(const NonDefCtorVec3& rhs) const {
+    return x == rhs.x && y == rhs.y && z == rhs.z;
+  }
+};
+#endif
+
 }  // anonymous namespace
 
 using ::testing::AnyOf;
@@ -57,6 +74,43 @@ using ::testing::Eq;
   }
 
 namespace YAML {
+
+template<>
+struct convert<Vec3> {
+  static Node encode(const Vec3& rhs) {
+    Node node;
+    node.push_back(rhs.x);
+    node.push_back(rhs.y);
+    node.push_back(rhs.z);
+    return node;
+  }
+
+  static bool decode(const Node& node, Vec3& rhs) {
+    if(!node.IsSequence() || node.size() != 3) {
+      return false;
+    }
+
+    rhs.x = node[0].as<double>();
+    rhs.y = node[1].as<double>();
+    rhs.z = node[2].as<double>();
+    return true;
+  }
+};
+
+#ifdef YAML_CPP_USE_OPTIONAL
+template <>
+struct convert<std::optional<NonDefCtorVec3>> {
+  static bool decode(const Node& node, std::optional<NonDefCtorVec3>& rhs) {
+    if (!node.IsSequence() || node.size() != 3) {
+      return false;
+    }
+    rhs.emplace(node[0].as<double>(), node[1].as<double>(), node[2].as<double>());
+
+    return true;
+  }
+};
+#endif
+
 namespace {
 TEST(NodeTest, SimpleScalar) {
   Node node = Node("Hello, World!");
@@ -909,6 +963,28 @@ TEST(NodeTest, CreateMapWithFloatingPoint0Key) {
   Node node;
   node[0.1] = 1.0;
   EXPECT_TRUE(node.IsMap());
+}
+
+TEST(NodeTest, CustomClassDecoding) {
+  YAML::Node node;
+  node.push_back(1.0);
+  node.push_back(2.0);
+  node.push_back(3.0);
+  ASSERT_TRUE(node.IsSequence());
+  EXPECT_EQ(node.as<Vec3>(), (Vec3{1.0, 2.0, 3.0}));
+}
+
+TEST(NodeTest, CustomNonDefaultConstructibleClassDecoding) {
+#ifdef YAML_CPP_USE_OPTIONAL
+  YAML::Node node;
+  node.push_back(1.0);
+  node.push_back(2.0);
+  node.push_back(3.0);
+  ASSERT_TRUE(node.IsSequence());
+  EXPECT_EQ(node.as<NonDefCtorVec3>(), (NonDefCtorVec3{1.0, 2.0, 3.0}));
+#else
+  GTEST_SKIP() << "Compile with C++17 for customizing non-default-constructible custom types.";
+#endif
 }
 
 class NodeEmitterTest : public ::testing::Test {

--- a/test/node/node_test.cpp
+++ b/test/node/node_test.cpp
@@ -50,7 +50,6 @@ struct Vec3 {
   }
 };
 
-#ifdef YAML_CPP_USE_OPTIONAL
 struct NonDefCtorVec3 {
   double x, y, z;
   NonDefCtorVec3(double x, double y, double z) : x(x), y(y), z(z) {}
@@ -58,7 +57,6 @@ struct NonDefCtorVec3 {
     return x == rhs.x && y == rhs.y && z == rhs.z;
   }
 };
-#endif
 
 }  // anonymous namespace
 
@@ -97,19 +95,20 @@ struct convert<Vec3> {
   }
 };
 
-#ifdef YAML_CPP_USE_OPTIONAL
 template <>
-struct convert<std::optional<NonDefCtorVec3>> {
-  static bool decode(const Node& node, std::optional<NonDefCtorVec3>& rhs) {
+struct convert<NonDefCtorVec3> {
+  static auto decode(const Node& node) -> expected<NonDefCtorVec3> {
     if (!node.IsSequence() || node.size() != 3) {
-      return false;
+      return unexpected{};
     }
-    rhs.emplace(node[0].as<double>(), node[1].as<double>(), node[2].as<double>());
-
-    return true;
+    return expected<NonDefCtorVec3> {
+        node[0].as<double>(),
+        node[1].as<double>(),
+        node[2].as<double>()
+    };
   }
 };
-#endif
+
 
 namespace {
 TEST(NodeTest, SimpleScalar) {
@@ -975,16 +974,12 @@ TEST(NodeTest, CustomClassDecoding) {
 }
 
 TEST(NodeTest, CustomNonDefaultConstructibleClassDecoding) {
-#ifdef YAML_CPP_USE_OPTIONAL
   YAML::Node node;
   node.push_back(1.0);
   node.push_back(2.0);
   node.push_back(3.0);
   ASSERT_TRUE(node.IsSequence());
   EXPECT_EQ(node.as<NonDefCtorVec3>(), (NonDefCtorVec3{1.0, 2.0, 3.0}));
-#else
-  GTEST_SKIP() << "Compile with C++17 for customizing non-default-constructible custom types.";
-#endif
 }
 
 class NodeEmitterTest : public ::testing::Test {


### PR DESCRIPTION
This is an alternative to #1479, #1010 and #1087. Fixes #506, #973 and #993.

As @alex-thiessen-for-siemens noted the suggested signature of `convert<T>::decode` in #1479 is not great.
I dislike having yaml-cpp in a state where it provides different functionality depending on the C++ version used.

So, I applied some c++ magic (SFINAE) and implemented a minimalistic replacement for `std::expected`.
I think it unites many desired properties: It is c++11 compatible, it has a nice signature for `decode`.
It leaves the original API untouched, but extends it nicely.
Disadvantage is, now we have a custom `YAML::expected` type.

Assume we have some type without default constructor:
```c++
class Vec3 {
  double x, y, z;
public:
  Vec3(double x, double y, double z} : x{x}, y{y}, z{z} {}
};
```
you could write
```c++
namespace YAML {
template<>
struct convert<Vec3> {
  static auto decode(const Node& node) -> expected<Vec3> {
    if(!node.IsSequence() || node.size() != 3) {
      return unexpected{};
    }
    return expected<Vec3> {
        node[0].as<double>(),
        node[1].as<double>(),
        node[2].as<double>()
    );
  }
};
}
```