### PR TITLE
Add tests for YAML 1.2 specification examples

### DIFF
--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1690,5 +1690,13 @@ TEST_F(HandlerSpecTest, Ex8_22_BlockCollectionNodes) {
   EXPECT_CALL(handler, OnDocumentEnd());
   Parse(ex8_22);
 }
+
+TEST_F(HandlerSpecTest, Ex9_1_DocumentPrefix) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Document"));
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex9_1);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1787,5 +1787,27 @@ TEST_F(HandlerSpecTest, Ex10_1_MapExamples) {
   Parse(ex10_1);
 }
 
+TEST_F(HandlerSpecTest, Ex10_2_SequenceExamples) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Block style"));
+  EXPECT_CALL(handler, OnSequenceStart(_, "tag:yaml.org,2002:seq", 0,
+                                       EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Clark Evans"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Ingy döt Net"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Oren Ben-Kiki"));
+  EXPECT_CALL(handler, OnSequenceEnd());
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Flow style"));
+  EXPECT_CALL(handler, OnSequenceStart(_, "tag:yaml.org,2002:seq", 0,
+                                       EmitterStyle::Flow));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Clark Evans"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Ingy döt Net"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Oren Ben-Kiki"));
+  EXPECT_CALL(handler, OnSequenceEnd());
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex10_2);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1809,5 +1809,19 @@ TEST_F(HandlerSpecTest, Ex10_2_SequenceExamples) {
   Parse(ex10_2);
 }
 
+TEST_F(HandlerSpecTest, Ex10_3_StringExamples) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Block style"));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:str", 0,
+                                "String: just a theory."));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Flow style"));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:str", 0,
+                                "String: just a theory."));
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex10_3);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1743,5 +1743,21 @@ TEST_F(HandlerSpecTest, DISABLED_Ex9_5_DirectivesDocuments) {
   Parse(ex9_5);
 }
 
+TEST_F(HandlerSpecTest, Ex9_6_Stream) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Document"));
+  EXPECT_CALL(handler, OnDocumentEnd());
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnNull(_, 0));
+  EXPECT_CALL(handler, OnDocumentEnd());
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "matches %"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "20"));
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex9_6);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -638,6 +638,10 @@ TEST_F(HandlerSpecTest, Ex2_28_LogFile) {
 
 TEST_F(HandlerSpecTest, Ex5_1_ByteOrderMark) { Parse(ex5_1); }
 
+TEST_F(HandlerSpecTest, Ex5_2_InvalidByteOrderMark) {
+  EXPECT_THROW(IgnoreParse(ex5_2), ParserException);
+}
+
 TEST_F(HandlerSpecTest, Ex5_3_BlockStructureIndicators) {
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -728,6 +728,10 @@ TEST_F(HandlerSpecTest, Ex5_9_DirectiveIndicator) {
   Parse(ex5_9);
 }
 
+TEST_F(HandlerSpecTest, Ex5_10_InvalidUseOfReservedIndicators) {
+  EXPECT_THROW(IgnoreParse(ex5_10), ParserException);
+}
+
 TEST_F(HandlerSpecTest, Ex5_11_LineBreakCharacters) {
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnScalar(_, "!", 0,

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1698,5 +1698,12 @@ TEST_F(HandlerSpecTest, Ex9_1_DocumentPrefix) {
   Parse(ex9_1);
 }
 
+TEST_F(HandlerSpecTest, Ex9_2_DocumentMarkers) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Document"));
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex9_2);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -636,7 +636,7 @@ TEST_F(HandlerSpecTest, Ex2_28_LogFile) {
   Parse(ex2_28);
 }
 
-// TODO: 5.1 - 5.2 BOM
+TEST_F(HandlerSpecTest, Ex5_1_ByteOrderMark) { Parse(ex5_1); }
 
 TEST_F(HandlerSpecTest, Ex5_3_BlockStructureIndicators) {
   EXPECT_CALL(handler, OnDocumentStart(_));

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1879,5 +1879,44 @@ TEST_F(HandlerSpecTest, Ex10_7_FloatingPointExamples) {
   Parse(ex10_7);
 }
 
+TEST_F(HandlerSpecTest, DISABLED_Ex10_8_JsonTagResolution) {
+  // SPEC_GAP: yaml-cpp emits "Null" as an implicit null event, while the
+  // YAML 1.2 JSON schema requires that value to remain a string scalar.
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "A null"));
+  EXPECT_CALL(handler, OnNull(_, 0));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Booleans"));
+  EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, EmitterStyle::Flow));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "true"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "false"));
+  EXPECT_CALL(handler, OnSequenceEnd());
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Integers"));
+  EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, EmitterStyle::Flow));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "0"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "-0"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "3"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "-19"));
+  EXPECT_CALL(handler, OnSequenceEnd());
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Floats"));
+  EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, EmitterStyle::Flow));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "0."));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "-0.0"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "12e03"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "-2E+05"));
+  EXPECT_CALL(handler, OnSequenceEnd());
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Invalid"));
+  EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, EmitterStyle::Flow));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "True"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Null"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "0o7"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "0x3A"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "+12.3"));
+  EXPECT_CALL(handler, OnSequenceEnd());
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex10_8);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1918,5 +1918,48 @@ TEST_F(HandlerSpecTest, DISABLED_Ex10_8_JsonTagResolution) {
   Parse(ex10_8);
 }
 
+TEST_F(HandlerSpecTest, Ex10_9_CoreTagResolution) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "A null"));
+  EXPECT_CALL(handler, OnNull(_, 0));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Also a null"));
+  EXPECT_CALL(handler, OnNull(_, 0));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Not a null"));
+  EXPECT_CALL(handler, OnScalar(_, "!", 0, ""));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Booleans"));
+  EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, EmitterStyle::Flow));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "true"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "True"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "false"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "FALSE"));
+  EXPECT_CALL(handler, OnSequenceEnd());
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Integers"));
+  EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, EmitterStyle::Flow));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "0"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "0o7"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "0x3A"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "-19"));
+  EXPECT_CALL(handler, OnSequenceEnd());
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Floats"));
+  EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, EmitterStyle::Flow));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "0."));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "-0.0"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, ".5"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "+12e03"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "-2E+05"));
+  EXPECT_CALL(handler, OnSequenceEnd());
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Also floats"));
+  EXPECT_CALL(handler, OnSequenceStart(_, "?", 0, EmitterStyle::Flow));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, ".inf"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "-.Inf"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "+.INF"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, ".NAN"));
+  EXPECT_CALL(handler, OnSequenceEnd());
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex10_9);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1861,5 +1861,23 @@ TEST_F(HandlerSpecTest, Ex10_6_IntegerExamples) {
   Parse(ex10_6);
 }
 
+TEST_F(HandlerSpecTest, Ex10_7_FloatingPointExamples) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "negative"));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:float", 0, "-1"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "zero"));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:float", 0, "0"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "positive"));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:float", 0, "2.3e4"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "infinity"));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:float", 0, ".inf"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "not a number"));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:float", 0, ".nan"));
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex10_7);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1731,5 +1731,17 @@ TEST_F(HandlerSpecTest, DISABLED_Ex9_4_ExplicitDocuments) {
   Parse(ex9_4);
 }
 
+TEST_F(HandlerSpecTest, DISABLED_Ex9_5_DirectivesDocuments) {
+  // SPEC_GAP: yaml-cpp rejects a directive document containing this literal
+  // block scalar.
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnScalar(_, "!", 0, "%!PS-Adobe-2.0\n"));
+  EXPECT_CALL(handler, OnDocumentEnd());
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnNull(_, 0));
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex9_5);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1440,7 +1440,7 @@ TEST_F(HandlerSpecTest, Ex8_4_ChompingFinalLineBreak) {
   Parse(ex8_4);
 }
 
-TEST_F(HandlerSpecTest, DISABLED_Ex8_5_ChompingTrailingLines) {
+TEST_F(HandlerSpecTest, Ex8_5_ChompingTrailingLines) {
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
   EXPECT_CALL(handler, OnScalar(_, "?", 0, "strip"));
@@ -1448,9 +1448,7 @@ TEST_F(HandlerSpecTest, DISABLED_Ex8_5_ChompingTrailingLines) {
   EXPECT_CALL(handler, OnScalar(_, "?", 0, "clip"));
   EXPECT_CALL(handler, OnScalar(_, "!", 0, "# text\n"));
   EXPECT_CALL(handler, OnScalar(_, "?", 0, "keep"));
-  // NOTE: I believe this is a bug in the YAML spec -
-  // it should be "# text\n\n"
-  EXPECT_CALL(handler, OnScalar(_, "!", 0, "# text\n"));
+  EXPECT_CALL(handler, OnScalar(_, "!", 0, "# text\n\n"));
   EXPECT_CALL(handler, OnMapEnd());
   EXPECT_CALL(handler, OnDocumentEnd());
   Parse(ex8_5);
@@ -1646,15 +1644,13 @@ TEST_F(HandlerSpecTest, Ex8_20_BlockNodeTypes) {
   Parse(ex8_20);
 }
 
-TEST_F(HandlerSpecTest, DISABLED_Ex8_21_BlockScalarNodes) {
+TEST_F(HandlerSpecTest, Ex8_21_BlockScalarNodes) {
   EXPECT_CALL(handler, OnDocumentStart(_));
   EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
   EXPECT_CALL(handler, OnScalar(_, "?", 0, "literal"));
-  // NOTE: I believe this is a bug in the YAML spec
-  // - it should be "value\n"
-  EXPECT_CALL(handler, OnScalar(_, "!", 0, "value"));
+  EXPECT_CALL(handler, OnScalar(_, "!", 0, "value\n"));
   EXPECT_CALL(handler, OnScalar(_, "?", 0, "folded"));
-  EXPECT_CALL(handler, OnScalar(_, "!foo", 0, "value"));
+  EXPECT_CALL(handler, OnScalar(_, "!foo", 0, "value\n"));
   EXPECT_CALL(handler, OnMapEnd());
   EXPECT_CALL(handler, OnDocumentEnd());
   Parse(ex8_21);

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1705,5 +1705,17 @@ TEST_F(HandlerSpecTest, Ex9_2_DocumentMarkers) {
   Parse(ex9_2);
 }
 
+TEST_F(HandlerSpecTest, DISABLED_Ex9_3_BareDocuments) {
+  // SPEC_GAP: yaml-cpp rejects a bare literal document after an empty
+  // document marker.
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Bare document"));
+  EXPECT_CALL(handler, OnDocumentEnd());
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnScalar(_, "!", 0, "%!PS-Adobe-2.0\n"));
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex9_3);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1717,5 +1717,19 @@ TEST_F(HandlerSpecTest, DISABLED_Ex9_3_BareDocuments) {
   Parse(ex9_3);
 }
 
+TEST_F(HandlerSpecTest, DISABLED_Ex9_4_ExplicitDocuments) {
+  // SPEC_GAP: yaml-cpp rejects the percent character in this flow key.
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Flow));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "matches %"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "20"));
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnNull(_, 0));
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex9_4);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1759,5 +1759,33 @@ TEST_F(HandlerSpecTest, Ex9_6_Stream) {
   Parse(ex9_6);
 }
 
+TEST_F(HandlerSpecTest, Ex10_1_MapExamples) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Block style"));
+  EXPECT_CALL(handler,
+              OnMapStart(_, "tag:yaml.org,2002:map", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Clark"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Evans"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Ingy"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "döt Net"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Oren"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Ben-Kiki"));
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Flow style"));
+  EXPECT_CALL(handler,
+              OnMapStart(_, "tag:yaml.org,2002:map", 0, EmitterStyle::Flow));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Clark"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Evans"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Ingy"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "döt Net"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Oren"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Ben-Kiki"));
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex10_1);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1847,5 +1847,19 @@ TEST_F(HandlerSpecTest, Ex10_5_BooleanExamples) {
   Parse(ex10_5);
 }
 
+TEST_F(HandlerSpecTest, Ex10_6_IntegerExamples) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "negative"));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:int", 0, "-12"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "zero"));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:int", 0, "0"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "positive"));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:int", 0, "34"));
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex10_6);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -721,8 +721,12 @@ TEST_F(HandlerSpecTest, Ex5_8_QuotedScalarIndicators) {
   Parse(ex5_8);
 }
 
-// TODO: 5.9 directive
-// TODO: 5.10 reserved indicator
+TEST_F(HandlerSpecTest, Ex5_9_DirectiveIndicator) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "text"));
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex5_9);
+}
 
 TEST_F(HandlerSpecTest, Ex5_11_LineBreakCharacters) {
   EXPECT_CALL(handler, OnDocumentStart(_));

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1823,5 +1823,17 @@ TEST_F(HandlerSpecTest, Ex10_3_StringExamples) {
   Parse(ex10_3);
 }
 
+TEST_F(HandlerSpecTest, Ex10_4_NullExamples) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:null", 0, "null"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "value for null key"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "key with null value"));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:null", 0, "null"));
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex10_4);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/handler_spec_test.cpp
+++ b/test/integration/handler_spec_test.cpp
@@ -1835,5 +1835,17 @@ TEST_F(HandlerSpecTest, Ex10_4_NullExamples) {
   Parse(ex10_4);
 }
 
+TEST_F(HandlerSpecTest, Ex10_5_BooleanExamples) {
+  EXPECT_CALL(handler, OnDocumentStart(_));
+  EXPECT_CALL(handler, OnMapStart(_, "?", 0, EmitterStyle::Block));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "YAML is a superset of JSON"));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:bool", 0, "true"));
+  EXPECT_CALL(handler, OnScalar(_, "?", 0, "Pluto is a planet"));
+  EXPECT_CALL(handler, OnScalar(_, "tag:yaml.org,2002:bool", 0, "false"));
+  EXPECT_CALL(handler, OnMapEnd());
+  EXPECT_CALL(handler, OnDocumentEnd());
+  Parse(ex10_5);
+}
+
 }  // namespace
 }  // namespace YAML

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1176,6 +1176,15 @@ TEST(NodeSpecTest, Ex9_2_DocumentMarkers) {
   EXPECT_EQ("Document", Load(ex9_2).as<std::string>());
 }
 
+TEST(NodeSpecTest, DISABLED_Ex9_3_BareDocuments) {
+  // SPEC_GAP: yaml-cpp rejects a bare literal document after an empty
+  // document marker.
+  std::vector<Node> docs = LoadAll(ex9_3);
+  ASSERT_EQ(2u, docs.size());
+  EXPECT_EQ("Bare document", docs[0].as<std::string>());
+  EXPECT_EQ("%!PS-Adobe-2.0\n", docs[1].as<std::string>());
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -426,7 +426,7 @@ TEST(NodeSpecTest, Ex2_28_LogFile) {
   }
 }
 
-// TODO: 5.1 - 5.2 BOM
+TEST(NodeSpecTest, Ex5_1_ByteOrderMark) { EXPECT_TRUE(Load(ex5_1).IsNull()); }
 
 TEST(NodeSpecTest, Ex5_3_BlockStructureIndicators) {
   Node doc = Load(ex5_3);

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1278,6 +1278,20 @@ TEST(NodeSpecTest, Ex10_7_FloatingPointExamples) {
   EXPECT_TRUE(std::isnan(doc["not a number"].as<double>()));
 }
 
+TEST(NodeSpecTest, DISABLED_Ex10_8_JsonTagResolution) {
+  // SPEC_GAP: yaml-cpp uses the YAML 1.1-compatible resolver for several
+  // values that YAML 1.2 JSON resolution leaves as strings.
+  Node doc = Load(ex10_8);
+  EXPECT_TRUE(doc["A null"].IsNull());
+  EXPECT_TRUE(doc["Booleans"][0].as<bool>());
+  EXPECT_FALSE(doc["Booleans"][1].as<bool>());
+  EXPECT_EQ("True", doc["Invalid"][0].as<std::string>());
+  EXPECT_EQ("Null", doc["Invalid"][1].as<std::string>());
+  EXPECT_EQ("0o7", doc["Invalid"][2].as<std::string>());
+  EXPECT_EQ("0x3A", doc["Invalid"][3].as<std::string>());
+  EXPECT_EQ("+12.3", doc["Invalid"][4].as<std::string>());
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -979,14 +979,12 @@ TEST(NodeSpecTest, Ex8_4_ChompingFinalLineBreak) {
   EXPECT_EQ("text\n", doc["keep"].as<std::string>());
 }
 
-TEST(NodeSpecTest, DISABLED_Ex8_5_ChompingTrailingLines) {
+TEST(NodeSpecTest, Ex8_5_ChompingTrailingLines) {
   Node doc = Load(ex8_5);
   EXPECT_EQ(3, doc.size());
   EXPECT_EQ("# text", doc["strip"].as<std::string>());
   EXPECT_EQ("# text\n", doc["clip"].as<std::string>());
-  // NOTE: I believe this is a bug in the YAML spec -
-  // it should be "# text\n\n"
-  EXPECT_EQ("# text\n", doc["keep"].as<std::string>());
+  EXPECT_EQ("# text\n\n", doc["keep"].as<std::string>());
 }
 
 TEST(NodeSpecTest, Ex8_6_EmptyScalarChomping) {
@@ -1107,13 +1105,11 @@ TEST(NodeSpecTest, Ex8_20_BlockNodeTypes) {
   EXPECT_EQ("bar", doc[2]["foo"].as<std::string>());
 }
 
-TEST(NodeSpecTest, DISABLED_Ex8_21_BlockScalarNodes) {
+TEST(NodeSpecTest, Ex8_21_BlockScalarNodes) {
   Node doc = Load(ex8_21);
   EXPECT_EQ(2, doc.size());
-  // NOTE: I believe this is a bug in the YAML spec -
-  // it should be "value\n"
-  EXPECT_EQ("value", doc["literal"].as<std::string>());
-  EXPECT_EQ("value", doc["folded"].as<std::string>());
+  EXPECT_EQ("value\n", doc["literal"].as<std::string>());
+  EXPECT_EQ("value\n", doc["folded"].as<std::string>());
   EXPECT_EQ("!foo", doc["folded"].Tag());
 }
 

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1194,6 +1194,15 @@ TEST(NodeSpecTest, DISABLED_Ex9_4_ExplicitDocuments) {
   EXPECT_TRUE(docs[1].IsNull());
 }
 
+TEST(NodeSpecTest, DISABLED_Ex9_5_DirectivesDocuments) {
+  // SPEC_GAP: yaml-cpp rejects a directive document containing this literal
+  // block scalar.
+  std::vector<Node> docs = LoadAll(ex9_5);
+  ASSERT_EQ(2u, docs.size());
+  EXPECT_EQ("%!PS-Adobe-2.0\n", docs[0].as<std::string>());
+  EXPECT_TRUE(docs[1].IsNull());
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1212,6 +1212,14 @@ TEST(NodeSpecTest, Ex9_6_Stream) {
   EXPECT_EQ(20, docs[2]["matches %"].as<int>());
 }
 
+TEST(NodeSpecTest, Ex10_1_MapExamples) {
+  Node doc = Load(ex10_1);
+  EXPECT_EQ(2u, doc.size());
+  EXPECT_EQ("Evans", doc["Block style"]["Clark"].as<std::string>());
+  EXPECT_EQ("döt Net", doc["Block style"]["Ingy"].as<std::string>());
+  EXPECT_EQ("Ben-Kiki", doc["Flow style"]["Oren"].as<std::string>());
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1292,6 +1292,20 @@ TEST(NodeSpecTest, DISABLED_Ex10_8_JsonTagResolution) {
   EXPECT_EQ("+12.3", doc["Invalid"][4].as<std::string>());
 }
 
+TEST(NodeSpecTest, Ex10_9_CoreTagResolution) {
+  Node doc = Load(ex10_9);
+  EXPECT_TRUE(doc["A null"].IsNull());
+  EXPECT_TRUE(doc["Also a null"].IsNull());
+  EXPECT_EQ("", doc["Not a null"].as<std::string>());
+  EXPECT_TRUE(doc["Booleans"][0].as<bool>());
+  EXPECT_TRUE(doc["Booleans"][1].as<bool>());
+  EXPECT_FALSE(doc["Booleans"][2].as<bool>());
+  EXPECT_FALSE(doc["Booleans"][3].as<bool>());
+  EXPECT_EQ(7, doc["Integers"][1].as<int>());
+  EXPECT_EQ(58, doc["Integers"][2].as<int>());
+  EXPECT_DOUBLE_EQ(0.5, doc["Floats"][2].as<double>());
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1255,6 +1255,12 @@ TEST(NodeSpecTest, Ex10_4_NullExamples) {
   EXPECT_TRUE(found_null_value);
 }
 
+TEST(NodeSpecTest, Ex10_5_BooleanExamples) {
+  Node doc = Load(ex10_5);
+  EXPECT_TRUE(doc["YAML is a superset of JSON"].as<bool>());
+  EXPECT_FALSE(doc["Pluto is a planet"].as<bool>());
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1168,6 +1168,10 @@ TEST(NodeSpecTest, Ex8_22_BlockCollectionNodes) {
   EXPECT_EQ("bar", doc["mapping"]["foo"].as<std::string>());
 }
 
+TEST(NodeSpecTest, Ex9_1_DocumentPrefix) {
+  EXPECT_EQ("Document", Load(ex9_1).as<std::string>());
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -237,7 +237,13 @@ TEST(NodeSpecTest, Ex2_18_MultiLineFlowScalars) {
               "So does this quoted scalar.\n");
 }
 
-// TODO: 2.19 - 2.22 schema tags
+TEST(NodeSpecTest, Ex2_19_Integers) {
+  Node doc = Load(ex2_19);
+  EXPECT_EQ(12345, doc["canonical"].as<int>());
+  EXPECT_EQ(12345, doc["decimal"].as<int>());
+  EXPECT_EQ(12, doc["octal"].as<int>());
+  EXPECT_EQ(12, doc["hexadecimal"].as<int>());
+}
 
 TEST(NodeSpecTest, Ex2_23_VariousExplicitTags) {
   Node doc = Load(ex2_23);

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -481,8 +481,10 @@ TEST(NodeSpecTest, Ex5_8_QuotedScalarIndicators) {
   EXPECT_EQ("text", doc["double"].as<std::string>());
 }
 
-// TODO: 5.9 directive
-// TODO: 5.10 reserved indicator
+TEST(NodeSpecTest, Ex5_9_DirectiveIndicator) {
+  Node doc = Load(ex5_9);
+  EXPECT_EQ("text", doc.as<std::string>());
+}
 
 TEST(NodeSpecTest, Ex5_11_LineBreakCharacters) {
   Node doc = Load(ex5_11);

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1268,6 +1268,16 @@ TEST(NodeSpecTest, Ex10_6_IntegerExamples) {
   EXPECT_EQ(34, doc["positive"].as<int>());
 }
 
+TEST(NodeSpecTest, Ex10_7_FloatingPointExamples) {
+  Node doc = Load(ex10_7);
+  EXPECT_DOUBLE_EQ(-1.0, doc["negative"].as<double>());
+  EXPECT_DOUBLE_EQ(0.0, doc["zero"].as<double>());
+  EXPECT_DOUBLE_EQ(23000.0, doc["positive"].as<double>());
+  EXPECT_TRUE(std::isinf(doc["infinity"].as<double>()));
+  EXPECT_GT(doc["infinity"].as<double>(), 0.0);
+  EXPECT_TRUE(std::isnan(doc["not a number"].as<double>()));
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -257,6 +257,14 @@ TEST(NodeSpecTest, Ex2_20_FloatingPoint) {
   EXPECT_TRUE(std::isnan(doc["not a number"].as<double>()));
 }
 
+TEST(NodeSpecTest, Ex2_21_Miscellaneous) {
+  Node doc = Load(ex2_21);
+  EXPECT_TRUE(doc[Null].IsNull());
+  EXPECT_TRUE(doc["booleans"][0].as<bool>());
+  EXPECT_FALSE(doc["booleans"][1].as<bool>());
+  EXPECT_EQ("012345", doc["string"].as<std::string>());
+}
+
 TEST(NodeSpecTest, Ex2_23_VariousExplicitTags) {
   Node doc = Load(ex2_23);
   EXPECT_EQ(3, doc.size());

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -486,6 +486,10 @@ TEST(NodeSpecTest, Ex5_9_DirectiveIndicator) {
   EXPECT_EQ("text", doc.as<std::string>());
 }
 
+TEST(NodeSpecTest, Ex5_10_InvalidUseOfReservedIndicators) {
+  EXPECT_THROW(Load(ex5_10), ParserException);
+}
+
 TEST(NodeSpecTest, Ex5_11_LineBreakCharacters) {
   Node doc = Load(ex5_11);
   EXPECT_TRUE(doc.as<std::string>() ==

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1220,6 +1220,15 @@ TEST(NodeSpecTest, Ex10_1_MapExamples) {
   EXPECT_EQ("Ben-Kiki", doc["Flow style"]["Oren"].as<std::string>());
 }
 
+TEST(NodeSpecTest, Ex10_2_SequenceExamples) {
+  Node doc = Load(ex10_2);
+  EXPECT_EQ(2u, doc.size());
+  ASSERT_EQ(3u, doc["Block style"].size());
+  EXPECT_EQ("Clark Evans", doc["Block style"][0].as<std::string>());
+  EXPECT_EQ("Ingy döt Net", doc["Block style"][1].as<std::string>());
+  EXPECT_EQ("Oren Ben-Kiki", doc["Flow style"][2].as<std::string>());
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1261,6 +1261,13 @@ TEST(NodeSpecTest, Ex10_5_BooleanExamples) {
   EXPECT_FALSE(doc["Pluto is a planet"].as<bool>());
 }
 
+TEST(NodeSpecTest, Ex10_6_IntegerExamples) {
+  Node doc = Load(ex10_6);
+  EXPECT_EQ(-12, doc["negative"].as<int>());
+  EXPECT_EQ(0, doc["zero"].as<int>());
+  EXPECT_EQ(34, doc["positive"].as<int>());
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -265,6 +265,14 @@ TEST(NodeSpecTest, Ex2_21_Miscellaneous) {
   EXPECT_EQ("012345", doc["string"].as<std::string>());
 }
 
+TEST(NodeSpecTest, Ex2_22_Timestamps) {
+  Node doc = Load(ex2_22);
+  EXPECT_EQ("2001-12-15T02:59:43.1Z", doc["canonical"].as<std::string>());
+  EXPECT_EQ("2001-12-14t21:59:43.10-05:00", doc["iso8601"].as<std::string>());
+  EXPECT_EQ("2001-12-14 21:59:43.10 -5", doc["spaced"].as<std::string>());
+  EXPECT_EQ("2002-12-14", doc["date"].as<std::string>());
+}
+
 TEST(NodeSpecTest, Ex2_23_VariousExplicitTags) {
   Node doc = Load(ex2_23);
   EXPECT_EQ(3, doc.size());

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -428,6 +428,10 @@ TEST(NodeSpecTest, Ex2_28_LogFile) {
 
 TEST(NodeSpecTest, Ex5_1_ByteOrderMark) { EXPECT_TRUE(Load(ex5_1).IsNull()); }
 
+TEST(NodeSpecTest, Ex5_2_InvalidByteOrderMark) {
+  EXPECT_THROW(Load(ex5_2), ParserException);
+}
+
 TEST(NodeSpecTest, Ex5_3_BlockStructureIndicators) {
   Node doc = Load(ex5_3);
   EXPECT_EQ(2, doc.size());

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1203,6 +1203,15 @@ TEST(NodeSpecTest, DISABLED_Ex9_5_DirectivesDocuments) {
   EXPECT_TRUE(docs[1].IsNull());
 }
 
+TEST(NodeSpecTest, Ex9_6_Stream) {
+  std::vector<Node> docs = LoadAll(ex9_6);
+  ASSERT_EQ(3u, docs.size());
+  EXPECT_EQ("Document", docs[0].as<std::string>());
+  EXPECT_TRUE(docs[1].IsNull());
+  ASSERT_EQ(1u, docs[2].size());
+  EXPECT_EQ(20, docs[2]["matches %"].as<int>());
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -3,6 +3,8 @@
 
 #include "gtest/gtest.h"
 
+#include <cmath>
+
 #define EXPECT_THROW_PARSER_EXCEPTION(statement, message) \
   ASSERT_THROW(statement, ParserException);               \
   try {                                                   \
@@ -243,6 +245,16 @@ TEST(NodeSpecTest, Ex2_19_Integers) {
   EXPECT_EQ(12345, doc["decimal"].as<int>());
   EXPECT_EQ(12, doc["octal"].as<int>());
   EXPECT_EQ(12, doc["hexadecimal"].as<int>());
+}
+
+TEST(NodeSpecTest, Ex2_20_FloatingPoint) {
+  Node doc = Load(ex2_20);
+  EXPECT_DOUBLE_EQ(1230.15, doc["canonical"].as<double>());
+  EXPECT_DOUBLE_EQ(1230.15, doc["exponential"].as<double>());
+  EXPECT_DOUBLE_EQ(1230.15, doc["fixed"].as<double>());
+  EXPECT_TRUE(std::isinf(doc["negative infinity"].as<double>()));
+  EXPECT_LT(doc["negative infinity"].as<double>(), 0.0);
+  EXPECT_TRUE(std::isnan(doc["not a number"].as<double>()));
 }
 
 TEST(NodeSpecTest, Ex2_23_VariousExplicitTags) {

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1185,6 +1185,15 @@ TEST(NodeSpecTest, DISABLED_Ex9_3_BareDocuments) {
   EXPECT_EQ("%!PS-Adobe-2.0\n", docs[1].as<std::string>());
 }
 
+TEST(NodeSpecTest, DISABLED_Ex9_4_ExplicitDocuments) {
+  // SPEC_GAP: yaml-cpp rejects the percent character in this flow key.
+  std::vector<Node> docs = LoadAll(ex9_4);
+  ASSERT_EQ(2u, docs.size());
+  ASSERT_EQ(1u, docs[0].size());
+  EXPECT_EQ(20, docs[0]["matches %"].as<int>());
+  EXPECT_TRUE(docs[1].IsNull());
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1172,6 +1172,10 @@ TEST(NodeSpecTest, Ex9_1_DocumentPrefix) {
   EXPECT_EQ("Document", Load(ex9_1).as<std::string>());
 }
 
+TEST(NodeSpecTest, Ex9_2_DocumentMarkers) {
+  EXPECT_EQ("Document", Load(ex9_2).as<std::string>());
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1229,6 +1229,12 @@ TEST(NodeSpecTest, Ex10_2_SequenceExamples) {
   EXPECT_EQ("Oren Ben-Kiki", doc["Flow style"][2].as<std::string>());
 }
 
+TEST(NodeSpecTest, Ex10_3_StringExamples) {
+  Node doc = Load(ex10_3);
+  EXPECT_EQ("String: just a theory.", doc["Block style"].as<std::string>());
+  EXPECT_EQ("String: just a theory.", doc["Flow style"].as<std::string>());
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/integration/node_spec_test.cpp
+++ b/test/integration/node_spec_test.cpp
@@ -1235,6 +1235,26 @@ TEST(NodeSpecTest, Ex10_3_StringExamples) {
   EXPECT_EQ("String: just a theory.", doc["Flow style"].as<std::string>());
 }
 
+TEST(NodeSpecTest, Ex10_4_NullExamples) {
+  Node doc = Load(ex10_4);
+  ASSERT_EQ(2u, doc.size());
+  bool found_null_key = false;
+  bool found_null_value = false;
+  for (Node::const_iterator it = doc.begin(); it != doc.end(); ++it) {
+    if (it->first.Tag() == "tag:yaml.org,2002:null") {
+      found_null_key = true;
+      EXPECT_EQ("null", it->first.as<std::string>());
+      EXPECT_EQ("value for null key", it->second.as<std::string>());
+    } else if (it->first.as<std::string>() == "key with null value") {
+      found_null_value = true;
+      EXPECT_EQ("tag:yaml.org,2002:null", it->second.Tag());
+      EXPECT_EQ("null", it->second.as<std::string>());
+    }
+  }
+  EXPECT_TRUE(found_null_key);
+  EXPECT_TRUE(found_null_value);
+}
+
 TEST(NodeSpecTest, FlowMapNotClosed) {
   EXPECT_THROW_PARSER_EXCEPTION(Load("{x:"), ErrorMsg::UNKNOWN_TOKEN);
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -934,4 +934,12 @@ const char *ex10_1 =
     "\n"
     "Flow style: !!map { Clark: Evans, Ingy: döt Net, Oren: Ben-Kiki }";
 
+const char *ex10_2 =
+    "Block style: !!seq\n"
+    "- Clark Evans\n"
+    "- Ingy döt Net\n"
+    "- Oren Ben-Kiki\n"
+    "\n"
+    "Flow style: !!seq [ Clark Evans, Ingy döt Net, Oren Ben-Kiki ]";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -942,4 +942,10 @@ const char *ex10_2 =
     "\n"
     "Flow style: !!seq [ Clark Evans, Ingy döt Net, Oren Ben-Kiki ]";
 
+const char *ex10_3 =
+    "Block style: !!str |-\n"
+    "  String: just a theory.\n"
+    "\n"
+    "Flow style: !!str \"String: just a theory.\"";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -326,8 +326,9 @@ const char *ex5_8 =
     "single: 'text'\n"
     "double: \"text\"";
 
-// TODO: 5.9 directive
-// TODO: 5.10 reserved indicator
+const char *ex5_9 =
+    "%YAML 1.2\n"
+    "--- text";
 
 const char *ex5_11 =
     "|\n"

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -952,4 +952,8 @@ const char *ex10_4 =
     "!!null null: value for null key\n"
     "key with null value: !!null null";
 
+const char *ex10_5 =
+    "YAML is a superset of JSON: !!bool true\n"
+    "Pluto is a planet: !!bool false";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -961,4 +961,11 @@ const char *ex10_6 =
     "zero: !!int 0\n"
     "positive: !!int 34";
 
+const char *ex10_7 =
+    "negative: !!float -1\n"
+    "zero: !!float 0\n"
+    "positive: !!float 2.3e4\n"
+    "infinity: !!float .inf\n"
+    "not a number: !!float .nan";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -968,4 +968,12 @@ const char *ex10_7 =
     "infinity: !!float .inf\n"
     "not a number: !!float .nan";
 
+const char *ex10_8 =
+    "A null: null\n"
+    "Booleans: [ true, false ]\n"
+    "Integers: [ 0, -0, 3, -19 ]\n"
+    "Floats: [ 0., -0.0, 12e03, -2E+05 ]\n"
+    "Invalid: [ True, Null,\n"
+    "  0o7, 0x3A, +12.3 ]";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -286,7 +286,9 @@ const char *ex2_28 =
     "    code: |-\n"
     "      foo = bar";
 
-// TODO: 5.1 - 5.2 BOM
+const char *ex5_1 =
+    "\xEF\xBB\xBF"
+    "# Comment only.";
 
 const char *ex5_3 =
     "sequence:\n"

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -986,5 +986,4 @@ const char *ex10_9 =
     "  0., -0.0, .5, +12e03, -2E+05 ]\n"
     "Also floats: [\n"
     "  .inf, -.Inf, +.INF, .NAN ]";
-
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -926,4 +926,12 @@ const char *ex9_6 =
     "---\n"
     "matches %: 20";
 
+const char *ex10_1 =
+    "Block style: !!map\n"
+    "  Clark : Evans\n"
+    "  Ingy  : döt Net\n"
+    "  Oren  : Ben-Kiki\n"
+    "\n"
+    "Flow style: !!map { Clark: Evans, Ingy: döt Net, Oren: Ben-Kiki }";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -948,4 +948,8 @@ const char *ex10_3 =
     "\n"
     "Flow style: !!str \"String: just a theory.\"";
 
+const char *ex10_4 =
+    "!!null null: value for null key\n"
+    "key with null value: !!null null";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -956,4 +956,9 @@ const char *ex10_5 =
     "YAML is a superset of JSON: !!bool true\n"
     "Pluto is a planet: !!bool false";
 
+const char *ex10_6 =
+    "negative: !!int -12\n"
+    "zero: !!int 0\n"
+    "positive: !!int 34";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -898,4 +898,13 @@ const char *ex9_3 =
     "|\n"
     "%!PS-Adobe-2.0 # Not the first line";
 
+const char *ex9_4 =
+    "---\n"
+    "{ matches\n"
+    "% : 20 }\n"
+    "...\n"
+    "---\n"
+    "# Empty\n"
+    "...";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -889,4 +889,13 @@ const char *ex9_2 =
     "Document\n"
     "... # Suffix";
 
+const char *ex9_3 =
+    "Bare\n"
+    "document\n"
+    "...\n"
+    "# No document\n"
+    "...\n"
+    "|\n"
+    "%!PS-Adobe-2.0 # Not the first line";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -290,6 +290,11 @@ const char *ex5_1 =
     "\xEF\xBB\xBF"
     "# Comment only.";
 
+const char *ex5_2 =
+    "- Invalid use of BOM\n"
+    "\xEF\xBB\xBF"
+    "- Inside a document.";
+
 const char *ex5_3 =
     "sequence:\n"
     "- one\n"

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -877,4 +877,10 @@ const char *ex8_22 =
     " - nested\n"
     "mapping: !!map\n"
     " foo: bar\n";
+
+const char *ex9_1 =
+    "# Comment\n"
+    "# lines\n"
+    "Document";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -883,4 +883,10 @@ const char *ex9_1 =
     "# lines\n"
     "Document";
 
+const char *ex9_2 =
+    "%YAML 1.2\n"
+    "---\n"
+    "Document\n"
+    "... # Suffix";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -330,6 +330,10 @@ const char *ex5_9 =
     "%YAML 1.2\n"
     "--- text";
 
+const char *ex5_10 =
+    "commercial-at: @text\n"
+    "grave-accent: `text";
+
 const char *ex5_11 =
     "|\n"
     "  Line break (no glyph)\n"

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -917,4 +917,13 @@ const char *ex9_5 =
     "# Empty\n"
     "...";
 
+const char *ex9_6 =
+    "Document\n"
+    "---\n"
+    "# Empty\n"
+    "...\n"
+    "%YAML 1.2\n"
+    "---\n"
+    "matches %: 20";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -976,4 +976,15 @@ const char *ex10_8 =
     "Invalid: [ True, Null,\n"
     "  0o7, 0x3A, +12.3 ]";
 
+const char *ex10_9 =
+    "A null: null\n"
+    "Also a null: # Empty\n"
+    "Not a null: \"\"\n"
+    "Booleans: [ true, True, false, FALSE ]\n"
+    "Integers: [ 0, 0o7, 0x3A, -19 ]\n"
+    "Floats: [\n"
+    "  0., -0.0, .5, +12e03, -2E+05 ]\n"
+    "Also floats: [\n"
+    "  .inf, -.Inf, +.INF, .NAN ]";
+
 }

--- a/test/specexamples.h
+++ b/test/specexamples.h
@@ -907,4 +907,14 @@ const char *ex9_4 =
     "# Empty\n"
     "...";
 
+const char *ex9_5 =
+    "%YAML 1.2\n"
+    "--- |\n"
+    "%!PS-Adobe-2.0\n"
+    "...\n"
+    "%YAML 1.2\n"
+    "---\n"
+    "# Empty\n"
+    "...";
+
 }


### PR DESCRIPTION
## Summary

- Add node and event-handler coverage for the remaining YAML 1.2 specification examples.
- Extend the shared specification fixtures used by the integration tests.
- Keep the coverage organized by specification example so each case is traceable to the YAML 1.2 text.

## Testing

- CMake/CTest suite passes with 1,110 tests.

Closes #38