### PR TITLE
treat a carriage return as a line break when emitting

### DIFF
--- a/src/emitterutils.cpp
+++ b/src/emitterutils.cpp
@@ -203,7 +203,7 @@ bool IsValidSingleQuotedScalar(const char* str, std::size_t size, bool escapeNon
   // TODO: check for non-printable characters?
   return std::none_of(str, str + size, [=](char ch) {
     return (escapeNonAscii && (0x80 <= static_cast<unsigned char>(ch))) ||
-           (ch == '\n');
+           (ch == '\n') || (ch == '\r');
   });
 }
 
@@ -214,8 +214,11 @@ bool IsValidLiteralScalar(const char* str, std::size_t size, FlowType::value flo
   }
 
   // TODO: check for non-printable characters?
+  // A carriage return is a line break to the parser, so a block scalar cannot
+  // carry one; leave those to the double-quoted form.
   return std::none_of(str, str + size, [=](char ch) {
-    return (escapeNonAscii && (0x80 <= static_cast<unsigned char>(ch)));
+    return (escapeNonAscii && (0x80 <= static_cast<unsigned char>(ch))) ||
+           (ch == '\r');
   });
 }
 
@@ -329,7 +332,7 @@ bool WriteSingleQuotedString(ostream_wrapper& out, const char* str, std::size_t 
   int codePoint;
   for (const char* i = str;
        GetNextCodePointAndAdvance(codePoint, i, str + size);) {
-    if (codePoint == '\n') {
+    if (codePoint == '\n' || codePoint == '\r') {
       return false;  // We can't handle a new line and the attendant indentation
                      // yet
     }
@@ -463,7 +466,10 @@ bool WriteComment(ostream_wrapper& out, const char* str, std::size_t size,
   int codePoint;
   for (const char* i = str;
        GetNextCodePointAndAdvance(codePoint, i, str + size);) {
-    if (codePoint == '\n') {
+    if (codePoint == '\n' || codePoint == '\r') {
+      if (codePoint == '\r' && i != str + size && *i == '\n') {
+        ++i;  // a CRLF pair is a single break
+      }
       out << "\n"
           << IndentTo(curIndent) << "#" << Indentation(postCommentIndent);
       out.set_comment();

--- a/test/integration/emitter_test.cpp
+++ b/test/integration/emitter_test.cpp
@@ -454,6 +454,22 @@ TEST_F(EmitterTest, LiteralWithAndWithoutTrailingEmptyLines) {
       "- something");
 }
 
+TEST_F(EmitterTest, SingleQuotedWithCarriageReturn) {
+  out << BeginMap;
+  out << Key << "key" << Value << SingleQuoted << "a\rb";
+  out << EndMap;
+
+  ExpectEmit("key: \"a\\rb\"");
+}
+
+TEST_F(EmitterTest, LiteralWithCarriageReturn) {
+  out << BeginMap;
+  out << Key << "key" << Value << Literal << "a\rb";
+  out << EndMap;
+
+  ExpectEmit("key: \"a\\rb\"");
+}
+
 
 TEST_F(EmitterTest, AutoLongKeyScalar) {
   out << BeginMap;
@@ -808,6 +824,26 @@ TEST_F(EmitterTest, MultiLineComment) {
   ExpectEmit(
       "- item 1  # really really long\n          # comment that couldn't "
       "possibly\n          # fit on one line\n- item 2");
+}
+
+TEST_F(EmitterTest, MultiLineCommentWithCarriageReturn) {
+  out << BeginSeq;
+  out << "item 1" << Comment("really long\rcomment on two lines");
+  out << "item 2";
+  out << EndSeq;
+
+  ExpectEmit(
+      "- item 1  # really long\n          # comment on two lines\n- item 2");
+}
+
+TEST_F(EmitterTest, MultiLineCommentWithCarriageReturnLineFeed) {
+  out << BeginSeq;
+  out << "item 1" << Comment("really long\r\ncomment on two lines");
+  out << "item 2";
+  out << EndSeq;
+
+  ExpectEmit(
+      "- item 1  # really long\n          # comment on two lines\n- item 2");
 }
 
 TEST_F(EmitterTest, ComplexComments) {


### PR DESCRIPTION
The scanner takes a bare CR as a line break (`Exp::Break`, after #986 and #1309), but the emitter helpers still only look for LF:

- `WriteComment` re-prefixes `#` on LF only, so `Comment("hi\rinjected: pwned")` on a one-key map reparses as two keys, the comment tail landing as document structure
- `IsValidSingleQuotedScalar` rejects LF but not CR, so `'a\rb'` goes out raw and folds back to `a b`
- `IsValidLiteralScalar` checks for neither, so a CR in a block scalar comes back as LF
- `WriteSingleQuotedString` keeps its own bail-out in step with its validator

Plain scalars already fall back to double quotes for this (#607); the two remaining explicit formats now do the same, while the comment writer handles the break in place since it owns the `#` continuation. A CRLF pair collapses to one break instead of two.
