### PR TITLE
Fix Base64 padding separated by whitespace

### DIFF
--- a/src/binary.cpp
+++ b/src/binary.cpp
@@ -75,6 +75,7 @@ std::vector<unsigned char> DecodeBase64(const std::string &input) {
 
   unsigned value = 0;
   std::size_t cnt = 0;
+  bool previous_was_padding = false;
   for (std::size_t i = 0; i < input.size(); i++) {
     if (std::isspace(static_cast<unsigned char>(input[i]))) {
       // skip newlines
@@ -87,7 +88,7 @@ std::vector<unsigned char> DecodeBase64(const std::string &input) {
     value = (value << 6) | d;
     if (cnt == 3) {
       *out++ = value >> 16;
-      if (i > 0 && input[i - 1] != '=')
+      if (!previous_was_padding)
         *out++ = value >> 8;
       if (input[i] != '=')
         *out++ = value;
@@ -95,6 +96,7 @@ std::vector<unsigned char> DecodeBase64(const std::string &input) {
     } else {
       ++cnt;
     }
+    previous_was_padding = input[i] == '=';
   }
   if (cnt != 0) {
     // An invalid number of characters were encountered.

--- a/test/binary_test.cpp
+++ b/test/binary_test.cpp
@@ -19,6 +19,11 @@ TEST(BinaryTest, DecodingTooShort) {
   EXPECT_TRUE(result.empty());
 }
 
+TEST(BinaryTest, DecodingWhitespaceBetweenPadding) {
+  const std::vector<unsigned char> &result = YAML::DecodeBase64("TQ= =");
+  EXPECT_EQ(std::vector<unsigned char>{'M'}, result);
+}
+
 TEST(BinaryTest, EmptyBinary) {
     YAML::Binary b;
     EXPECT_TRUE(b.size() == 0);


### PR DESCRIPTION
## Summary

Fix Base64 decoding when whitespace separates padding characters.

`DecodeBase64("TQ= =")` previously emitted an extra zero byte because it
checked the raw preceding input character after whitespace had been skipped.
The decoder now tracks whether the previous non-whitespace Base64 character
was padding. The focused test verifies that the result remains the single byte
`M`.

## Validation

- C++11 CMake/CTest: 3/3 tests passed.
- Pinned Debian Trixie evaluation: CMake/CTest, ASan/UBSan, Valgrind,
  clang-format, clang-tidy, exhaustive cppcheck, Bazel, and Bzlmod passed.
- PyYAML 6.0.3, using YAML 1.1 `!!binary` native-value semantics, matched
  the decoded byte `4d`.
- libyaml 0.2.5 matched the yaml-cpp parser/event stream for the fixture.
